### PR TITLE
fix(high): load schema.Examples into []any

### DIFF
--- a/datamodel/high/base/schema.go
+++ b/datamodel/high/base/schema.go
@@ -165,6 +165,13 @@ func NewSchema(schema *base.Schema) *Schema {
 		s.Deprecated = &schema.Deprecated.Value
 	}
 	s.Example = schema.Example.Value
+	if len(schema.Examples.Value) > 0 {
+		examples := make([]any, len(schema.Examples.Value))
+		for i := 0; i < len(schema.Examples.Value); i++ {
+			examples[i] = schema.Examples.Value[i].Value
+		}
+		s.Examples = examples
+	}
 	s.Extensions = high.ExtractExtensions(schema.Extensions)
 	if !schema.Discriminator.IsEmpty() {
 		s.Discriminator = NewDiscriminator(schema.Discriminator.Value)

--- a/datamodel/high/base/schema_test.go
+++ b/datamodel/high/base/schema_test.go
@@ -500,6 +500,18 @@ exclusiveMaximum: 5
 	assert.EqualValues(t, &value, highSchema.ExclusiveMaximum)
 }
 
+func TestSchemaExamples(t *testing.T) {
+	yml := `
+type: number
+examples:
+- 5
+- 10
+`
+	highSchema := getHighSchema(t, yml)
+
+	assert.Equal(t, []any{int64(5), int64(10)}, highSchema.Examples)
+}
+
 func ExampleNewSchema() {
 
 	// create an example schema object


### PR DESCRIPTION
It looks like the `schema.Examples` field was missed when loading the high-level schema from a low-level one. This adds it along with a test. It allocates a new slice because we want to go from the low-level model to just the values in a `[]any`.

Part of https://github.com/danielgtaylor/restish/issues/115