### PR TITLE
Fix setting JSON schema for OAS 3.1.0

### DIFF
--- a/datamodel/spec_info.go
+++ b/datamodel/spec_info.go
@@ -7,10 +7,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/pb33f/libopenapi/utils"
-	"gopkg.in/yaml.v3"
 	"strings"
 	"time"
+
+	"github.com/pb33f/libopenapi/utils"
+	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -111,11 +112,14 @@ func ExtractSpecInfo(spec []byte) (*SpecInfo, error) {
 
 	// check for specific keys
 	if openAPI3 != nil {
-		specVersion.SpecType = utils.OpenApi3
 		version, majorVersion, versionError := parseVersionTypeData(openAPI3.Value)
 		if versionError != nil {
 			return nil, versionError
 		}
+
+		specVersion.SpecType = utils.OpenApi3
+		specVersion.Version = version
+		specVersion.SpecFormat = OAS3
 
 		// parse JSON
 		parseJSON(spec, specVersion, &parsedSpec)
@@ -125,16 +129,17 @@ func ExtractSpecInfo(spec []byte) (*SpecInfo, error) {
 			specVersion.Error = errors.New("spec is defined as an openapi spec, but is using a swagger (2.0), or unknown version")
 			return specVersion, specVersion.Error
 		}
-		specVersion.Version = version
-		specVersion.SpecFormat = OAS3
 	}
 
 	if openAPI2 != nil {
-		specVersion.SpecType = utils.OpenApi2
 		version, majorVersion, versionError := parseVersionTypeData(openAPI2.Value)
 		if versionError != nil {
 			return nil, versionError
 		}
+
+		specVersion.SpecType = utils.OpenApi2
+		specVersion.Version = version
+		specVersion.SpecFormat = OAS2
 
 		// parse JSON
 		parseJSON(spec, specVersion, &parsedSpec)
@@ -144,15 +149,16 @@ func ExtractSpecInfo(spec []byte) (*SpecInfo, error) {
 			specVersion.Error = errors.New("spec is defined as a swagger (openapi 2.0) spec, but is an openapi 3 or unknown version")
 			return specVersion, specVersion.Error
 		}
-		specVersion.Version = version
-		specVersion.SpecFormat = OAS2
 	}
 	if asyncAPI != nil {
-		specVersion.SpecType = utils.AsyncApi
 		version, majorVersion, versionErr := parseVersionTypeData(asyncAPI.Value)
 		if versionErr != nil {
 			return nil, versionErr
 		}
+
+		specVersion.SpecType = utils.AsyncApi
+		specVersion.Version = version
+		// TODO: format for AsyncAPI.
 
 		// parse JSON
 		parseJSON(spec, specVersion, &parsedSpec)
@@ -162,9 +168,6 @@ func ExtractSpecInfo(spec []byte) (*SpecInfo, error) {
 			specVersion.Error = errors.New("spec is defined as asyncapi, but has a major version that is invalid")
 			return specVersion, specVersion.Error
 		}
-		specVersion.Version = version
-		// TODO: format for AsyncAPI.
-
 	}
 
 	if specVersion.SpecType == "" {

--- a/datamodel/spec_info_test.go
+++ b/datamodel/spec_info_test.go
@@ -5,10 +5,11 @@ package datamodel
 
 import (
 	"fmt"
-	"github.com/pb33f/libopenapi/utils"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"testing"
+
+	"github.com/pb33f/libopenapi/utils"
+	"github.com/stretchr/testify/assert"
 )
 
 const (
@@ -49,13 +50,13 @@ var badYAML = `name: kitty
 
 var OpenApiWat = `openapi: 3.2
 info:
-  title: Test API, valid, but not quite valid 
+  title: Test API, valid, but not quite valid
 servers:
   - url: https://quobix.com/api`
 
 var OpenApi31 = `openapi: 3.1
 info:
-  title: Test API, valid, but not quite valid 
+  title: Test API, valid, but not quite valid
 servers:
   - url: https://quobix.com/api`
 
@@ -152,7 +153,7 @@ func TestExtractSpecInfo_OpenAPI3(t *testing.T) {
 	assert.Equal(t, utils.OpenApi3, r.SpecType)
 	assert.Equal(t, "3.0.1", r.Version)
 	assert.Greater(t, len(*r.SpecJSONBytes), 0)
-
+	assert.Contains(t, r.APISchema, "https://spec.openapis.org/oas/3.0/schema/2021-09-28")
 }
 
 func TestExtractSpecInfo_OpenAPIWat(t *testing.T) {
@@ -169,6 +170,7 @@ func TestExtractSpecInfo_OpenAPI31(t *testing.T) {
 	assert.Nil(t, e)
 	assert.Equal(t, OpenApi3, r.SpecType)
 	assert.Equal(t, "3.1", r.Version)
+	assert.Contains(t, r.APISchema, "https://spec.openapis.org/oas/3.1/schema/2022-02-27")
 }
 
 func TestExtractSpecInfo_OpenAPIFalse(t *testing.T) {
@@ -185,6 +187,7 @@ func TestExtractSpecInfo_OpenAPI2(t *testing.T) {
 	assert.Equal(t, OpenApi2, r.SpecType)
 	assert.Equal(t, "2.0.1", r.Version)
 	assert.Greater(t, len(*r.SpecJSONBytes), 0)
+	assert.Contains(t, r.APISchema, "http://swagger.io/v2/schema.json#")
 }
 
 func TestExtractSpecInfo_OpenAPI2_OddVersion(t *testing.T) {


### PR DESCRIPTION
This fixes setting the correct JSON schema for OAS 3.1 documents. It was set to the default 3.0.