### PR TITLE
(fix): `X-` is a valid prefix for `SecurityScheme` components. #54

### DIFF
--- a/datamodel/low/v3/components.go
+++ b/datamodel/low/v3/components.go
@@ -254,7 +254,8 @@ func extractComponentValues[T low.Buildable[N], N any](label string, root *yaml.
 			currentLabel = v
 			continue
 		}
-		if strings.HasPrefix(strings.ToLower(currentLabel.Value), "x-") {
+		// only check for lowercase extensions as 'X-' is still valid as a key (annoyingly).
+		if strings.HasPrefix(currentLabel.Value, "x-") {
 			continue
 		}
 		totalComponents++


### PR DESCRIPTION
Security schemes with a `X-` prefix were being seen mistakenly as extensions, because the key name was automatically set to lowercase, before a check.