### PR TITLE
feat: add parent nodes and paths to server index references

### DIFF
--- a/index/spec_index.go
+++ b/index/spec_index.go
@@ -1648,6 +1648,8 @@ func (index *SpecIndex) extractDefinitionsAndSchemas(schemasNode *yaml.Node, pat
 			Definition: def,
 			Name:       name,
 			Node:       schema,
+			Path:       fmt.Sprintf("$.components.schemas.%s", name),
+			ParentNode: schemasNode,
 		}
 		index.allSchemas[def] = ref
 	}

--- a/index/spec_index.go
+++ b/index/spec_index.go
@@ -1091,6 +1091,7 @@ func (index *SpecIndex) GetComponentSchemaCount() int {
 							Name:       "server",
 							Node:       def,
 							Path:       fmt.Sprintf("$.servers[%d]", x),
+							ParentNode: index.rootServersNode,
 						}
 						index.serversRefs = append(index.serversRefs, ref)
 					}
@@ -1370,11 +1371,13 @@ func (index *SpecIndex) GetOperationsParameterCount() int {
 							index.opServersRefs[pathItemNode.Value] = make(map[string][]*Reference)
 						}
 						var serverRefs []*Reference
-						for _, serverRef := range serversNode.Content {
+						for i, serverRef := range serversNode.Content {
 							ref := &Reference{
 								Definition: serverRef.Value,
 								Name:       serverRef.Value,
 								Node:       serverRef,
+								ParentNode: prop,
+								Path:       fmt.Sprintf("$.paths.%s.servers[%d]", pathItemNode.Value, i),
 							}
 							serverRefs = append(serverRefs, ref)
 						}
@@ -1452,11 +1455,13 @@ func (index *SpecIndex) GetOperationsParameterCount() int {
 									serversNode := pathPropertyNode.Content[y+1].Content[z+1]
 
 									var serverRefs []*Reference
-									for _, serverRef := range serversNode.Content {
+									for i, serverRef := range serversNode.Content {
 										ref := &Reference{
 											Definition: "servers",
 											Name:       "servers",
 											Node:       serverRef,
+											ParentNode: httpMethodProp,
+											Path:       fmt.Sprintf("$.paths.%s.%s.servers[%d]", pathItemNode.Value, prop.Value, i),
 										}
 										serverRefs = append(serverRefs, ref)
 									}

--- a/index/spec_index_test.go
+++ b/index/spec_index_test.go
@@ -722,6 +722,27 @@ paths:
 	}
 }
 
+func TestSpecIndex_schemaComponentsHaveParentsAndPaths(t *testing.T) {
+	yml := `components:
+  schemas:
+    Pet:
+      type: object
+    Dog:
+      type: object`
+
+	var rootNode yaml.Node
+	yaml.Unmarshal([]byte(yml), &rootNode)
+
+	index := NewSpecIndex(&rootNode)
+
+	schemas := index.GetAllSchemas()
+
+	for _, schema := range schemas {
+		assert.NotNil(t, schema.ParentNode)
+		assert.Equal(t, fmt.Sprintf("$.components.schemas.%s", schema.Name), schema.Path)
+	}
+}
+
 // Example of how to load in an OpenAPI Specification and index it.
 func ExampleNewSpecIndex() {
 	// define a rootNode to hold our raw spec AST.


### PR DESCRIPTION
This adds paths and parent nodes to the references for servers which help to improve any code using these references