### PR TITLE
fix: panic thrown when paths is wrapped in an array #4

### DIFF
--- a/document_test.go
+++ b/document_test.go
@@ -360,3 +360,30 @@ info:
 	//     license:
 	//         url: https://pb33f.io/license
 }
+
+func TestDocument_Panic(t *testing.T) {
+
+	// How to mutate values in an OpenAPI Specification, without re-ordering original content.
+
+	// create very small, and useless spec that does nothing useful, except showcase this feature.
+	spec := `{
+    "openapi": "3.1.0",
+    "paths": [
+        "/": {
+            "get": {}
+        }
+    ]
+}
+`
+	// create a new document from specification bytes
+	doc, err := NewDocument([]byte(spec))
+
+	// if anything went wrong, an error is thrown
+	if err != nil {
+		panic(fmt.Sprintf("cannot create new document: %e", err))
+	}
+
+	// because we know this is a v3 spec, we can build a ready to go model from it.
+	v3Model, errors := doc.BuildV3Model()
+	fmt.Print(v3Model, errors)
+}

--- a/index/spec_index.go
+++ b/index/spec_index.go
@@ -1279,7 +1279,12 @@ func (index *SpecIndex) GetOperationCount() int {
 	for x, p := range index.pathsNode.Content {
 		if x%2 == 0 {
 
-			method := index.pathsNode.Content[x+1]
+			var method *yaml.Node
+			if utils.IsNodeArray(index.pathsNode) {
+				method = index.pathsNode.Content[x]
+			} else {
+				method = index.pathsNode.Content[x+1]
+			}
 
 			// extract methods for later use.
 			for y, m := range method.Content {
@@ -1339,7 +1344,12 @@ func (index *SpecIndex) GetOperationsParameterCount() int {
 	for x, pathItemNode := range index.pathsNode.Content {
 		if x%2 == 0 {
 
-			pathPropertyNode := index.pathsNode.Content[x+1]
+			var pathPropertyNode *yaml.Node
+			if utils.IsNodeArray(index.pathsNode) {
+				pathPropertyNode = index.pathsNode.Content[x]
+			} else {
+				pathPropertyNode = index.pathsNode.Content[x+1]
+			}
 
 			// extract methods for later use.
 			for y, prop := range pathPropertyNode.Content {

--- a/index/spec_index_test.go
+++ b/index/spec_index_test.go
@@ -474,6 +474,22 @@ func TestSpecIndex_FindComponent(t *testing.T) {
 }
 
 func TestSpecIndex_performExternalLookup(t *testing.T) {
+	yml := `{
+    "openapi": "3.1.0",
+    "paths": [
+        {"/": {
+            "get": {}
+        }}
+    ]
+}`
+	var rootNode yaml.Node
+	yaml.Unmarshal([]byte(yml), &rootNode)
+
+	index := NewSpecIndex(&rootNode)
+	assert.Len(t, index.GetPathsNode().Content, 1)
+}
+
+func TestSpecIndex_TestPathsNodeAsArray(t *testing.T) {
 	yml := `components:
   schemas:
     pizza:


### PR DESCRIPTION
When paths are wrapped in an array, the index throws an error because it's expecting them to be supplied as a map. Now paths can be wrapped or unwrapped, the index won't care.