### PR TITLE
Version 0.3.0

### DIFF
--- a/datamodel/high/v3/document.go
+++ b/datamodel/high/v3/document.go
@@ -48,7 +48,7 @@ type Document struct {
 	// to authorize a request. Individual operations can override this definition. To make security optional,
 	// an empty security requirement ({}) can be included in the array.
 	// - https://spec.openapis.org/oas/v3.1.0#security-requirement-object
-	Security *base.SecurityRequirement
+	Security []*base.SecurityRequirement
 
 	// Tags is a slice of base.Tag instances defined by the specification
 	// A list of tags used by the document with additional metadata. The order of the tags can be used to reflect on
@@ -121,17 +121,24 @@ func NewDocument(document *low.Document) *Document {
 	if !document.Paths.IsEmpty() {
 		d.Paths = NewPaths(document.Paths.Value)
 	}
-	if !document.JsonSchemaDialect.IsEmpty() {
-		d.JsonSchemaDialect = document.JsonSchemaDialect.Value
-	}
-	if !document.Webhooks.IsEmpty() {
-		hooks := make(map[string]*PathItem)
-		for h := range document.Webhooks.Value {
-			hooks[h.Value] = NewPathItem(document.Webhooks.Value[h].Value)
-		}
-		d.Webhooks = hooks
-	}
-	return d
+    if !document.JsonSchemaDialect.IsEmpty() {
+        d.JsonSchemaDialect = document.JsonSchemaDialect.Value
+    }
+    if !document.Webhooks.IsEmpty() {
+        hooks := make(map[string]*PathItem)
+        for h := range document.Webhooks.Value {
+            hooks[h.Value] = NewPathItem(document.Webhooks.Value[h].Value)
+        }
+        d.Webhooks = hooks
+    }
+    if !document.Security.IsEmpty() {
+        var security []*base.SecurityRequirement
+        for s := range document.Security.Value {
+            security = append(security, base.NewSecurityRequirement(document.Security.Value[s].Value))
+        }
+        d.Security = security
+    }
+    return d
 }
 
 // GoLow returns the low-level Document that was used to create the high level one.

--- a/datamodel/high/v3/document_test.go
+++ b/datamodel/high/v3/document_test.go
@@ -43,6 +43,15 @@ func TestNewDocument_ExternalDocs(t *testing.T) {
     assert.Equal(t, "https://pb33f.io", h.ExternalDocs.URL)
 }
 
+func TestNewDocument_Security(t *testing.T) {
+    initTest()
+    h := NewDocument(lowDoc)
+    assert.Len(t, h.Security, 1)
+    assert.Len(t, h.Security[0].Requirements, 1)
+    assert.Len(t, h.Security[0].Requirements["OAuthScheme"], 2)
+
+}
+
 func TestNewDocument_Info(t *testing.T) {
     initTest()
     highDoc := NewDocument(lowDoc)

--- a/datamodel/high/v3/server.go
+++ b/datamodel/high/v3/server.go
@@ -3,7 +3,10 @@
 
 package v3
 
-import low "github.com/pb33f/libopenapi/datamodel/low/v3"
+import (
+	"github.com/pb33f/libopenapi/datamodel/high"
+	low "github.com/pb33f/libopenapi/datamodel/low/v3"
+)
 
 // Server represents a high-level OpenAPI 3+ Server object, that is backed by a low level one.
 //  - https://spec.openapis.org/oas/v3.1.0#server-object
@@ -11,6 +14,7 @@ type Server struct {
 	URL         string
 	Description string
 	Variables   map[string]*ServerVariable
+	Extensions  map[string]any
 	low         *low.Server
 }
 
@@ -25,6 +29,7 @@ func NewServer(server *low.Server) *Server {
 		vars[k.Value] = NewServerVariable(val.Value)
 	}
 	s.Variables = vars
+	s.Extensions = high.ExtractExtensions(server.Extensions)
 	return s
 }
 

--- a/datamodel/low/v3/media_type.go
+++ b/datamodel/low/v3/media_type.go
@@ -54,7 +54,15 @@ func (mt *MediaType) Build(root *yaml.Node, idx *index.SpecIndex) error {
 	// handle example if set.
 	_, expLabel, expNode := utils.FindKeyNodeFull(base.ExampleLabel, root.Content)
 	if expNode != nil {
-		mt.Example = low.NodeReference[any]{Value: expNode.Value, KeyNode: expLabel, ValueNode: expNode}
+		var value string
+		if utils.IsNodeMap(expNode) || utils.IsNodeArray(expNode) {
+			y, _ := yaml.Marshal(expNode)
+			z, _ := utils.ConvertYAMLtoJSON(y)
+			value = fmt.Sprintf("%s", z)
+		} else {
+			value = expNode.Value
+		}
+		mt.Example = low.NodeReference[any]{Value: value, KeyNode: expLabel, ValueNode: expNode}
 	}
 
 	//handle schema

--- a/datamodel/low/v3/server.go
+++ b/datamodel/low/v3/server.go
@@ -19,6 +19,7 @@ type Server struct {
 	URL         low.NodeReference[string]
 	Description low.NodeReference[string]
 	Variables   low.NodeReference[map[low.KeyReference[string]]low.ValueReference[*ServerVariable]]
+	Extensions  map[low.KeyReference[string]]low.ValueReference[any]
 }
 
 // FindVariable attempts to locate a ServerVariable instance using the supplied key.
@@ -28,6 +29,7 @@ func (s *Server) FindVariable(serverVar string) *low.ValueReference[*ServerVaria
 
 // Build will extract server variables from the supplied node.
 func (s *Server) Build(root *yaml.Node, idx *index.SpecIndex) error {
+	s.Extensions = low.ExtractExtensions(root)
 	kn, vars := utils.FindKeyNode(VariablesLabel, root.Content)
 	if vars == nil {
 		return nil

--- a/what-changed/model/example_test.go
+++ b/what-changed/model/example_test.go
@@ -39,6 +39,91 @@ func TestCompareExamples_SummaryModified(t *testing.T) {
 	assert.Equal(t, "cure all", extChanges.Changes[0].New)
 }
 
+func TestCompareExamples_Map(t *testing.T) {
+
+	left := `value:
+  cheesy: bread
+  pasta: sauce`
+
+	right := `value:
+  cheesy: cakes
+  pasta: spicy`
+
+	var lNode, rNode yaml.Node
+	_ = yaml.Unmarshal([]byte(left), &lNode)
+	_ = yaml.Unmarshal([]byte(right), &rNode)
+
+	// create low level objects
+	var lDoc base.Example
+	var rDoc base.Example
+	_ = low.BuildModel(lNode.Content[0], &lDoc)
+	_ = low.BuildModel(rNode.Content[0], &rDoc)
+	_ = lDoc.Build(lNode.Content[0], nil)
+	_ = rDoc.Build(rNode.Content[0], nil)
+
+	extChanges := CompareExamples(&lDoc, &rDoc)
+
+	assert.Equal(t, extChanges.TotalChanges(), 2)
+	assert.Equal(t, 0, extChanges.TotalBreakingChanges())
+	assert.Equal(t, Modified, extChanges.Changes[0].ChangeType)
+}
+
+func TestCompareExamples_MapAdded(t *testing.T) {
+
+	left := `value:
+  cheesy: bread`
+
+	right := `value:
+  cheesy: bread
+  pasta: sauce`
+
+	var lNode, rNode yaml.Node
+	_ = yaml.Unmarshal([]byte(left), &lNode)
+	_ = yaml.Unmarshal([]byte(right), &rNode)
+
+	// create low level objects
+	var lDoc base.Example
+	var rDoc base.Example
+	_ = low.BuildModel(lNode.Content[0], &lDoc)
+	_ = low.BuildModel(rNode.Content[0], &rDoc)
+	_ = lDoc.Build(lNode.Content[0], nil)
+	_ = rDoc.Build(rNode.Content[0], nil)
+
+	extChanges := CompareExamples(&lDoc, &rDoc)
+
+	assert.Equal(t, extChanges.TotalChanges(), 1)
+	assert.Equal(t, 0, extChanges.TotalBreakingChanges())
+	assert.Equal(t, PropertyAdded, extChanges.Changes[0].ChangeType)
+}
+
+func TestCompareExamples_MapRemoved(t *testing.T) {
+
+	left := `value:
+  cheesy: bread`
+
+	right := `value:
+  cheesy: bread
+  pasta: sauce`
+
+	var lNode, rNode yaml.Node
+	_ = yaml.Unmarshal([]byte(left), &lNode)
+	_ = yaml.Unmarshal([]byte(right), &rNode)
+
+	// create low level objects
+	var lDoc base.Example
+	var rDoc base.Example
+	_ = low.BuildModel(lNode.Content[0], &lDoc)
+	_ = low.BuildModel(rNode.Content[0], &rDoc)
+	_ = lDoc.Build(lNode.Content[0], nil)
+	_ = rDoc.Build(rNode.Content[0], nil)
+
+	extChanges := CompareExamples(&rDoc, &lDoc)
+
+	assert.Equal(t, extChanges.TotalChanges(), 1)
+	assert.Equal(t, 0, extChanges.TotalBreakingChanges())
+	assert.Equal(t, PropertyRemoved, extChanges.Changes[0].ChangeType)
+}
+
 func TestCompareExamples_SummaryAdded(t *testing.T) {
 
 	left := `summary: magic herbs`

--- a/what-changed/model/media_type.go
+++ b/what-changed/model/media_type.go
@@ -4,7 +4,6 @@
 package model
 
 import (
-    "fmt"
     "github.com/pb33f/libopenapi/datamodel/low"
     "github.com/pb33f/libopenapi/datamodel/low/v3"
     "github.com/pb33f/libopenapi/utils"
@@ -74,14 +73,12 @@ func CompareMediaTypes(l, r *v3.MediaType) *MediaTypeChanges {
     if !l.Example.IsEmpty() && !r.Example.IsEmpty() {
         if (utils.IsNodeMap(l.Example.ValueNode) && utils.IsNodeMap(r.Example.ValueNode)) ||
             (utils.IsNodeArray(l.Example.ValueNode) && utils.IsNodeArray(r.Example.ValueNode)) {
-            render, err := yaml.Marshal(l.Example.ValueNode)
-            if err != nil {
-                l.Example.ValueNode.Value = fmt.Sprintf("%s", render)
-            }
-            render, err = yaml.Marshal(r.Example.ValueNode)
-            if err == nil {
-                r.Example.ValueNode.Value = fmt.Sprintf("%s", render)
-            }
+            render, _ := yaml.Marshal(l.Example.ValueNode)
+            render, _ = utils.ConvertYAMLtoJSON(render)
+            l.Example.ValueNode.Value = string(render)
+            render, _ = yaml.Marshal(r.Example.ValueNode)
+            render, _ = utils.ConvertYAMLtoJSON(render)
+            r.Example.ValueNode.Value = string(render)
         }
         addPropertyCheck(&props, l.Example.ValueNode, r.Example.ValueNode,
             l.Example.Value, r.Example.Value, &changes, v3.ExampleLabel, false)
@@ -89,17 +86,15 @@ func CompareMediaTypes(l, r *v3.MediaType) *MediaTypeChanges {
     } else {
 
         if utils.IsNodeMap(l.Example.ValueNode) || utils.IsNodeArray(l.Example.ValueNode) {
-            render, err := yaml.Marshal(l.Example.ValueNode)
-            if err != nil {
-                l.Example.ValueNode.Value = fmt.Sprint(render)
-            }
+            render, _ := yaml.Marshal(l.Example.ValueNode)
+            render, _ = utils.ConvertYAMLtoJSON(render)
+            l.Example.ValueNode.Value = string(render)
         }
 
         if utils.IsNodeMap(r.Example.ValueNode) || utils.IsNodeArray(r.Example.ValueNode) {
-            render, err := yaml.Marshal(r.Example.ValueNode)
-            if err == nil {
-                r.Example.ValueNode.Value = fmt.Sprintf("%s", render)
-            }
+            render, _ := yaml.Marshal(r.Example.ValueNode)
+            render, _ = utils.ConvertYAMLtoJSON(render)
+            r.Example.ValueNode.Value = string(render)
         }
 
         addPropertyCheck(&props, l.Example.ValueNode, r.Example.ValueNode,
@@ -131,9 +126,5 @@ func CompareMediaTypes(l, r *v3.MediaType) *MediaTypeChanges {
 
     mc.ExtensionChanges = CompareExtensions(l.Extensions, r.Extensions)
     mc.PropertyChanges = NewPropertyChanges(changes)
-
-    if mc.TotalChanges() <= 0 {
-        return nil
-    }
     return mc
 }

--- a/what-changed/model/media_type_test.go
+++ b/what-changed/model/media_type_test.go
@@ -89,6 +89,104 @@ encoding:
 	assert.Equal(t, v3.ExampleLabel, extChanges.Changes[0].Property)
 }
 
+func TestCompareMediaTypes_Modify_Examples(t *testing.T) {
+
+	left := `schema:
+  type: string
+example:
+  smoke: and a pancake?`
+
+	right := `schema:
+  type: string
+example:
+  smoke: and a pancake?
+  pipe: pipe and a crepe?`
+
+	var lNode, rNode yaml.Node
+	_ = yaml.Unmarshal([]byte(left), &lNode)
+	_ = yaml.Unmarshal([]byte(right), &rNode)
+
+	// create low level objects
+	var lDoc v3.MediaType
+	var rDoc v3.MediaType
+	_ = low.BuildModel(lNode.Content[0], &lDoc)
+	_ = low.BuildModel(rNode.Content[0], &rDoc)
+	_ = lDoc.Build(lNode.Content[0], nil)
+	_ = rDoc.Build(rNode.Content[0], nil)
+
+	// compare.
+	extChanges := CompareMediaTypes(&lDoc, &rDoc)
+	assert.NotNil(t, extChanges)
+	assert.Equal(t, 1, extChanges.TotalChanges())
+	assert.Equal(t, 0, extChanges.TotalBreakingChanges())
+	assert.Equal(t, Modified, extChanges.Changes[0].ChangeType)
+	assert.Equal(t, v3.ExampleLabel, extChanges.Changes[0].Property)
+}
+
+func TestCompareMediaTypes_ExampleChangedToMap(t *testing.T) {
+
+	left := `schema:
+  type: string`
+
+	right := `schema:
+  type: string
+example:
+  smoke: and a pancake?
+  pipe: pipe and a crepe?`
+
+	var lNode, rNode yaml.Node
+	_ = yaml.Unmarshal([]byte(left), &lNode)
+	_ = yaml.Unmarshal([]byte(right), &rNode)
+
+	// create low level objects
+	var lDoc v3.MediaType
+	var rDoc v3.MediaType
+	_ = low.BuildModel(lNode.Content[0], &lDoc)
+	_ = low.BuildModel(rNode.Content[0], &rDoc)
+	_ = lDoc.Build(lNode.Content[0], nil)
+	_ = rDoc.Build(rNode.Content[0], nil)
+
+	// compare.
+	extChanges := CompareMediaTypes(&lDoc, &rDoc)
+	assert.NotNil(t, extChanges)
+	assert.Equal(t, 1, extChanges.TotalChanges())
+	assert.Equal(t, 0, extChanges.TotalBreakingChanges())
+	assert.Equal(t, PropertyAdded, extChanges.Changes[0].ChangeType)
+	assert.Equal(t, v3.ExampleLabel, extChanges.Changes[0].Property)
+}
+
+func TestCompareMediaTypes_ExampleMapRemoved(t *testing.T) {
+
+	left := `schema:
+  type: string`
+
+	right := `schema:
+  type: string
+example:
+  smoke: and a pancake?
+  pipe: pipe and a crepe?`
+
+	var lNode, rNode yaml.Node
+	_ = yaml.Unmarshal([]byte(left), &lNode)
+	_ = yaml.Unmarshal([]byte(right), &rNode)
+
+	// create low level objects
+	var lDoc v3.MediaType
+	var rDoc v3.MediaType
+	_ = low.BuildModel(lNode.Content[0], &lDoc)
+	_ = low.BuildModel(rNode.Content[0], &rDoc)
+	_ = lDoc.Build(lNode.Content[0], nil)
+	_ = rDoc.Build(rNode.Content[0], nil)
+
+	// compare.
+	extChanges := CompareMediaTypes(&rDoc, &lDoc)
+	assert.NotNil(t, extChanges)
+	assert.Equal(t, 1, extChanges.TotalChanges())
+	assert.Equal(t, 0, extChanges.TotalBreakingChanges())
+	assert.Equal(t, PropertyRemoved, extChanges.Changes[0].ChangeType)
+	assert.Equal(t, v3.ExampleLabel, extChanges.Changes[0].Property)
+}
+
 func TestCompareMediaTypes_AddSchema(t *testing.T) {
 
 	left := `example: tasty herbs in the morning

--- a/what-changed/model/operation.go
+++ b/what-changed/model/operation.go
@@ -365,7 +365,7 @@ func CompareOperations(l, r any) *OperationChanges {
         }
         if lOperation.Callbacks.IsEmpty() && !rOperation.Callbacks.IsEmpty() {
             CreateChange(&changes, PropertyAdded, v3.CallbacksLabel,
-                nil, rOperation.Callbacks.ValueNode, true, nil,
+                nil, rOperation.Callbacks.ValueNode, false, nil,
                 rOperation.Callbacks.Value)
         }
 

--- a/what-changed/model/operation_test.go
+++ b/what-changed/model/operation_test.go
@@ -988,6 +988,184 @@ func TestCompareOperations_V3_ModifyServers(t *testing.T) {
 	assert.Equal(t, PropertyAdded, extChanges.ServerChanges[0].Changes[0].ChangeType)
 }
 
+func TestCompareOperations_V3_ModifyCallback(t *testing.T) {
+
+	left := `callbacks:
+  myCallback:
+    '{$request.query.queryUrl}':
+      post:
+        description: something old`
+
+	right := `callbacks:
+  myCallback:
+    '{$request.query.queryUrl}':
+      post:
+        description: something new!`
+
+	var lNode, rNode yaml.Node
+	_ = yaml.Unmarshal([]byte(left), &lNode)
+	_ = yaml.Unmarshal([]byte(right), &rNode)
+
+	// create low level objects
+	var lDoc v3.Operation
+	var rDoc v3.Operation
+	_ = low.BuildModel(lNode.Content[0], &lDoc)
+	_ = low.BuildModel(rNode.Content[0], &rDoc)
+	_ = lDoc.Build(lNode.Content[0], nil)
+	_ = rDoc.Build(rNode.Content[0], nil)
+
+	// compare.
+	extChanges := CompareOperations(&lDoc, &rDoc)
+	assert.Equal(t, 1, extChanges.TotalChanges())
+	assert.Equal(t, 0, extChanges.TotalBreakingChanges())
+	assert.Equal(t, Modified, extChanges.
+		CallbackChanges["myCallback"].
+		ExpressionChanges["{$request.query.queryUrl}"].
+		PostChanges.Changes[0].ChangeType)
+}
+
+func TestCompareOperations_V3_AddCallback(t *testing.T) {
+
+	left := `callbacks:
+  myCallback:
+    '{$request.query.queryUrl}':
+      post:
+        description: something old`
+
+	right := `callbacks:
+  myCallback:
+    '{$request.query.queryUrl}':
+      post:
+        description: something old
+  aNewCallback:
+    aLovelyHorse:
+      post:
+        description: something new!`
+
+	var lNode, rNode yaml.Node
+	_ = yaml.Unmarshal([]byte(left), &lNode)
+	_ = yaml.Unmarshal([]byte(right), &rNode)
+
+	// create low level objects
+	var lDoc v3.Operation
+	var rDoc v3.Operation
+	_ = low.BuildModel(lNode.Content[0], &lDoc)
+	_ = low.BuildModel(rNode.Content[0], &rDoc)
+	_ = lDoc.Build(lNode.Content[0], nil)
+	_ = rDoc.Build(rNode.Content[0], nil)
+
+	// compare.
+	extChanges := CompareOperations(&lDoc, &rDoc)
+	assert.Equal(t, 1, extChanges.TotalChanges())
+	assert.Equal(t, 0, extChanges.TotalBreakingChanges())
+	assert.Equal(t, ObjectAdded, extChanges.Changes[0].ChangeType)
+}
+
+func TestCompareOperations_V3_AddCallbacks(t *testing.T) {
+
+	left := `operationId: 123`
+
+	right := `operationId: 123
+callbacks:
+  myCallback:
+    '{$request.query.queryUrl}':
+      post:
+        description: something old
+  aNewCallback:
+    aLovelyHorse:
+      post:
+        description: something new!`
+
+	var lNode, rNode yaml.Node
+	_ = yaml.Unmarshal([]byte(left), &lNode)
+	_ = yaml.Unmarshal([]byte(right), &rNode)
+
+	// create low level objects
+	var lDoc v3.Operation
+	var rDoc v3.Operation
+	_ = low.BuildModel(lNode.Content[0], &lDoc)
+	_ = low.BuildModel(rNode.Content[0], &rDoc)
+	_ = lDoc.Build(lNode.Content[0], nil)
+	_ = rDoc.Build(rNode.Content[0], nil)
+
+	// compare.
+	extChanges := CompareOperations(&lDoc, &rDoc)
+	assert.Equal(t, 1, extChanges.TotalChanges())
+	assert.Equal(t, 0, extChanges.TotalBreakingChanges())
+	assert.Equal(t, PropertyAdded, extChanges.Changes[0].ChangeType)
+}
+
+func TestCompareOperations_V3_RemoveCallbacks(t *testing.T) {
+
+	left := `operationId: 123`
+
+	right := `operationId: 123
+callbacks:
+  myCallback:
+    '{$request.query.queryUrl}':
+      post:
+        description: something old
+  aNewCallback:
+    aLovelyHorse:
+      post:
+        description: something new!`
+
+	var lNode, rNode yaml.Node
+	_ = yaml.Unmarshal([]byte(left), &lNode)
+	_ = yaml.Unmarshal([]byte(right), &rNode)
+
+	// create low level objects
+	var lDoc v3.Operation
+	var rDoc v3.Operation
+	_ = low.BuildModel(lNode.Content[0], &lDoc)
+	_ = low.BuildModel(rNode.Content[0], &rDoc)
+	_ = lDoc.Build(lNode.Content[0], nil)
+	_ = rDoc.Build(rNode.Content[0], nil)
+
+	// compare.
+	extChanges := CompareOperations(&rDoc, &lDoc)
+	assert.Equal(t, 1, extChanges.TotalChanges())
+	assert.Equal(t, 1, extChanges.TotalBreakingChanges())
+	assert.Equal(t, PropertyRemoved, extChanges.Changes[0].ChangeType)
+}
+
+func TestCompareOperations_V3_RemoveCallback(t *testing.T) {
+
+	left := `callbacks:
+  myCallback:
+    '{$request.query.queryUrl}':
+      post:
+        description: something old`
+
+	right := `callbacks:
+  myCallback:
+    '{$request.query.queryUrl}':
+      post:
+        description: something old
+  aNewCallback:
+    aLovelyHorse:
+      post:
+        description: something new!`
+
+	var lNode, rNode yaml.Node
+	_ = yaml.Unmarshal([]byte(left), &lNode)
+	_ = yaml.Unmarshal([]byte(right), &rNode)
+
+	// create low level objects
+	var lDoc v3.Operation
+	var rDoc v3.Operation
+	_ = low.BuildModel(lNode.Content[0], &lDoc)
+	_ = low.BuildModel(rNode.Content[0], &rDoc)
+	_ = lDoc.Build(lNode.Content[0], nil)
+	_ = rDoc.Build(rNode.Content[0], nil)
+
+	// compare.
+	extChanges := CompareOperations(&rDoc, &lDoc)
+	assert.Equal(t, 1, extChanges.TotalChanges())
+	assert.Equal(t, 1, extChanges.TotalBreakingChanges())
+	assert.Equal(t, ObjectRemoved, extChanges.Changes[0].ChangeType)
+}
+
 func TestCompareOperations_V3_AddServer(t *testing.T) {
 
 	left := `servers:

--- a/what-changed/model/response.go
+++ b/what-changed/model/response.go
@@ -168,8 +168,5 @@ func CompareResponse(l, r any) *ResponseChanges {
 
     CheckProperties(props)
     rc.PropertyChanges = NewPropertyChanges(changes)
-    if rc.TotalChanges() <= 0 {
-        return nil
-    }
     return rc
 }


### PR DESCRIPTION
This release fixes a couple of missing elements:

- The v3 high-level `Document` object was incorrectly implemented. The `security` property needed to be a slice. **Breaking**
- `Server` was missing extensions in both high and low-level APIs.

This is a whole feature bump because of the change to the `Document` model. `Security` is now a slice and not a single instance. A small breaking change, but a breaking one none-the-less
