### PR TITLE
fix: Index incorrectly handling file references 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 <p align="center">
-	<img src="libopenapi-logo.png" alt="libopenapi" height="300px"/>
+	<img src="libopenapi-logo.png" alt="libopenapi" height="300px" width="450px"/>
 </p>
 
 # libopenapi - enterprise grade OpenAPI tools for golang.
+
 
 ![Pipeline](https://github.com/pb33f/libopenapi/workflows/Build/badge.svg)
 [![GoReportCard](https://goreportcard.com/badge/github.com/pb33f/libopenapi)](https://goreportcard.com/report/github.com/pb33f/libopenapi)


### PR DESCRIPTION
Local files expected a component path (#/something/) to be postponed to the URL. This fix allows full file imports now to be supported in-line.

This was reported in https://github.com/daveshanley/vacuum/issues/225, and it's a continuation of the issue found in https://github.com/pb33f/libopenapi/issues/37. This fix allows the full import of the file (not just a path/component) to be imported.

Signed-off-by: Dave Shanley <dave@quobix.com>