### PR TITLE
Add GoLow method to high-level SchemaProxy

### DIFF
--- a/datamodel/high/base/schema_proxy.go
+++ b/datamodel/high/base/schema_proxy.go
@@ -67,3 +67,10 @@ func (sp *SchemaProxy) Schema() *Schema {
 func (sp *SchemaProxy) GetBuildError() error {
 	return sp.buildError
 }
+
+func (sp *SchemaProxy) GoLow() *base.SchemaProxy {
+	if sp.schema == nil {
+		return nil
+	}
+	return sp.schema.Value
+}


### PR DESCRIPTION
A client of high-level SchemaProxy may want to know whether a schema is a reference and the name of the reference.  This information is available from methods GetSchemaReference() and IsSchemaReference() in low-level SchemaProxy.  Provide a GoLow() method to retrieve the low-level SchemaProxy for a high-level SchemaProxy.