### PR TITLE
(fix): A memory leak was detected and fixed #46

### DIFF
--- a/datamodel/spec_info.go
+++ b/datamodel/spec_info.go
@@ -105,8 +105,7 @@ func ExtractSpecInfo(spec []byte) (*SpecInfo, error) {
 			spec.SpecJSONBytes = &bytes
 			spec.SpecJSON = &jsonSpec
 		}
-		spec.JsonParsingChannel <- true
-		close(spec.JsonParsingChannel)
+		close(spec.JsonParsingChannel) // this needs removing at some point
 	}
 
 	// check for specific keys
@@ -128,8 +127,6 @@ func ExtractSpecInfo(spec []byte) (*SpecInfo, error) {
 		specVersion.Version = version
 		specVersion.SpecFormat = OAS3
 	}
-
-	//return specVersion, nil
 
 	if openAPI2 != nil {
 		specVersion.SpecType = utils.OpenApi2
@@ -172,10 +169,10 @@ func ExtractSpecInfo(spec []byte) (*SpecInfo, error) {
 	if specVersion.SpecType == "" {
 		// parse JSON
 		parseJSON(spec, specVersion, &parsedSpec)
-
 		specVersion.Error = errors.New("spec type not supported by vacuum, sorry")
 		return specVersion, specVersion.Error
 	}
+
 	return specVersion, nil
 }
 

--- a/datamodel/spec_info_test.go
+++ b/datamodel/spec_info_test.go
@@ -115,7 +115,6 @@ info:
 
 func TestExtractSpecInfo_ValidJSON(t *testing.T) {
 	r, e := ExtractSpecInfo([]byte(goodJSON))
-	<-r.JsonParsingChannel
 	assert.Greater(t, len(*r.SpecJSONBytes), 0)
 	assert.Error(t, e)
 }
@@ -132,7 +131,6 @@ func TestExtractSpecInfo_Nothing(t *testing.T) {
 
 func TestExtractSpecInfo_ValidYAML(t *testing.T) {
 	r, e := ExtractSpecInfo([]byte(goodYAML))
-	<-r.JsonParsingChannel
 	assert.Greater(t, len(*r.SpecJSONBytes), 0)
 	assert.Error(t, e)
 }
@@ -153,8 +151,6 @@ func TestExtractSpecInfo_OpenAPI3(t *testing.T) {
 	assert.Nil(t, e)
 	assert.Equal(t, utils.OpenApi3, r.SpecType)
 	assert.Equal(t, "3.0.1", r.Version)
-
-	<-r.JsonParsingChannel
 	assert.Greater(t, len(*r.SpecJSONBytes), 0)
 
 }
@@ -188,8 +184,6 @@ func TestExtractSpecInfo_OpenAPI2(t *testing.T) {
 	assert.Nil(t, e)
 	assert.Equal(t, OpenApi2, r.SpecType)
 	assert.Equal(t, "2.0.1", r.Version)
-
-	<-r.JsonParsingChannel
 	assert.Greater(t, len(*r.SpecJSONBytes), 0)
 }
 
@@ -207,7 +201,6 @@ func TestExtractSpecInfo_AsyncAPI(t *testing.T) {
 	assert.Nil(t, e)
 	assert.Equal(t, AsyncApi, r.SpecType)
 	assert.Equal(t, "2.0.0", r.Version)
-	<-r.JsonParsingChannel
 	assert.Greater(t, len(*r.SpecJSONBytes), 0)
 }
 

--- a/document.go
+++ b/document.go
@@ -84,6 +84,16 @@ func NewDocument(specByteArray []byte) (Document, error) {
 	d := new(document)
 	d.version = info.Version
 	d.info = info
+
+	// wait for json to be ready
+	// this needs to be deprecated at some-point
+	done := false
+	for !done {
+		select {
+		case <-info.JsonParsingChannel:
+			done = true
+		}
+	}
 	return d, nil
 }
 

--- a/document.go
+++ b/document.go
@@ -84,16 +84,6 @@ func NewDocument(specByteArray []byte) (Document, error) {
 	d := new(document)
 	d.version = info.Version
 	d.info = info
-
-	// wait for json to be ready
-	// this needs to be deprecated at some-point
-	done := false
-	for !done {
-		select {
-		case <-info.JsonParsingChannel:
-			done = true
-		}
-	}
 	return d, nil
 }
 


### PR DESCRIPTION
The issue lay with the `ExtractSpecInfo()` method from within the `datamodel` module. There is a round of parsing that happens in another thread inside there, and a notification is pumped down a channel once done. The problem is that nothing was listening on that channel, so everything in those threads just kept piling up with the garbage collector unable to free any of it.