### PR TITLE
Fixed resolving bug with polymorphic schemas.

### DIFF
--- a/index/spec_index_test.go
+++ b/index/spec_index_test.go
@@ -376,7 +376,7 @@ func TestSpecIndex_TestEmptyBrokenReferences(t *testing.T) {
 	assert.Equal(t, 2, index.GetOperationsParameterCount())
 	assert.Equal(t, 1, index.GetInlineDuplicateParamCount())
 	assert.Equal(t, 1, index.GetInlineUniqueParamCount())
-	assert.Len(t, index.refErrors, 7)
+	assert.Len(t, index.refErrors, 6)
 
 }
 


### PR DESCRIPTION
Multiple polymorphic, deeply embedded schemas cause resolving issues as a channel waits forever due to a counting issue.

This has been resolved.

Signed-off-by: Dave Shanley <dshanley@splunk.com>