### PR TITLE
feat: add extensions to info

### DIFF
--- a/datamodel/high/base/info.go
+++ b/datamodel/high/base/info.go
@@ -4,6 +4,7 @@
 package base
 
 import (
+	"github.com/pb33f/libopenapi/datamodel/high"
 	low "github.com/pb33f/libopenapi/datamodel/low/base"
 )
 
@@ -12,8 +13,8 @@ import (
 // The object provides metadata about the API. The metadata MAY be used by the clients if needed, and MAY be presented
 // in editing or documentation generation tools for convenience.
 //
-//  v2 - https://swagger.io/specification/v2/#infoObject
-//  v3 - https://spec.openapis.org/oas/v3.1.0#info-object
+//	v2 - https://swagger.io/specification/v2/#infoObject
+//	v3 - https://spec.openapis.org/oas/v3.1.0#info-object
 type Info struct {
 	Title          string
 	Description    string
@@ -21,6 +22,7 @@ type Info struct {
 	Contact        *Contact
 	License        *License
 	Version        string
+	Extensions     map[string]any
 	low            *low.Info
 }
 
@@ -45,6 +47,9 @@ func NewInfo(info *low.Info) *Info {
 	}
 	if !info.Version.IsEmpty() {
 		i.Version = info.Version.Value
+	}
+	if len(info.Extensions) > 0 {
+		i.Extensions = high.ExtractExtensions(info.Extensions)
 	}
 	return i
 }

--- a/datamodel/high/base/info_test.go
+++ b/datamodel/high/base/info_test.go
@@ -5,11 +5,12 @@ package base
 
 import (
 	"fmt"
+	"testing"
+
 	lowmodel "github.com/pb33f/libopenapi/datamodel/low"
 	lowbase "github.com/pb33f/libopenapi/datamodel/low/base"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"
-	"testing"
 )
 
 func TestNewInfo(t *testing.T) {
@@ -24,7 +25,8 @@ contact:
 license:
   name: pb33f
   url: https://pb33f.io
-version: 99.99`
+version: 99.99
+x-cli-name: chicken cli`
 
 	_ = yaml.Unmarshal([]byte(yml), &cNode)
 
@@ -41,6 +43,7 @@ version: 99.99`
 	assert.Equal(t, "pb33f", highInfo.License.Name)
 	assert.Equal(t, "https://pb33f.io", highInfo.License.URL)
 	assert.Equal(t, "99.99", highInfo.Version)
+	assert.Equal(t, "chicken cli", highInfo.Extensions["x-cli-name"])
 
 	wentLow := highInfo.GoLow()
 	assert.Equal(t, 9, wentLow.Version.ValueNode.Line)

--- a/datamodel/low/base/info.go
+++ b/datamodel/low/base/info.go
@@ -14,8 +14,8 @@ import (
 // The object provides metadata about the API. The metadata MAY be used by the clients if needed, and MAY be presented
 // in editing or documentation generation tools for convenience.
 //
-//  v2 - https://swagger.io/specification/v2/#infoObject
-//  v3 - https://spec.openapis.org/oas/v3.1.0#info-object
+//	v2 - https://swagger.io/specification/v2/#infoObject
+//	v3 - https://spec.openapis.org/oas/v3.1.0#info-object
 type Info struct {
 	Title          low.NodeReference[string]
 	Description    low.NodeReference[string]
@@ -23,10 +23,18 @@ type Info struct {
 	Contact        low.NodeReference[*Contact]
 	License        low.NodeReference[*License]
 	Version        low.NodeReference[string]
+	Extensions     map[low.KeyReference[string]]low.ValueReference[any]
+}
+
+// FindExtension attempts to locate an extension with the supplied key
+func (i *Info) FindExtension(ext string) *low.ValueReference[any] {
+	return low.FindItemInMap(ext, i.Extensions)
 }
 
 // Build will extract out the Contact and Info objects from the supplied root node.
 func (i *Info) Build(root *yaml.Node, idx *index.SpecIndex) error {
+	i.Extensions = low.ExtractExtensions(root)
+
 	// extract contact
 	contact, _ := low.ExtractObject[*Contact](ContactLabel, root, idx)
 	i.Contact = contact

--- a/datamodel/low/base/info_test.go
+++ b/datamodel/low/base/info_test.go
@@ -4,11 +4,12 @@
 package base
 
 import (
+	"testing"
+
 	"github.com/pb33f/libopenapi/datamodel/low"
 	"github.com/pb33f/libopenapi/index"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"
-	"testing"
 )
 
 func TestInfo_Build(t *testing.T) {
@@ -22,7 +23,8 @@ contact:
   email: buckaroo@pb33f.io
 license:
  name: magic
- url: https://pb33f.io/license`
+ url: https://pb33f.io/license
+x-cli-name: pizza cli`
 
 	var idxNode yaml.Node
 	_ = yaml.Unmarshal([]byte(yml), &idxNode)
@@ -49,6 +51,10 @@ license:
 	assert.NotNil(t, lic)
 	assert.Equal(t, "magic", lic.Name.Value)
 	assert.Equal(t, "https://pb33f.io/license", lic.URL.Value)
+
+	cliName := n.FindExtension("x-cli-name")
+	assert.NotNil(t, cliName)
+	assert.Equal(t, "pizza cli", cliName.Value)
 }
 
 func TestContact_Build(t *testing.T) {


### PR DESCRIPTION
From the [Open API 3.1 spec](https://spec.openapis.org/oas/latest.html#info-object) on the top-level `info` object:

> This object MAY be extended with [Specification Extensions](https://spec.openapis.org/oas/latest.html#specificationExtensions).

This PR implements support for that, which is relevant for supporting [Restish Open API extensions](https://rest.sh/#/openapi?id=name) which let you e.g. modify the name, description, etc or hide operations from the CLI directly from your Open API spec.

I added a basic test which covers the newly added lines. I see the Go formatter changed a couple of things - let me know if that's a problem and I'll undo those changes.

Part of https://github.com/danielgtaylor/restish/issues/115