### PR TITLE
feat: Allow circular references which contain optional properties in their journeys

### DIFF
--- a/datamodel/high/v3/document_test.go
+++ b/datamodel/high/v3/document_test.go
@@ -4,413 +4,419 @@
 package v3
 
 import (
-    "fmt"
-    "github.com/pb33f/libopenapi/datamodel"
-    v2 "github.com/pb33f/libopenapi/datamodel/high/v2"
-    lowv2 "github.com/pb33f/libopenapi/datamodel/low/v2"
-    lowv3 "github.com/pb33f/libopenapi/datamodel/low/v3"
-    "github.com/stretchr/testify/assert"
-    "io/ioutil"
-    "testing"
+	"fmt"
+	"io/ioutil"
+	"testing"
+
+	"github.com/pb33f/libopenapi/datamodel"
+	v2 "github.com/pb33f/libopenapi/datamodel/high/v2"
+	lowv2 "github.com/pb33f/libopenapi/datamodel/low/v2"
+	lowv3 "github.com/pb33f/libopenapi/datamodel/low/v3"
+	"github.com/stretchr/testify/assert"
 )
 
 var lowDoc *lowv3.Document
 
 func initTest() {
-    data, _ := ioutil.ReadFile("../../../test_specs/burgershop.openapi.yaml")
-    info, _ := datamodel.ExtractSpecInfo(data)
-    var err []error
-    lowDoc, err = lowv3.CreateDocument(info)
-    if err != nil {
-        panic("broken something")
-    }
+	data, _ := ioutil.ReadFile("../../../test_specs/burgershop.openapi.yaml")
+	info, _ := datamodel.ExtractSpecInfo(data)
+	var err []error
+	lowDoc, err = lowv3.CreateDocument(info)
+	if err != nil {
+		panic("broken something")
+	}
 }
 
 func BenchmarkNewDocument(b *testing.B) {
-    initTest()
-    for i := 0; i < b.N; i++ {
-        _ = NewDocument(lowDoc)
-    }
+	initTest()
+	for i := 0; i < b.N; i++ {
+		_ = NewDocument(lowDoc)
+	}
 }
 
 func TestNewDocument_Extensions(t *testing.T) {
-    initTest()
-    h := NewDocument(lowDoc)
-    assert.Equal(t, "darkside", h.Extensions["x-something-something"])
+	initTest()
+	h := NewDocument(lowDoc)
+	assert.Equal(t, "darkside", h.Extensions["x-something-something"])
 }
 
 func TestNewDocument_ExternalDocs(t *testing.T) {
-    initTest()
-    h := NewDocument(lowDoc)
-    assert.Equal(t, "https://pb33f.io", h.ExternalDocs.URL)
+	initTest()
+	h := NewDocument(lowDoc)
+	assert.Equal(t, "https://pb33f.io", h.ExternalDocs.URL)
 }
 
 func TestNewDocument_Security(t *testing.T) {
-    initTest()
-    h := NewDocument(lowDoc)
-    assert.Len(t, h.Security, 1)
-    assert.Len(t, h.Security[0].Requirements, 1)
-    assert.Len(t, h.Security[0].Requirements["OAuthScheme"], 2)
-
+	initTest()
+	h := NewDocument(lowDoc)
+	assert.Len(t, h.Security, 1)
+	assert.Len(t, h.Security[0].Requirements, 1)
+	assert.Len(t, h.Security[0].Requirements["OAuthScheme"], 2)
 }
 
 func TestNewDocument_Info(t *testing.T) {
-    initTest()
-    highDoc := NewDocument(lowDoc)
-    assert.Equal(t, "3.1.0", highDoc.Version)
-    assert.Equal(t, "Burger Shop", highDoc.Info.Title)
-    assert.Equal(t, "https://pb33f.io", highDoc.Info.TermsOfService)
-    assert.Equal(t, "pb33f", highDoc.Info.Contact.Name)
-    assert.Equal(t, "buckaroo@pb33f.io", highDoc.Info.Contact.Email)
-    assert.Equal(t, "https://pb33f.io", highDoc.Info.Contact.URL)
-    assert.Equal(t, "pb33f", highDoc.Info.License.Name)
-    assert.Equal(t, "https://pb33f.io/made-up", highDoc.Info.License.URL)
-    assert.Equal(t, "1.2", highDoc.Info.Version)
-    assert.Equal(t, "https://pb33f.io/schema", highDoc.JsonSchemaDialect)
+	initTest()
+	highDoc := NewDocument(lowDoc)
+	assert.Equal(t, "3.1.0", highDoc.Version)
+	assert.Equal(t, "Burger Shop", highDoc.Info.Title)
+	assert.Equal(t, "https://pb33f.io", highDoc.Info.TermsOfService)
+	assert.Equal(t, "pb33f", highDoc.Info.Contact.Name)
+	assert.Equal(t, "buckaroo@pb33f.io", highDoc.Info.Contact.Email)
+	assert.Equal(t, "https://pb33f.io", highDoc.Info.Contact.URL)
+	assert.Equal(t, "pb33f", highDoc.Info.License.Name)
+	assert.Equal(t, "https://pb33f.io/made-up", highDoc.Info.License.URL)
+	assert.Equal(t, "1.2", highDoc.Info.Version)
+	assert.Equal(t, "https://pb33f.io/schema", highDoc.JsonSchemaDialect)
 
-    wentLow := highDoc.GoLow()
-    assert.Equal(t, 1, wentLow.Version.ValueNode.Line)
-    assert.Equal(t, 3, wentLow.Info.Value.Title.KeyNode.Line)
+	wentLow := highDoc.GoLow()
+	assert.Equal(t, 1, wentLow.Version.ValueNode.Line)
+	assert.Equal(t, 3, wentLow.Info.Value.Title.KeyNode.Line)
 
-    wentLower := highDoc.Info.Contact.GoLow()
-    assert.Equal(t, 8, wentLower.Name.ValueNode.Line)
-    assert.Equal(t, 11, wentLower.Name.ValueNode.Column)
+	wentLower := highDoc.Info.Contact.GoLow()
+	assert.Equal(t, 8, wentLower.Name.ValueNode.Line)
+	assert.Equal(t, 11, wentLower.Name.ValueNode.Column)
 
-    wentLowAgain := highDoc.Info.GoLow()
-    assert.Equal(t, 3, wentLowAgain.Title.ValueNode.Line)
-    assert.Equal(t, 10, wentLowAgain.Title.ValueNode.Column)
+	wentLowAgain := highDoc.Info.GoLow()
+	assert.Equal(t, 3, wentLowAgain.Title.ValueNode.Line)
+	assert.Equal(t, 10, wentLowAgain.Title.ValueNode.Column)
 
-    wentOnceMore := highDoc.Info.License.GoLow()
-    assert.Equal(t, 12, wentOnceMore.Name.ValueNode.Line)
-    assert.Equal(t, 11, wentOnceMore.Name.ValueNode.Column)
-
+	wentOnceMore := highDoc.Info.License.GoLow()
+	assert.Equal(t, 12, wentOnceMore.Name.ValueNode.Line)
+	assert.Equal(t, 11, wentOnceMore.Name.ValueNode.Column)
 }
 
 func TestNewDocument_Servers(t *testing.T) {
-    initTest()
-    h := NewDocument(lowDoc)
-    assert.Len(t, h.Servers, 2)
-    assert.Equal(t, "{scheme}://api.pb33f.io", h.Servers[0].URL)
-    assert.Equal(t, "this is our main API server, for all fun API things.", h.Servers[0].Description)
-    assert.Len(t, h.Servers[0].Variables, 1)
-    assert.Equal(t, "https", h.Servers[0].Variables["scheme"].Default)
-    assert.Len(t, h.Servers[0].Variables["scheme"].Enum, 2)
+	initTest()
+	h := NewDocument(lowDoc)
+	assert.Len(t, h.Servers, 2)
+	assert.Equal(t, "{scheme}://api.pb33f.io", h.Servers[0].URL)
+	assert.Equal(t, "this is our main API server, for all fun API things.", h.Servers[0].Description)
+	assert.Len(t, h.Servers[0].Variables, 1)
+	assert.Equal(t, "https", h.Servers[0].Variables["scheme"].Default)
+	assert.Len(t, h.Servers[0].Variables["scheme"].Enum, 2)
 
-    assert.Equal(t, "https://{domain}.{host}.com", h.Servers[1].URL)
-    assert.Equal(t, "this is our second API server, for all fun API things.", h.Servers[1].Description)
-    assert.Len(t, h.Servers[1].Variables, 2)
-    assert.Equal(t, "api", h.Servers[1].Variables["domain"].Default)
-    assert.Equal(t, "pb33f.io", h.Servers[1].Variables["host"].Default)
+	assert.Equal(t, "https://{domain}.{host}.com", h.Servers[1].URL)
+	assert.Equal(t, "this is our second API server, for all fun API things.", h.Servers[1].Description)
+	assert.Len(t, h.Servers[1].Variables, 2)
+	assert.Equal(t, "api", h.Servers[1].Variables["domain"].Default)
+	assert.Equal(t, "pb33f.io", h.Servers[1].Variables["host"].Default)
 
-    wentLow := h.GoLow()
-    assert.Equal(t, 45, wentLow.Servers.Value[0].Value.Description.KeyNode.Line)
-    assert.Equal(t, 5, wentLow.Servers.Value[0].Value.Description.KeyNode.Column)
-    assert.Equal(t, 45, wentLow.Servers.Value[0].Value.Description.ValueNode.Line)
-    assert.Equal(t, 18, wentLow.Servers.Value[0].Value.Description.ValueNode.Column)
+	wentLow := h.GoLow()
+	assert.Equal(t, 45, wentLow.Servers.Value[0].Value.Description.KeyNode.Line)
+	assert.Equal(t, 5, wentLow.Servers.Value[0].Value.Description.KeyNode.Column)
+	assert.Equal(t, 45, wentLow.Servers.Value[0].Value.Description.ValueNode.Line)
+	assert.Equal(t, 18, wentLow.Servers.Value[0].Value.Description.ValueNode.Column)
 
-    wentLower := h.Servers[0].GoLow()
-    assert.Equal(t, 45, wentLower.Description.ValueNode.Line)
-    assert.Equal(t, 18, wentLower.Description.ValueNode.Column)
+	wentLower := h.Servers[0].GoLow()
+	assert.Equal(t, 45, wentLower.Description.ValueNode.Line)
+	assert.Equal(t, 18, wentLower.Description.ValueNode.Column)
 
-    wentLowest := h.Servers[0].Variables["scheme"].GoLow()
-    assert.Equal(t, 50, wentLowest.Description.ValueNode.Line)
-    assert.Equal(t, 22, wentLowest.Description.ValueNode.Column)
-
+	wentLowest := h.Servers[0].Variables["scheme"].GoLow()
+	assert.Equal(t, 50, wentLowest.Description.ValueNode.Line)
+	assert.Equal(t, 22, wentLowest.Description.ValueNode.Column)
 }
 
 func TestNewDocument_Tags(t *testing.T) {
-    initTest()
-    h := NewDocument(lowDoc)
-    assert.Len(t, h.Tags, 2)
-    assert.Equal(t, "Burgers", h.Tags[0].Name)
-    assert.Equal(t, "All kinds of yummy burgers.", h.Tags[0].Description)
-    assert.Equal(t, "Find out more", h.Tags[0].ExternalDocs.Description)
-    assert.Equal(t, "https://pb33f.io", h.Tags[0].ExternalDocs.URL)
-    assert.Equal(t, "somethingSpecial", h.Tags[0].Extensions["x-internal-ting"])
-    assert.Equal(t, int64(1), h.Tags[0].Extensions["x-internal-tong"])
-    assert.Equal(t, 1.2, h.Tags[0].Extensions["x-internal-tang"])
-    assert.True(t, h.Tags[0].Extensions["x-internal-tung"].(bool))
+	initTest()
+	h := NewDocument(lowDoc)
+	assert.Len(t, h.Tags, 2)
+	assert.Equal(t, "Burgers", h.Tags[0].Name)
+	assert.Equal(t, "All kinds of yummy burgers.", h.Tags[0].Description)
+	assert.Equal(t, "Find out more", h.Tags[0].ExternalDocs.Description)
+	assert.Equal(t, "https://pb33f.io", h.Tags[0].ExternalDocs.URL)
+	assert.Equal(t, "somethingSpecial", h.Tags[0].Extensions["x-internal-ting"])
+	assert.Equal(t, int64(1), h.Tags[0].Extensions["x-internal-tong"])
+	assert.Equal(t, 1.2, h.Tags[0].Extensions["x-internal-tang"])
+	assert.True(t, h.Tags[0].Extensions["x-internal-tung"].(bool))
 
-    wentLow := h.Tags[1].GoLow()
-    assert.Equal(t, 39, wentLow.Description.KeyNode.Line)
-    assert.Equal(t, 5, wentLow.Description.KeyNode.Column)
+	wentLow := h.Tags[1].GoLow()
+	assert.Equal(t, 39, wentLow.Description.KeyNode.Line)
+	assert.Equal(t, 5, wentLow.Description.KeyNode.Column)
 
-    wentLower := h.Tags[0].ExternalDocs.GoLow()
-    assert.Equal(t, 23, wentLower.Description.ValueNode.Line)
-    assert.Equal(t, 20, wentLower.Description.ValueNode.Column)
+	wentLower := h.Tags[0].ExternalDocs.GoLow()
+	assert.Equal(t, 23, wentLower.Description.ValueNode.Line)
+	assert.Equal(t, 20, wentLower.Description.ValueNode.Column)
 }
 
 func TestNewDocument_Webhooks(t *testing.T) {
-    initTest()
-    h := NewDocument(lowDoc)
-    assert.Len(t, h.Webhooks, 1)
-    assert.Equal(t, "Information about a new burger", h.Webhooks["someHook"].Post.RequestBody.Description)
+	initTest()
+	h := NewDocument(lowDoc)
+	assert.Len(t, h.Webhooks, 1)
+	assert.Equal(t, "Information about a new burger", h.Webhooks["someHook"].Post.RequestBody.Description)
 }
 
 func TestNewDocument_Components_Links(t *testing.T) {
-    initTest()
-    h := NewDocument(lowDoc)
-    assert.Len(t, h.Components.Links, 2)
-    assert.Equal(t, "locateBurger", h.Components.Links["LocateBurger"].OperationId)
-    assert.Equal(t, "$response.body#/id", h.Components.Links["LocateBurger"].Parameters["burgerId"])
+	initTest()
+	h := NewDocument(lowDoc)
+	assert.Len(t, h.Components.Links, 2)
+	assert.Equal(t, "locateBurger", h.Components.Links["LocateBurger"].OperationId)
+	assert.Equal(t, "$response.body#/id", h.Components.Links["LocateBurger"].Parameters["burgerId"])
 
-    wentLow := h.Components.Links["LocateBurger"].GoLow()
-    assert.Equal(t, 305, wentLow.OperationId.ValueNode.Line)
-    assert.Equal(t, 20, wentLow.OperationId.ValueNode.Column)
-
+	wentLow := h.Components.Links["LocateBurger"].GoLow()
+	assert.Equal(t, 305, wentLow.OperationId.ValueNode.Line)
+	assert.Equal(t, 20, wentLow.OperationId.ValueNode.Column)
 }
 
 func TestNewDocument_Components_Callbacks(t *testing.T) {
-    initTest()
-    h := NewDocument(lowDoc)
-    assert.Len(t, h.Components.Callbacks, 1)
-    assert.Equal(t, "Callback payload",
-        h.Components.Callbacks["BurgerCallback"].Expression["{$request.query.queryUrl}"].Post.RequestBody.Description)
+	initTest()
+	h := NewDocument(lowDoc)
+	assert.Len(t, h.Components.Callbacks, 1)
+	assert.Equal(
+		t,
+		"Callback payload",
+		h.Components.Callbacks["BurgerCallback"].Expression["{$request.query.queryUrl}"].Post.RequestBody.Description,
+	)
+	assert.Equal(
+		t,
+		293,
+		h.Components.Callbacks["BurgerCallback"].GoLow().FindExpression("{$request.query.queryUrl}").ValueNode.Line,
+	)
+	assert.Equal(
+		t,
+		9,
+		h.Components.Callbacks["BurgerCallback"].GoLow().FindExpression("{$request.query.queryUrl}").ValueNode.Column,
+	)
 
-    assert.Equal(t, 293,
-        h.Components.Callbacks["BurgerCallback"].GoLow().FindExpression("{$request.query.queryUrl}").ValueNode.Line)
-    assert.Equal(t, 9,
-        h.Components.Callbacks["BurgerCallback"].GoLow().FindExpression("{$request.query.queryUrl}").ValueNode.Column)
+	assert.Equal(t, "please", h.Components.Callbacks["BurgerCallback"].Extensions["x-break-everything"])
 
-    assert.Equal(t, "please", h.Components.Callbacks["BurgerCallback"].Extensions["x-break-everything"])
-
-    for k := range h.Components.GoLow().Callbacks.Value {
-        if k.Value == "BurgerCallback" {
-            assert.Equal(t, 290, k.KeyNode.Line)
-            assert.Equal(t, 5, k.KeyNode.Column)
-        }
-    }
+	for k := range h.Components.GoLow().Callbacks.Value {
+		if k.Value == "BurgerCallback" {
+			assert.Equal(t, 290, k.KeyNode.Line)
+			assert.Equal(t, 5, k.KeyNode.Column)
+		}
+	}
 }
 
 func TestNewDocument_Components_Schemas(t *testing.T) {
-    initTest()
-    h := NewDocument(lowDoc)
-    assert.Len(t, h.Components.Schemas, 6)
+	initTest()
+	h := NewDocument(lowDoc)
+	assert.Len(t, h.Components.Schemas, 6)
 
-    goLow := h.Components.GoLow()
+	goLow := h.Components.GoLow()
 
-    a := h.Components.Schemas["Error"]
-    abcd := a.Schema().Properties["message"].Schema().Example
-    assert.Equal(t, "No such burger as 'Big-Whopper'", abcd)
-    assert.Equal(t, 428, goLow.Schemas.KeyNode.Line)
-    assert.Equal(t, 3, goLow.Schemas.KeyNode.Column)
-    assert.Equal(t, 431, a.Schema().GoLow().Description.KeyNode.Line)
+	a := h.Components.Schemas["Error"]
+	abcd := a.Schema().Properties["message"].Schema().Example
+	assert.Equal(t, "No such burger as 'Big-Whopper'", abcd)
+	assert.Equal(t, 428, goLow.Schemas.KeyNode.Line)
+	assert.Equal(t, 3, goLow.Schemas.KeyNode.Column)
+	assert.Equal(t, 431, a.Schema().GoLow().Description.KeyNode.Line)
 
-    b := h.Components.Schemas["Burger"]
-    assert.Len(t, b.Schema().Required, 2)
-    assert.Equal(t, "golden slices of happy fun joy", b.Schema().Properties["fries"].Schema().Description)
-    assert.Equal(t, int64(2), b.Schema().Properties["numPatties"].Schema().Example)
-    assert.Equal(t, 443, goLow.FindSchema("Burger").Value.Schema().Properties.KeyNode.Line)
-    assert.Equal(t, 7, goLow.FindSchema("Burger").Value.Schema().Properties.KeyNode.Column)
-    assert.Equal(t, 445, b.Schema().GoLow().FindProperty("name").ValueNode.Line)
+	b := h.Components.Schemas["Burger"]
+	assert.Len(t, b.Schema().Required, 2)
+	assert.Equal(t, "golden slices of happy fun joy", b.Schema().Properties["fries"].Schema().Description)
+	assert.Equal(t, int64(2), b.Schema().Properties["numPatties"].Schema().Example)
+	assert.Equal(t, 443, goLow.FindSchema("Burger").Value.Schema().Properties.KeyNode.Line)
+	assert.Equal(t, 7, goLow.FindSchema("Burger").Value.Schema().Properties.KeyNode.Column)
+	assert.Equal(t, 445, b.Schema().GoLow().FindProperty("name").ValueNode.Line)
 
-    f := h.Components.Schemas["Fries"]
-    assert.Equal(t, "salt", f.Schema().Properties["seasoning"].Schema().Items.A.Schema().Example)
-    assert.Len(t, f.Schema().Properties["favoriteDrink"].Schema().Properties["drinkType"].Schema().Enum, 2)
+	f := h.Components.Schemas["Fries"]
+	assert.Equal(t, "salt", f.Schema().Properties["seasoning"].Schema().Items.A.Schema().Example)
+	assert.Len(t, f.Schema().Properties["favoriteDrink"].Schema().Properties["drinkType"].Schema().Enum, 2)
 
-    d := h.Components.Schemas["Drink"]
-    assert.Len(t, d.Schema().Required, 2)
-    assert.True(t, d.Schema().AdditionalProperties.(bool))
-    assert.Equal(t, "drinkType", d.Schema().Discriminator.PropertyName)
-    assert.Equal(t, "some value", d.Schema().Discriminator.Mapping["drink"])
-    assert.Equal(t, 511, d.Schema().Discriminator.GoLow().PropertyName.ValueNode.Line)
-    assert.Equal(t, 23, d.Schema().Discriminator.GoLow().PropertyName.ValueNode.Column)
+	d := h.Components.Schemas["Drink"]
+	assert.Len(t, d.Schema().Required, 2)
+	assert.True(t, d.Schema().AdditionalProperties.(bool))
+	assert.Equal(t, "drinkType", d.Schema().Discriminator.PropertyName)
+	assert.Equal(t, "some value", d.Schema().Discriminator.Mapping["drink"])
+	assert.Equal(t, 511, d.Schema().Discriminator.GoLow().PropertyName.ValueNode.Line)
+	assert.Equal(t, 23, d.Schema().Discriminator.GoLow().PropertyName.ValueNode.Column)
 
-    pl := h.Components.Schemas["SomePayload"]
-    assert.Equal(t, "is html programming? yes.", pl.Schema().XML.Name)
-    assert.Equal(t, 518, pl.Schema().XML.GoLow().Name.ValueNode.Line)
+	pl := h.Components.Schemas["SomePayload"]
+	assert.Equal(t, "is html programming? yes.", pl.Schema().XML.Name)
+	assert.Equal(t, 518, pl.Schema().XML.GoLow().Name.ValueNode.Line)
 
-    ext := h.Components.Extensions
-    assert.Equal(t, "loud", ext["x-screaming-baby"])
+	ext := h.Components.Extensions
+	assert.Equal(t, "loud", ext["x-screaming-baby"])
 }
 
 func TestNewDocument_Components_Headers(t *testing.T) {
-    initTest()
-    h := NewDocument(lowDoc)
-    assert.Len(t, h.Components.Headers, 1)
-    assert.Equal(t, "this is a header example for UseOil", h.Components.Headers["UseOil"].Description)
-    assert.Equal(t, 318, h.Components.Headers["UseOil"].GoLow().Description.ValueNode.Line)
-    assert.Equal(t, 20, h.Components.Headers["UseOil"].GoLow().Description.ValueNode.Column)
+	initTest()
+	h := NewDocument(lowDoc)
+	assert.Len(t, h.Components.Headers, 1)
+	assert.Equal(t, "this is a header example for UseOil", h.Components.Headers["UseOil"].Description)
+	assert.Equal(t, 318, h.Components.Headers["UseOil"].GoLow().Description.ValueNode.Line)
+	assert.Equal(t, 20, h.Components.Headers["UseOil"].GoLow().Description.ValueNode.Column)
 }
 
 func TestNewDocument_Components_RequestBodies(t *testing.T) {
-    initTest()
-    h := NewDocument(lowDoc)
-    assert.Len(t, h.Components.RequestBodies, 1)
-    assert.Equal(t, "Give us the new burger!", h.Components.RequestBodies["BurgerRequest"].Description)
-    assert.Equal(t, 323, h.Components.RequestBodies["BurgerRequest"].GoLow().Description.ValueNode.Line)
-    assert.Equal(t, 20, h.Components.RequestBodies["BurgerRequest"].GoLow().Description.ValueNode.Column)
-    assert.Len(t, h.Components.RequestBodies["BurgerRequest"].Content["application/json"].Examples, 2)
+	initTest()
+	h := NewDocument(lowDoc)
+	assert.Len(t, h.Components.RequestBodies, 1)
+	assert.Equal(t, "Give us the new burger!", h.Components.RequestBodies["BurgerRequest"].Description)
+	assert.Equal(t, 323, h.Components.RequestBodies["BurgerRequest"].GoLow().Description.ValueNode.Line)
+	assert.Equal(t, 20, h.Components.RequestBodies["BurgerRequest"].GoLow().Description.ValueNode.Column)
+	assert.Len(t, h.Components.RequestBodies["BurgerRequest"].Content["application/json"].Examples, 2)
 }
 
 func TestNewDocument_Components_Examples(t *testing.T) {
-    initTest()
-    h := NewDocument(lowDoc)
-    assert.Len(t, h.Components.Examples, 1)
-    assert.Equal(t, "A juicy two hander sammich", h.Components.Examples["QuarterPounder"].Summary)
-    assert.Equal(t, 341, h.Components.Examples["QuarterPounder"].GoLow().Summary.ValueNode.Line)
-    assert.Equal(t, 16, h.Components.Examples["QuarterPounder"].GoLow().Summary.ValueNode.Column)
-
+	initTest()
+	h := NewDocument(lowDoc)
+	assert.Len(t, h.Components.Examples, 1)
+	assert.Equal(t, "A juicy two hander sammich", h.Components.Examples["QuarterPounder"].Summary)
+	assert.Equal(t, 341, h.Components.Examples["QuarterPounder"].GoLow().Summary.ValueNode.Line)
+	assert.Equal(t, 16, h.Components.Examples["QuarterPounder"].GoLow().Summary.ValueNode.Column)
 }
 
 func TestNewDocument_Components_Responses(t *testing.T) {
-    initTest()
-    h := NewDocument(lowDoc)
-    assert.Len(t, h.Components.Responses, 1)
-    assert.Equal(t, "all the dressings for a burger.", h.Components.Responses["DressingResponse"].Description)
-    assert.Equal(t, "array", h.Components.Responses["DressingResponse"].Content["application/json"].Schema.Schema().Type[0])
-    assert.Equal(t, 347, h.Components.Responses["DressingResponse"].GoLow().Description.KeyNode.Line)
-    assert.Equal(t, 7, h.Components.Responses["DressingResponse"].GoLow().Description.KeyNode.Column)
+	initTest()
+	h := NewDocument(lowDoc)
+	assert.Len(t, h.Components.Responses, 1)
+	assert.Equal(t, "all the dressings for a burger.", h.Components.Responses["DressingResponse"].Description)
+	assert.Equal(t, "array", h.Components.Responses["DressingResponse"].Content["application/json"].Schema.Schema().Type[0])
+	assert.Equal(t, 347, h.Components.Responses["DressingResponse"].GoLow().Description.KeyNode.Line)
+	assert.Equal(t, 7, h.Components.Responses["DressingResponse"].GoLow().Description.KeyNode.Column)
 }
 
 func TestNewDocument_Components_SecuritySchemes(t *testing.T) {
-    initTest()
-    h := NewDocument(lowDoc)
-    assert.Len(t, h.Components.SecuritySchemes, 3)
+	initTest()
+	h := NewDocument(lowDoc)
+	assert.Len(t, h.Components.SecuritySchemes, 3)
 
-    api := h.Components.SecuritySchemes["APIKeyScheme"]
-    assert.Equal(t, "an apiKey security scheme", api.Description)
-    assert.Equal(t, 359, api.GoLow().Description.ValueNode.Line)
-    assert.Equal(t, 20, api.GoLow().Description.ValueNode.Column)
+	api := h.Components.SecuritySchemes["APIKeyScheme"]
+	assert.Equal(t, "an apiKey security scheme", api.Description)
+	assert.Equal(t, 359, api.GoLow().Description.ValueNode.Line)
+	assert.Equal(t, 20, api.GoLow().Description.ValueNode.Column)
 
-    jwt := h.Components.SecuritySchemes["JWTScheme"]
-    assert.Equal(t, "an JWT security scheme", jwt.Description)
-    assert.Equal(t, 364, jwt.GoLow().Description.ValueNode.Line)
-    assert.Equal(t, 20, jwt.GoLow().Description.ValueNode.Column)
+	jwt := h.Components.SecuritySchemes["JWTScheme"]
+	assert.Equal(t, "an JWT security scheme", jwt.Description)
+	assert.Equal(t, 364, jwt.GoLow().Description.ValueNode.Line)
+	assert.Equal(t, 20, jwt.GoLow().Description.ValueNode.Column)
 
-    oAuth := h.Components.SecuritySchemes["OAuthScheme"]
-    assert.Equal(t, "an oAuth security scheme", oAuth.Description)
-    assert.Equal(t, 370, oAuth.GoLow().Description.ValueNode.Line)
-    assert.Equal(t, 20, oAuth.GoLow().Description.ValueNode.Column)
-    assert.Len(t, oAuth.Flows.Implicit.Scopes, 2)
-    assert.Equal(t, "read all burgers", oAuth.Flows.Implicit.Scopes["read:burgers"])
-    assert.Equal(t, "https://pb33f.io/oauth", oAuth.Flows.AuthorizationCode.AuthorizationUrl)
+	oAuth := h.Components.SecuritySchemes["OAuthScheme"]
+	assert.Equal(t, "an oAuth security scheme", oAuth.Description)
+	assert.Equal(t, 370, oAuth.GoLow().Description.ValueNode.Line)
+	assert.Equal(t, 20, oAuth.GoLow().Description.ValueNode.Column)
+	assert.Len(t, oAuth.Flows.Implicit.Scopes, 2)
+	assert.Equal(t, "read all burgers", oAuth.Flows.Implicit.Scopes["read:burgers"])
+	assert.Equal(t, "https://pb33f.io/oauth", oAuth.Flows.AuthorizationCode.AuthorizationUrl)
 
-    // check the lowness is low.
-    assert.Equal(t, 375, oAuth.Flows.GoLow().Implicit.Value.Scopes.KeyNode.Line)
-    assert.Equal(t, 11, oAuth.Flows.GoLow().Implicit.Value.Scopes.KeyNode.Column)
-    assert.Equal(t, 375, oAuth.Flows.Implicit.GoLow().Scopes.KeyNode.Line)
-    assert.Equal(t, 11, oAuth.Flows.Implicit.GoLow().Scopes.KeyNode.Column)
-
+	// check the lowness is low.
+	assert.Equal(t, 375, oAuth.Flows.GoLow().Implicit.Value.Scopes.KeyNode.Line)
+	assert.Equal(t, 11, oAuth.Flows.GoLow().Implicit.Value.Scopes.KeyNode.Column)
+	assert.Equal(t, 375, oAuth.Flows.Implicit.GoLow().Scopes.KeyNode.Line)
+	assert.Equal(t, 11, oAuth.Flows.Implicit.GoLow().Scopes.KeyNode.Column)
 }
 
 func TestNewDocument_Components_Parameters(t *testing.T) {
-    initTest()
-    h := NewDocument(lowDoc)
-    assert.Len(t, h.Components.Parameters, 2)
-    bh := h.Components.Parameters["BurgerHeader"]
-    assert.Equal(t, "burgerHeader", bh.Name)
-    assert.Equal(t, 387, bh.GoLow().Name.KeyNode.Line)
-    assert.Len(t, bh.Schema.Schema().Properties, 2)
-    assert.Equal(t, "big-mac", bh.Example)
-    assert.True(t, bh.Required)
-    assert.Equal(t, "this is a header",
-        bh.Content["application/json"].Encoding["burgerTheme"].Headers["someHeader"].Description)
-    assert.Len(t, bh.Content["application/json"].Schema.Schema().Properties, 2)
-    assert.Equal(t, 404, bh.Content["application/json"].Encoding["burgerTheme"].GoLow().ContentType.ValueNode.Line)
-
+	initTest()
+	h := NewDocument(lowDoc)
+	assert.Len(t, h.Components.Parameters, 2)
+	bh := h.Components.Parameters["BurgerHeader"]
+	assert.Equal(t, "burgerHeader", bh.Name)
+	assert.Equal(t, 387, bh.GoLow().Name.KeyNode.Line)
+	assert.Len(t, bh.Schema.Schema().Properties, 2)
+	assert.Equal(t, "big-mac", bh.Example)
+	assert.True(t, bh.Required)
+	assert.Equal(
+		t,
+		"this is a header",
+		bh.Content["application/json"].Encoding["burgerTheme"].Headers["someHeader"].Description,
+	)
+	assert.Len(t, bh.Content["application/json"].Schema.Schema().Properties, 2)
+	assert.Equal(t, 404, bh.Content["application/json"].Encoding["burgerTheme"].GoLow().ContentType.ValueNode.Line)
 }
 
 func TestNewDocument_Paths(t *testing.T) {
-    initTest()
-    h := NewDocument(lowDoc)
-    assert.Len(t, h.Paths.PathItems, 5)
+	initTest()
+	h := NewDocument(lowDoc)
+	assert.Len(t, h.Paths.PathItems, 5)
 
-    burgersOp := h.Paths.PathItems["/burgers"]
+	burgersOp := h.Paths.PathItems["/burgers"]
 
-    assert.Len(t, burgersOp.GetOperations(), 1)
-    assert.Equal(t, "meaty", burgersOp.Extensions["x-burger-meta"])
-    assert.Nil(t, burgersOp.Get)
-    assert.Nil(t, burgersOp.Put)
-    assert.Nil(t, burgersOp.Patch)
-    assert.Nil(t, burgersOp.Head)
-    assert.Nil(t, burgersOp.Options)
-    assert.Nil(t, burgersOp.Trace)
-    assert.Equal(t, 64, burgersOp.GoLow().Post.KeyNode.Line)
-    assert.Equal(t, "createBurger", burgersOp.Post.OperationId)
-    assert.Len(t, burgersOp.Post.Tags, 1)
-    assert.Equal(t, "A new burger for our menu, yummy yum yum.", burgersOp.Post.Description)
-    assert.Equal(t, "Give us the new burger!", burgersOp.Post.RequestBody.Description)
-    assert.Len(t, burgersOp.Post.Responses.Codes, 3)
-    assert.Equal(t, 63, h.Paths.GoLow().FindPath("/burgers").ValueNode.Line)
+	assert.Len(t, burgersOp.GetOperations(), 1)
+	assert.Equal(t, "meaty", burgersOp.Extensions["x-burger-meta"])
+	assert.Nil(t, burgersOp.Get)
+	assert.Nil(t, burgersOp.Put)
+	assert.Nil(t, burgersOp.Patch)
+	assert.Nil(t, burgersOp.Head)
+	assert.Nil(t, burgersOp.Options)
+	assert.Nil(t, burgersOp.Trace)
+	assert.Equal(t, 64, burgersOp.GoLow().Post.KeyNode.Line)
+	assert.Equal(t, "createBurger", burgersOp.Post.OperationId)
+	assert.Len(t, burgersOp.Post.Tags, 1)
+	assert.Equal(t, "A new burger for our menu, yummy yum yum.", burgersOp.Post.Description)
+	assert.Equal(t, "Give us the new burger!", burgersOp.Post.RequestBody.Description)
+	assert.Len(t, burgersOp.Post.Responses.Codes, 3)
+	assert.Equal(t, 63, h.Paths.GoLow().FindPath("/burgers").ValueNode.Line)
 
-    okResp := burgersOp.Post.Responses.FindResponseByCode(200)
-    assert.Len(t, okResp.Headers, 1)
-    assert.Equal(t, "A tasty burger for you to eat.", okResp.Description)
-    assert.Equal(t, 69, burgersOp.Post.GoLow().Description.ValueNode.Line)
-    assert.Len(t, okResp.Content["application/json"].Examples, 2)
-    assert.Equal(t, "a cripsy fish sammich filled with ocean goodness.",
-        okResp.Content["application/json"].Examples["filetOFish"].Summary)
-    assert.Equal(t, 74, burgersOp.Post.Responses.GoLow().FindResponseByCode("200").ValueNode.Line)
+	okResp := burgersOp.Post.Responses.FindResponseByCode(200)
+	assert.Len(t, okResp.Headers, 1)
+	assert.Equal(t, "A tasty burger for you to eat.", okResp.Description)
+	assert.Equal(t, 69, burgersOp.Post.GoLow().Description.ValueNode.Line)
+	assert.Len(t, okResp.Content["application/json"].Examples, 2)
+	assert.Equal(
+		t,
+		"a cripsy fish sammich filled with ocean goodness.",
+		okResp.Content["application/json"].Examples["filetOFish"].Summary,
+	)
+	assert.Equal(t, 74, burgersOp.Post.Responses.GoLow().FindResponseByCode("200").ValueNode.Line)
 
-    assert.Equal(t, 80, okResp.Content["application/json"].GoLow().Schema.KeyNode.Line)
-    assert.Equal(t, 15, okResp.Content["application/json"].GoLow().Schema.KeyNode.Column)
+	assert.Equal(t, 80, okResp.Content["application/json"].GoLow().Schema.KeyNode.Line)
+	assert.Equal(t, 15, okResp.Content["application/json"].GoLow().Schema.KeyNode.Column)
 
-    assert.Equal(t, 77, okResp.GoLow().Description.KeyNode.Line)
-    assert.Len(t, okResp.Links, 2)
-    assert.Equal(t, "locateBurger", okResp.Links["LocateBurger"].OperationId)
-    assert.Equal(t, 305, okResp.Links["LocateBurger"].GoLow().OperationId.ValueNode.Line)
-    assert.Len(t, burgersOp.Post.Security[0].Requirements, 1)
-    assert.Len(t, burgersOp.Post.Security[0].Requirements["OAuthScheme"], 2)
-    assert.Equal(t, "read:burgers", burgersOp.Post.Security[0].Requirements["OAuthScheme"][0])
-    assert.Equal(t, 118, burgersOp.Post.Security[0].GoLow().Requirements.ValueNode.Line)
-    assert.Len(t, burgersOp.Post.Servers, 1)
-    assert.Equal(t, "https://pb33f.io", burgersOp.Post.Servers[0].URL)
-
+	assert.Equal(t, 77, okResp.GoLow().Description.KeyNode.Line)
+	assert.Len(t, okResp.Links, 2)
+	assert.Equal(t, "locateBurger", okResp.Links["LocateBurger"].OperationId)
+	assert.Equal(t, 305, okResp.Links["LocateBurger"].GoLow().OperationId.ValueNode.Line)
+	assert.Len(t, burgersOp.Post.Security[0].Requirements, 1)
+	assert.Len(t, burgersOp.Post.Security[0].Requirements["OAuthScheme"], 2)
+	assert.Equal(t, "read:burgers", burgersOp.Post.Security[0].Requirements["OAuthScheme"][0])
+	assert.Equal(t, 118, burgersOp.Post.Security[0].GoLow().Requirements.ValueNode.Line)
+	assert.Len(t, burgersOp.Post.Servers, 1)
+	assert.Equal(t, "https://pb33f.io", burgersOp.Post.Servers[0].URL)
 }
 
 func TestStripeAsDoc(t *testing.T) {
-    data, _ := ioutil.ReadFile("../../../test_specs/stripe.yaml")
-    info, _ := datamodel.ExtractSpecInfo(data)
-    var err []error
-    lowDoc, err = lowv3.CreateDocument(info)
-    assert.Len(t, err, 23)
-    d := NewDocument(lowDoc)
-    assert.NotNil(t, d)
+	data, _ := ioutil.ReadFile("../../../test_specs/stripe.yaml")
+	info, _ := datamodel.ExtractSpecInfo(data)
+	var err []error
+	lowDoc, err = lowv3.CreateDocument(info)
+	assert.Len(t, err, 3)
+	d := NewDocument(lowDoc)
+	assert.NotNil(t, d)
 }
 
 func TestK8sAsDoc(t *testing.T) {
-    data, _ := ioutil.ReadFile("../../../test_specs/k8s.json")
-    info, _ := datamodel.ExtractSpecInfo(data)
-    var err []error
-    lowSwag, err := lowv2.CreateDocument(info)
-    d := v2.NewSwaggerDocument(lowSwag)
-    assert.Len(t, err, 1)
-    assert.NotNil(t, d)
-
+	data, _ := ioutil.ReadFile("../../../test_specs/k8s.json")
+	info, _ := datamodel.ExtractSpecInfo(data)
+	var err []error
+	lowSwag, err := lowv2.CreateDocument(info)
+	d := v2.NewSwaggerDocument(lowSwag)
+	assert.Len(t, err, 0)
+	assert.NotNil(t, d)
 }
 
 func TestAsanaAsDoc(t *testing.T) {
-    data, _ := ioutil.ReadFile("../../../test_specs/asana.yaml")
-    info, _ := datamodel.ExtractSpecInfo(data)
-    var err []error
-    lowDoc, err = lowv3.CreateDocument(info)
-    if err != nil {
-        panic("broken something")
-    }
-    d := NewDocument(lowDoc)
-    fmt.Println(d)
+	data, _ := ioutil.ReadFile("../../../test_specs/asana.yaml")
+	info, _ := datamodel.ExtractSpecInfo(data)
+	var err []error
+	lowDoc, err = lowv3.CreateDocument(info)
+	if err != nil {
+		panic("broken something")
+	}
+	d := NewDocument(lowDoc)
+	fmt.Println(d)
 }
 
 func TestPetstoreAsDoc(t *testing.T) {
-    data, _ := ioutil.ReadFile("../../../test_specs/petstorev3.json")
-    info, _ := datamodel.ExtractSpecInfo(data)
-    var err []error
-    lowDoc, err = lowv3.CreateDocument(info)
-    if err != nil {
-        panic("broken something")
-    }
-    d := NewDocument(lowDoc)
-    fmt.Println(d)
+	data, _ := ioutil.ReadFile("../../../test_specs/petstorev3.json")
+	info, _ := datamodel.ExtractSpecInfo(data)
+	var err []error
+	lowDoc, err = lowv3.CreateDocument(info)
+	if err != nil {
+		panic("broken something")
+	}
+	d := NewDocument(lowDoc)
+	fmt.Println(d)
 }
 
 func TestCircularReferencesDoc(t *testing.T) {
-    data, _ := ioutil.ReadFile("../../../test_specs/circular-tests.yaml")
-    info, _ := datamodel.ExtractSpecInfo(data)
-    var err []error
-    lowDoc, err = lowv3.CreateDocument(info)
-    assert.Len(t, err, 3)
-    d := NewDocument(lowDoc)
-    assert.Len(t, d.Components.Schemas, 9)
-    assert.Len(t, d.Index.GetCircularReferences(), 3)
+	data, _ := ioutil.ReadFile("../../../test_specs/circular-tests.yaml")
+	info, _ := datamodel.ExtractSpecInfo(data)
+	var err []error
+	lowDoc, err = lowv3.CreateDocument(info)
+	assert.Len(t, err, 3)
+	d := NewDocument(lowDoc)
+	assert.Len(t, d.Components.Schemas, 9)
+	assert.Len(t, d.Index.GetCircularReferences(), 3)
 }

--- a/datamodel/low/base/schema_test.go
+++ b/datamodel/low/base/schema_test.go
@@ -1,12 +1,13 @@
 package base
 
 import (
+	"testing"
+
 	"github.com/pb33f/libopenapi/datamodel/low"
 	"github.com/pb33f/libopenapi/index"
 	"github.com/pb33f/libopenapi/resolver"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"
-	"testing"
 )
 
 func test_get_schema_blob() string {
@@ -1151,10 +1152,15 @@ func TestExtractSchema_CheckChildPropCircular(t *testing.T) {
       properties:
         nothing:
           $ref: '#/components/schemas/Nothing'
+      required:
+        - nothing
     Nothing:
       properties:
         something: 
-          $ref: '#/components/schemas/Something'`
+          $ref: '#/components/schemas/Something'
+      required:
+        - something
+`
 
 	var iNode yaml.Node
 	mErr := yaml.Unmarshal([]byte(yml), &iNode)

--- a/datamodel/low/extraction_functions_test.go
+++ b/datamodel/low/extraction_functions_test.go
@@ -6,13 +6,14 @@ package low
 import (
 	"crypto/sha256"
 	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+
 	"github.com/pb33f/libopenapi/index"
 	"github.com/pb33f/libopenapi/resolver"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"
-	"io/ioutil"
-	"os"
-	"testing"
 )
 
 func TestFindItemInMap(t *testing.T) {
@@ -218,7 +219,6 @@ func TestExtractObject_DoubleRef(t *testing.T) {
 }
 
 func TestExtractObject_DoubleRef_Circular(t *testing.T) {
-
 	yml := `components:
   schemas:
     loopy:
@@ -249,7 +249,6 @@ func TestExtractObject_DoubleRef_Circular(t *testing.T) {
 }
 
 func TestExtractObject_DoubleRef_Circular_Fail(t *testing.T) {
-
 	yml := `components:
   schemas:
     loopy:

--- a/datamodel/low/reference_test.go
+++ b/datamodel/low/reference_test.go
@@ -5,11 +5,12 @@ package low
 
 import (
 	"crypto/sha256"
+	"testing"
+
 	"github.com/pb33f/libopenapi/index"
 	"github.com/pb33f/libopenapi/resolver"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"
-	"testing"
 )
 
 func TestNodeReference_IsEmpty(t *testing.T) {
@@ -103,10 +104,15 @@ func TestIsCircular_LookupFromJourney(t *testing.T) {
       properties:
         nothing:
           $ref: '#/components/schemas/Nothing'
+      required:
+        - nothing
     Nothing:
       properties:
         something: 
-          $ref: '#/components/schemas/Something'`
+          $ref: '#/components/schemas/Something'
+      required:
+        - something
+`
 
 	var iNode yaml.Node
 	mErr := yaml.Unmarshal([]byte(yml), &iNode)
@@ -135,10 +141,15 @@ func TestIsCircular_LookupFromLoopPoint(t *testing.T) {
       properties:
         nothing:
           $ref: '#/components/schemas/Nothing'
+      required:
+        - nothing
     Nothing:
       properties:
         something: 
-          $ref: '#/components/schemas/Something'`
+          $ref: '#/components/schemas/Something'
+      required:
+        - something
+`
 
 	var iNode yaml.Node
 	mErr := yaml.Unmarshal([]byte(yml), &iNode)
@@ -169,10 +180,15 @@ func TestIsCircular_FromRefLookup(t *testing.T) {
       properties:
         nothing:
           $ref: '#/components/schemas/Nothing'
+      required:
+        - nothing
     Nothing:
       properties:
         something: 
-          $ref: '#/components/schemas/Something'`
+          $ref: '#/components/schemas/Something'
+      required:
+        - something
+`
 
 	var iNode yaml.Node
 	mErr := yaml.Unmarshal([]byte(yml), &iNode)
@@ -211,10 +227,15 @@ func TestGetCircularReferenceResult_FromJourney(t *testing.T) {
       properties:
         nothing:
           $ref: '#/components/schemas/Nothing'
+      required:
+        - nothing
     Nothing:
       properties:
         something: 
-          $ref: '#/components/schemas/Something'`
+          $ref: '#/components/schemas/Something'
+      required:
+        - something
+`
 
 	var iNode yaml.Node
 	mErr := yaml.Unmarshal([]byte(yml), &iNode)
@@ -246,10 +267,15 @@ func TestGetCircularReferenceResult_FromLoopPoint(t *testing.T) {
       properties:
         nothing:
           $ref: '#/components/schemas/Nothing'
+      required:
+        - nothing
     Nothing:
       properties:
         something: 
-          $ref: '#/components/schemas/Something'`
+          $ref: '#/components/schemas/Something'
+      required:
+        - something
+`
 
 	var iNode yaml.Node
 	mErr := yaml.Unmarshal([]byte(yml), &iNode)
@@ -281,10 +307,15 @@ func TestGetCircularReferenceResult_FromMappedRef(t *testing.T) {
       properties:
         nothing:
           $ref: '#/components/schemas/Nothing'
+      required:
+        - nothing
     Nothing:
       properties:
         something: 
-          $ref: '#/components/schemas/Something'`
+          $ref: '#/components/schemas/Something'
+      required:
+        - something
+`
 
 	var iNode yaml.Node
 	mErr := yaml.Unmarshal([]byte(yml), &iNode)

--- a/datamodel/low/v3/create_document_test.go
+++ b/datamodel/low/v3/create_document_test.go
@@ -1,518 +1,519 @@
 package v3
 
 import (
-    "fmt"
-    "github.com/pb33f/libopenapi/datamodel"
-    "github.com/pb33f/libopenapi/datamodel/low/base"
-    "github.com/stretchr/testify/assert"
-    "io/ioutil"
-    "testing"
+	"fmt"
+	"io/ioutil"
+	"testing"
+
+	"github.com/pb33f/libopenapi/datamodel"
+	"github.com/pb33f/libopenapi/datamodel/low/base"
+	"github.com/stretchr/testify/assert"
 )
 
 var doc *Document
 
 func initTest() {
-    if doc != nil {
-        return
-    }
-    data, _ := ioutil.ReadFile("../../../test_specs/burgershop.openapi.yaml")
-    info, _ := datamodel.ExtractSpecInfo(data)
-    var err []error
-    doc, err = CreateDocument(info)
-    if err != nil {
-        panic("broken something")
-    }
+	if doc != nil {
+		return
+	}
+	data, _ := ioutil.ReadFile("../../../test_specs/burgershop.openapi.yaml")
+	info, _ := datamodel.ExtractSpecInfo(data)
+	var err []error
+	doc, err = CreateDocument(info)
+	if err != nil {
+		panic("broken something")
+	}
 }
 
 func BenchmarkCreateDocument(b *testing.B) {
-    data, _ := ioutil.ReadFile("../../../test_specs/burgershop.openapi.yaml")
-    info, _ := datamodel.ExtractSpecInfo(data)
-    for i := 0; i < b.N; i++ {
-        doc, _ = CreateDocument(info)
-    }
+	data, _ := ioutil.ReadFile("../../../test_specs/burgershop.openapi.yaml")
+	info, _ := datamodel.ExtractSpecInfo(data)
+	for i := 0; i < b.N; i++ {
+		doc, _ = CreateDocument(info)
+	}
 }
 
 func BenchmarkCreateDocument_Circular(b *testing.B) {
-    data, _ := ioutil.ReadFile("../../../test_specs/circular-tests.yaml")
-    info, _ := datamodel.ExtractSpecInfo(data)
-    for i := 0; i < b.N; i++ {
-        _, err := CreateDocument(info)
-        if err != nil {
-            panic("this should not error")
-        }
-    }
+	data, _ := ioutil.ReadFile("../../../test_specs/circular-tests.yaml")
+	info, _ := datamodel.ExtractSpecInfo(data)
+	for i := 0; i < b.N; i++ {
+		_, err := CreateDocument(info)
+		if err != nil {
+			panic("this should not error")
+		}
+	}
 }
 
 func BenchmarkCreateDocument_k8s(b *testing.B) {
 
-    data, _ := ioutil.ReadFile("../../../test_specs/k8s.json")
-    info, _ := datamodel.ExtractSpecInfo(data)
+	data, _ := ioutil.ReadFile("../../../test_specs/k8s.json")
+	info, _ := datamodel.ExtractSpecInfo(data)
 
-    for i := 0; i < b.N; i++ {
+	for i := 0; i < b.N; i++ {
 
-        _, err := CreateDocument(info)
-        if err != nil {
-            panic("this should not error")
-        }
-    }
+		_, err := CreateDocument(info)
+		if err != nil {
+			panic("this should not error")
+		}
+	}
 }
 
 func TestCircularReferenceError(t *testing.T) {
 
-    data, _ := ioutil.ReadFile("../../../test_specs/circular-tests.yaml")
-    info, _ := datamodel.ExtractSpecInfo(data)
-    circDoc, err := CreateDocument(info)
-    assert.NotNil(t, circDoc)
-    assert.Len(t, err, 3)
+	data, _ := ioutil.ReadFile("../../../test_specs/circular-tests.yaml")
+	info, _ := datamodel.ExtractSpecInfo(data)
+	circDoc, err := CreateDocument(info)
+	assert.NotNil(t, circDoc)
+	assert.Len(t, err, 3)
 }
 
 func BenchmarkCreateDocument_Stripe(b *testing.B) {
-    data, _ := ioutil.ReadFile("../../../test_specs/stripe.yaml")
-    info, _ := datamodel.ExtractSpecInfo(data)
+	data, _ := ioutil.ReadFile("../../../test_specs/stripe.yaml")
+	info, _ := datamodel.ExtractSpecInfo(data)
 
-    for i := 0; i < b.N; i++ {
-        _, err := CreateDocument(info)
-        if err != nil {
-            panic("this should not error")
-        }
-    }
+	for i := 0; i < b.N; i++ {
+		_, err := CreateDocument(info)
+		if err != nil {
+			panic("this should not error")
+		}
+	}
 }
 
 func BenchmarkCreateDocument_Petstore(b *testing.B) {
-    data, _ := ioutil.ReadFile("../../../test_specs/petstorev3.json")
-    info, _ := datamodel.ExtractSpecInfo(data)
-    for i := 0; i < b.N; i++ {
-        _, err := CreateDocument(info)
-        if err != nil {
-            panic("this should not error")
-        }
-    }
+	data, _ := ioutil.ReadFile("../../../test_specs/petstorev3.json")
+	info, _ := datamodel.ExtractSpecInfo(data)
+	for i := 0; i < b.N; i++ {
+		_, err := CreateDocument(info)
+		if err != nil {
+			panic("this should not error")
+		}
+	}
 }
 
 func TestCreateDocumentStripe(t *testing.T) {
 
-    data, _ := ioutil.ReadFile("../../../test_specs/stripe.yaml")
-    info, _ := datamodel.ExtractSpecInfo(data)
-    d, err := CreateDocument(info)
-    assert.Len(t, err, 23)
+	data, _ := ioutil.ReadFile("../../../test_specs/stripe.yaml")
+	info, _ := datamodel.ExtractSpecInfo(data)
+	d, err := CreateDocument(info)
+	assert.Len(t, err, 3)
 
-    assert.Equal(t, "3.0.0", d.Version.Value)
-    assert.Equal(t, "Stripe API", d.Info.Value.Title.Value)
-    assert.NotEmpty(t, d.Info.Value.Title.Value)
+	assert.Equal(t, "3.0.0", d.Version.Value)
+	assert.Equal(t, "Stripe API", d.Info.Value.Title.Value)
+	assert.NotEmpty(t, d.Info.Value.Title.Value)
 }
 
 func TestCreateDocument(t *testing.T) {
-    initTest()
-    assert.Equal(t, "3.1.0", doc.Version.Value)
-    assert.Equal(t, "Burger Shop", doc.Info.Value.Title.Value)
-    assert.NotEmpty(t, doc.Info.Value.Title.Value)
-    assert.Equal(t, "https://pb33f.io/schema", doc.JsonSchemaDialect.Value)
-    assert.Len(t, doc.GetExtensions(), 1)
+	initTest()
+	assert.Equal(t, "3.1.0", doc.Version.Value)
+	assert.Equal(t, "Burger Shop", doc.Info.Value.Title.Value)
+	assert.NotEmpty(t, doc.Info.Value.Title.Value)
+	assert.Equal(t, "https://pb33f.io/schema", doc.JsonSchemaDialect.Value)
+	assert.Len(t, doc.GetExtensions(), 1)
 }
 
 func TestCreateDocument_Info(t *testing.T) {
-    initTest()
-    assert.Equal(t, "https://pb33f.io", doc.Info.Value.TermsOfService.Value)
-    assert.Equal(t, "pb33f", doc.Info.Value.Contact.Value.Name.Value)
-    assert.Equal(t, "buckaroo@pb33f.io", doc.Info.Value.Contact.Value.Email.Value)
-    assert.Equal(t, "https://pb33f.io", doc.Info.Value.Contact.Value.URL.Value)
-    assert.Equal(t, "pb33f", doc.Info.Value.License.Value.Name.Value)
-    assert.Equal(t, "https://pb33f.io/made-up", doc.Info.Value.License.Value.URL.Value)
+	initTest()
+	assert.Equal(t, "https://pb33f.io", doc.Info.Value.TermsOfService.Value)
+	assert.Equal(t, "pb33f", doc.Info.Value.Contact.Value.Name.Value)
+	assert.Equal(t, "buckaroo@pb33f.io", doc.Info.Value.Contact.Value.Email.Value)
+	assert.Equal(t, "https://pb33f.io", doc.Info.Value.Contact.Value.URL.Value)
+	assert.Equal(t, "pb33f", doc.Info.Value.License.Value.Name.Value)
+	assert.Equal(t, "https://pb33f.io/made-up", doc.Info.Value.License.Value.URL.Value)
 }
 
 func TestCreateDocument_WebHooks(t *testing.T) {
-    initTest()
-    assert.Len(t, doc.Webhooks.Value, 1)
-    for i := range doc.Webhooks.Value {
-        // a nice deep model should be available for us.
-        assert.Equal(t, "Information about a new burger",
-            doc.Webhooks.Value[i].Value.Post.Value.RequestBody.Value.Description.Value)
-    }
+	initTest()
+	assert.Len(t, doc.Webhooks.Value, 1)
+	for i := range doc.Webhooks.Value {
+		// a nice deep model should be available for us.
+		assert.Equal(t, "Information about a new burger",
+			doc.Webhooks.Value[i].Value.Post.Value.RequestBody.Value.Description.Value)
+	}
 }
 
 func TestCreateDocument_WebHooks_Error(t *testing.T) {
-    yml := `webhooks:
+	yml := `webhooks:
       $ref: #bork`
 
-    info, _ := datamodel.ExtractSpecInfo([]byte(yml))
-    var err []error
-    _, err = CreateDocument(info)
-    assert.Len(t, err, 1)
+	info, _ := datamodel.ExtractSpecInfo([]byte(yml))
+	var err []error
+	_, err = CreateDocument(info)
+	assert.Len(t, err, 1)
 }
 
 func TestCreateDocument_Servers(t *testing.T) {
-    initTest()
-    assert.Len(t, doc.Servers.Value, 2)
-    server1 := doc.Servers.Value[0].Value
-    server2 := doc.Servers.Value[1].Value
+	initTest()
+	assert.Len(t, doc.Servers.Value, 2)
+	server1 := doc.Servers.Value[0].Value
+	server2 := doc.Servers.Value[1].Value
 
-    // server 1
-    assert.Equal(t, "{scheme}://api.pb33f.io", server1.URL.Value)
-    assert.NotEmpty(t, server1.Description.Value)
-    assert.Len(t, server1.Variables.Value, 1)
-    assert.Len(t, server1.FindVariable("scheme").Value.Enum, 2)
-    assert.Equal(t, server1.FindVariable("scheme").Value.Default.Value, "https")
-    assert.NotEmpty(t, server1.FindVariable("scheme").Value.Description.Value)
+	// server 1
+	assert.Equal(t, "{scheme}://api.pb33f.io", server1.URL.Value)
+	assert.NotEmpty(t, server1.Description.Value)
+	assert.Len(t, server1.Variables.Value, 1)
+	assert.Len(t, server1.FindVariable("scheme").Value.Enum, 2)
+	assert.Equal(t, server1.FindVariable("scheme").Value.Default.Value, "https")
+	assert.NotEmpty(t, server1.FindVariable("scheme").Value.Description.Value)
 
-    // server 2
-    assert.Equal(t, "https://{domain}.{host}.com", server2.URL.Value)
-    assert.NotEmpty(t, server2.Description.Value)
-    assert.Len(t, server2.Variables.Value, 2)
-    assert.Equal(t, "api", server2.FindVariable("domain").Value.Default.Value)
-    assert.NotEmpty(t, server2.FindVariable("domain").Value.Description.Value)
-    assert.NotEmpty(t, server2.FindVariable("host").Value.Description.Value)
-    assert.Equal(t, server2.FindVariable("host").Value.Default.Value, "pb33f.io")
-    assert.Equal(t, "1.2", doc.Info.Value.Version.Value)
+	// server 2
+	assert.Equal(t, "https://{domain}.{host}.com", server2.URL.Value)
+	assert.NotEmpty(t, server2.Description.Value)
+	assert.Len(t, server2.Variables.Value, 2)
+	assert.Equal(t, "api", server2.FindVariable("domain").Value.Default.Value)
+	assert.NotEmpty(t, server2.FindVariable("domain").Value.Description.Value)
+	assert.NotEmpty(t, server2.FindVariable("host").Value.Description.Value)
+	assert.Equal(t, server2.FindVariable("host").Value.Default.Value, "pb33f.io")
+	assert.Equal(t, "1.2", doc.Info.Value.Version.Value)
 }
 
 func TestCreateDocument_Tags(t *testing.T) {
-    initTest()
-    assert.Len(t, doc.Tags.Value, 2)
+	initTest()
+	assert.Len(t, doc.Tags.Value, 2)
 
-    // tag1
-    assert.Equal(t, "Burgers", doc.Tags.Value[0].Value.Name.Value)
-    assert.NotEmpty(t, doc.Tags.Value[0].Value.Description.Value)
-    assert.NotNil(t, doc.Tags.Value[0].Value.ExternalDocs.Value)
-    assert.Equal(t, "https://pb33f.io", doc.Tags.Value[0].Value.ExternalDocs.Value.URL.Value)
-    assert.NotEmpty(t, doc.Tags.Value[0].Value.ExternalDocs.Value.URL.Value)
-    assert.Len(t, doc.Tags.Value[0].Value.Extensions, 7)
+	// tag1
+	assert.Equal(t, "Burgers", doc.Tags.Value[0].Value.Name.Value)
+	assert.NotEmpty(t, doc.Tags.Value[0].Value.Description.Value)
+	assert.NotNil(t, doc.Tags.Value[0].Value.ExternalDocs.Value)
+	assert.Equal(t, "https://pb33f.io", doc.Tags.Value[0].Value.ExternalDocs.Value.URL.Value)
+	assert.NotEmpty(t, doc.Tags.Value[0].Value.ExternalDocs.Value.URL.Value)
+	assert.Len(t, doc.Tags.Value[0].Value.Extensions, 7)
 
-    for key, extension := range doc.Tags.Value[0].Value.Extensions {
-        switch key.Value {
-        case "x-internal-ting":
-            assert.Equal(t, "somethingSpecial", extension.Value)
-        case "x-internal-tong":
-            assert.Equal(t, int64(1), extension.Value)
-        case "x-internal-tang":
-            assert.Equal(t, 1.2, extension.Value)
-        case "x-internal-tung":
-            assert.Equal(t, true, extension.Value)
-        case "x-internal-arr":
-            assert.Len(t, extension.Value, 2)
-            assert.Equal(t, "one", extension.Value.([]interface{})[0].(string))
-        case "x-internal-arrmap":
-            assert.Len(t, extension.Value, 2)
-            assert.Equal(t, "now", extension.Value.([]interface{})[0].(map[string]interface{})["what"])
-        case "x-something-else":
-            // crazy times in the upside down. this API should be avoided for the higher up use cases.
-            // this is why we will need a higher level API to this model, this looks cool and all, but dude.
-            assert.Equal(t, "now?", extension.Value.(map[string]interface{})["ok"].([]interface{})[0].(map[string]interface{})["what"])
-        }
+	for key, extension := range doc.Tags.Value[0].Value.Extensions {
+		switch key.Value {
+		case "x-internal-ting":
+			assert.Equal(t, "somethingSpecial", extension.Value)
+		case "x-internal-tong":
+			assert.Equal(t, int64(1), extension.Value)
+		case "x-internal-tang":
+			assert.Equal(t, 1.2, extension.Value)
+		case "x-internal-tung":
+			assert.Equal(t, true, extension.Value)
+		case "x-internal-arr":
+			assert.Len(t, extension.Value, 2)
+			assert.Equal(t, "one", extension.Value.([]interface{})[0].(string))
+		case "x-internal-arrmap":
+			assert.Len(t, extension.Value, 2)
+			assert.Equal(t, "now", extension.Value.([]interface{})[0].(map[string]interface{})["what"])
+		case "x-something-else":
+			// crazy times in the upside down. this API should be avoided for the higher up use cases.
+			// this is why we will need a higher level API to this model, this looks cool and all, but dude.
+			assert.Equal(t, "now?", extension.Value.(map[string]interface{})["ok"].([]interface{})[0].(map[string]interface{})["what"])
+		}
 
-    }
+	}
 
-    /// tag2
-    assert.Equal(t, "Dressing", doc.Tags.Value[1].Value.Name.Value)
-    assert.NotEmpty(t, doc.Tags.Value[1].Value.Description.Value)
-    assert.NotNil(t, doc.Tags.Value[1].Value.ExternalDocs.Value)
-    assert.Equal(t, "https://pb33f.io", doc.Tags.Value[1].Value.ExternalDocs.Value.URL.Value)
-    assert.NotEmpty(t, doc.Tags.Value[1].Value.ExternalDocs.Value.URL.Value)
-    assert.Len(t, doc.Tags.Value[1].Value.Extensions, 0)
+	/// tag2
+	assert.Equal(t, "Dressing", doc.Tags.Value[1].Value.Name.Value)
+	assert.NotEmpty(t, doc.Tags.Value[1].Value.Description.Value)
+	assert.NotNil(t, doc.Tags.Value[1].Value.ExternalDocs.Value)
+	assert.Equal(t, "https://pb33f.io", doc.Tags.Value[1].Value.ExternalDocs.Value.URL.Value)
+	assert.NotEmpty(t, doc.Tags.Value[1].Value.ExternalDocs.Value.URL.Value)
+	assert.Len(t, doc.Tags.Value[1].Value.Extensions, 0)
 
 }
 
 func TestCreateDocument_Paths(t *testing.T) {
-    initTest()
-    assert.Len(t, doc.Paths.Value.PathItems, 5)
-    burgerId := doc.Paths.Value.FindPath("/burgers/{burgerId}")
-    assert.NotNil(t, burgerId)
-    assert.Len(t, burgerId.Value.Get.Value.Parameters.Value, 2)
-    param := burgerId.Value.Get.Value.Parameters.Value[1]
-    assert.Equal(t, "burgerHeader", param.Value.Name.Value)
-    prop := param.Value.Schema.Value.Schema().FindProperty("burgerTheme").Value
-    assert.Equal(t, "something about a theme goes in here?", prop.Schema().Description.Value)
-    assert.Equal(t, "big-mac", param.Value.Example.Value)
+	initTest()
+	assert.Len(t, doc.Paths.Value.PathItems, 5)
+	burgerId := doc.Paths.Value.FindPath("/burgers/{burgerId}")
+	assert.NotNil(t, burgerId)
+	assert.Len(t, burgerId.Value.Get.Value.Parameters.Value, 2)
+	param := burgerId.Value.Get.Value.Parameters.Value[1]
+	assert.Equal(t, "burgerHeader", param.Value.Name.Value)
+	prop := param.Value.Schema.Value.Schema().FindProperty("burgerTheme").Value
+	assert.Equal(t, "something about a theme goes in here?", prop.Schema().Description.Value)
+	assert.Equal(t, "big-mac", param.Value.Example.Value)
 
-    // check content
-    pContent := param.Value.FindContent("application/json")
-    assert.Equal(t, "somethingNice", pContent.Value.Example.Value)
+	// check content
+	pContent := param.Value.FindContent("application/json")
+	assert.Equal(t, "somethingNice", pContent.Value.Example.Value)
 
-    encoding := pContent.Value.FindPropertyEncoding("burgerTheme")
-    assert.NotNil(t, encoding.Value)
-    assert.Len(t, encoding.Value.Headers.Value, 1)
+	encoding := pContent.Value.FindPropertyEncoding("burgerTheme")
+	assert.NotNil(t, encoding.Value)
+	assert.Len(t, encoding.Value.Headers.Value, 1)
 
-    header := encoding.Value.FindHeader("someHeader")
-    assert.NotNil(t, header.Value)
-    assert.Equal(t, "this is a header", header.Value.Description.Value)
-    assert.Equal(t, "string", header.Value.Schema.Value.Schema().Type.Value.A)
+	header := encoding.Value.FindHeader("someHeader")
+	assert.NotNil(t, header.Value)
+	assert.Equal(t, "this is a header", header.Value.Description.Value)
+	assert.Equal(t, "string", header.Value.Schema.Value.Schema().Type.Value.A)
 
-    // check request body on operation
-    burgers := doc.Paths.Value.FindPath("/burgers")
-    assert.NotNil(t, burgers.Value.Post.Value)
+	// check request body on operation
+	burgers := doc.Paths.Value.FindPath("/burgers")
+	assert.NotNil(t, burgers.Value.Post.Value)
 
-    burgersPost := burgers.Value.Post.Value
-    assert.Equal(t, "createBurger", burgersPost.OperationId.Value)
-    assert.Equal(t, "Create a new burger", burgersPost.Summary.Value)
-    assert.NotEmpty(t, burgersPost.Description.Value)
+	burgersPost := burgers.Value.Post.Value
+	assert.Equal(t, "createBurger", burgersPost.OperationId.Value)
+	assert.Equal(t, "Create a new burger", burgersPost.Summary.Value)
+	assert.NotEmpty(t, burgersPost.Description.Value)
 
-    requestBody := burgersPost.RequestBody.Value
+	requestBody := burgersPost.RequestBody.Value
 
-    assert.NotEmpty(t, requestBody.Description.Value)
-    content := requestBody.FindContent("application/json").Value
+	assert.NotEmpty(t, requestBody.Description.Value)
+	content := requestBody.FindContent("application/json").Value
 
-    assert.NotNil(t, content)
-    assert.Len(t, content.Schema.Value.Schema().Properties.Value, 4)
-    assert.Len(t, content.GetAllExamples(), 2)
+	assert.NotNil(t, content)
+	assert.Len(t, content.Schema.Value.Schema().Properties.Value, 4)
+	assert.Len(t, content.GetAllExamples(), 2)
 
-    ex := content.FindExample("pbjBurger")
-    assert.NotNil(t, ex.Value)
-    assert.NotEmpty(t, ex.Value.Summary.Value)
-    assert.NotNil(t, ex.Value.Value.Value)
+	ex := content.FindExample("pbjBurger")
+	assert.NotNil(t, ex.Value)
+	assert.NotEmpty(t, ex.Value.Summary.Value)
+	assert.NotNil(t, ex.Value.Value.Value)
 
-    if n, ok := ex.Value.Value.Value.(map[string]interface{}); ok {
-        assert.Len(t, n, 2)
-        assert.Equal(t, 3, n["numPatties"])
-    } else {
-        assert.Fail(t, "should easily be convertable. something changed!")
-    }
+	if n, ok := ex.Value.Value.Value.(map[string]interface{}); ok {
+		assert.Len(t, n, 2)
+		assert.Equal(t, 3, n["numPatties"])
+	} else {
+		assert.Fail(t, "should easily be convertable. something changed!")
+	}
 
-    cb := content.FindExample("cakeBurger")
-    assert.NotNil(t, cb.Value)
-    assert.NotEmpty(t, cb.Value.Summary.Value)
-    assert.NotNil(t, cb.Value.Value.Value)
+	cb := content.FindExample("cakeBurger")
+	assert.NotNil(t, cb.Value)
+	assert.NotEmpty(t, cb.Value.Summary.Value)
+	assert.NotNil(t, cb.Value.Value.Value)
 
-    if n, ok := cb.Value.Value.Value.(map[string]interface{}); ok {
-        assert.Len(t, n, 2)
-        assert.Equal(t, "Chocolate Cake Burger", n["name"])
-        assert.Equal(t, 5, n["numPatties"])
-    } else {
-        assert.Fail(t, "should easily be convertable. something changed!")
-    }
+	if n, ok := cb.Value.Value.Value.(map[string]interface{}); ok {
+		assert.Len(t, n, 2)
+		assert.Equal(t, "Chocolate Cake Burger", n["name"])
+		assert.Equal(t, 5, n["numPatties"])
+	} else {
+		assert.Fail(t, "should easily be convertable. something changed!")
+	}
 
-    // check responses
-    responses := burgersPost.Responses.Value
-    assert.NotNil(t, responses)
-    assert.Len(t, responses.Codes, 3)
+	// check responses
+	responses := burgersPost.Responses.Value
+	assert.NotNil(t, responses)
+	assert.Len(t, responses.Codes, 3)
 
-    okCode := responses.FindResponseByCode("200")
-    assert.NotNil(t, okCode.Value)
-    assert.Equal(t, "A tasty burger for you to eat.", okCode.Value.Description.Value)
+	okCode := responses.FindResponseByCode("200")
+	assert.NotNil(t, okCode.Value)
+	assert.Equal(t, "A tasty burger for you to eat.", okCode.Value.Description.Value)
 
-    // check headers are populated
-    assert.Len(t, okCode.Value.Headers.Value, 1)
-    okheader := okCode.Value.FindHeader("UseOil")
-    assert.NotNil(t, okheader.Value)
-    assert.Equal(t, "this is a header example for UseOil", okheader.Value.Description.Value)
+	// check headers are populated
+	assert.Len(t, okCode.Value.Headers.Value, 1)
+	okheader := okCode.Value.FindHeader("UseOil")
+	assert.NotNil(t, okheader.Value)
+	assert.Equal(t, "this is a header example for UseOil", okheader.Value.Description.Value)
 
-    respContent := okCode.Value.FindContent("application/json").Value
-    assert.NotNil(t, respContent)
+	respContent := okCode.Value.FindContent("application/json").Value
+	assert.NotNil(t, respContent)
 
-    assert.NotNil(t, respContent.Schema.Value)
-    assert.Len(t, respContent.Schema.Value.Schema().Required.Value, 2)
+	assert.NotNil(t, respContent.Schema.Value)
+	assert.Len(t, respContent.Schema.Value.Schema().Required.Value, 2)
 
-    respExample := respContent.FindExample("quarterPounder")
-    assert.NotNil(t, respExample.Value)
-    assert.NotNil(t, respExample.Value.Value.Value)
+	respExample := respContent.FindExample("quarterPounder")
+	assert.NotNil(t, respExample.Value)
+	assert.NotNil(t, respExample.Value.Value.Value)
 
-    if n, ok := respExample.Value.Value.Value.(map[string]interface{}); ok {
-        assert.Len(t, n, 2)
-        assert.Equal(t, "Quarter Pounder with Cheese", n["name"])
-        assert.Equal(t, 1, n["numPatties"])
-    } else {
-        assert.Fail(t, "should easily be convertable. something changed!")
-    }
+	if n, ok := respExample.Value.Value.Value.(map[string]interface{}); ok {
+		assert.Len(t, n, 2)
+		assert.Equal(t, "Quarter Pounder with Cheese", n["name"])
+		assert.Equal(t, 1, n["numPatties"])
+	} else {
+		assert.Fail(t, "should easily be convertable. something changed!")
+	}
 
-    // check links
-    links := okCode.Value.Links
-    assert.NotNil(t, links.Value)
-    assert.Len(t, links.Value, 2)
-    assert.Equal(t, "locateBurger", okCode.Value.FindLink("LocateBurger").Value.OperationId.Value)
+	// check links
+	links := okCode.Value.Links
+	assert.NotNil(t, links.Value)
+	assert.Len(t, links.Value, 2)
+	assert.Equal(t, "locateBurger", okCode.Value.FindLink("LocateBurger").Value.OperationId.Value)
 
-    locateBurger := okCode.Value.FindLink("LocateBurger").Value
+	locateBurger := okCode.Value.FindLink("LocateBurger").Value
 
-    burgerIdParam := locateBurger.FindParameter("burgerId")
-    assert.NotNil(t, burgerIdParam)
-    assert.Equal(t, "$response.body#/id", burgerIdParam.Value)
+	burgerIdParam := locateBurger.FindParameter("burgerId")
+	assert.NotNil(t, burgerIdParam)
+	assert.Equal(t, "$response.body#/id", burgerIdParam.Value)
 
-    // check security requirements
-    oAuthReq := burgersPost.FindSecurityRequirement("OAuthScheme")
-    assert.Len(t, oAuthReq, 2)
-    assert.Equal(t, "read:burgers", oAuthReq[0].Value)
+	// check security requirements
+	oAuthReq := burgersPost.FindSecurityRequirement("OAuthScheme")
+	assert.Len(t, oAuthReq, 2)
+	assert.Equal(t, "read:burgers", oAuthReq[0].Value)
 
-    servers := burgersPost.Servers.Value
-    assert.NotNil(t, servers)
-    assert.Len(t, servers, 1)
-    assert.Equal(t, "https://pb33f.io", servers[0].Value.URL.Value)
+	servers := burgersPost.Servers.Value
+	assert.NotNil(t, servers)
+	assert.Len(t, servers, 1)
+	assert.Equal(t, "https://pb33f.io", servers[0].Value.URL.Value)
 
 }
 
 func TestCreateDocument_Components_Schemas(t *testing.T) {
-    initTest()
+	initTest()
 
-    components := doc.Components.Value
-    assert.NotNil(t, components)
-    assert.Len(t, components.Schemas.Value, 6)
+	components := doc.Components.Value
+	assert.NotNil(t, components)
+	assert.Len(t, components.Schemas.Value, 6)
 
-    burger := components.FindSchema("Burger").Value
-    assert.NotNil(t, burger)
-    assert.Equal(t, "The tastiest food on the planet you would love to eat everyday", burger.Schema().Description.Value)
+	burger := components.FindSchema("Burger").Value
+	assert.NotNil(t, burger)
+	assert.Equal(t, "The tastiest food on the planet you would love to eat everyday", burger.Schema().Description.Value)
 
-    er := components.FindSchema("Error")
-    assert.NotNil(t, er.Value)
-    assert.Equal(t, "Error defining what went wrong when providing a specification. The message should help "+
-        "indicate the issue clearly.", er.Value.Schema().Description.Value)
+	er := components.FindSchema("Error")
+	assert.NotNil(t, er.Value)
+	assert.Equal(t, "Error defining what went wrong when providing a specification. The message should help "+
+		"indicate the issue clearly.", er.Value.Schema().Description.Value)
 
-    fries := components.FindSchema("Fries")
-    assert.NotNil(t, fries.Value)
+	fries := components.FindSchema("Fries")
+	assert.NotNil(t, fries.Value)
 
-    assert.Len(t, fries.Value.Schema().Properties.Value, 3)
-    p := fries.Value.Schema().FindProperty("favoriteDrink")
-    assert.Equal(t, "a frosty cold beverage can be coke or sprite",
-        p.Value.Schema().Description.Value)
+	assert.Len(t, fries.Value.Schema().Properties.Value, 3)
+	p := fries.Value.Schema().FindProperty("favoriteDrink")
+	assert.Equal(t, "a frosty cold beverage can be coke or sprite",
+		p.Value.Schema().Description.Value)
 
 }
 
 func TestCreateDocument_Components_SecuritySchemes(t *testing.T) {
-    initTest()
-    components := doc.Components.Value
-    securitySchemes := components.SecuritySchemes.Value
-    assert.Len(t, securitySchemes, 3)
+	initTest()
+	components := doc.Components.Value
+	securitySchemes := components.SecuritySchemes.Value
+	assert.Len(t, securitySchemes, 3)
 
-    apiKey := components.FindSecurityScheme("APIKeyScheme").Value
-    assert.NotNil(t, apiKey)
-    assert.Equal(t, "an apiKey security scheme", apiKey.Description.Value)
+	apiKey := components.FindSecurityScheme("APIKeyScheme").Value
+	assert.NotNil(t, apiKey)
+	assert.Equal(t, "an apiKey security scheme", apiKey.Description.Value)
 
-    oAuth := components.FindSecurityScheme("OAuthScheme").Value
-    assert.NotNil(t, oAuth)
-    assert.Equal(t, "an oAuth security scheme", oAuth.Description.Value)
-    assert.NotNil(t, oAuth.Flows.Value.Implicit.Value)
-    assert.NotNil(t, oAuth.Flows.Value.AuthorizationCode.Value)
+	oAuth := components.FindSecurityScheme("OAuthScheme").Value
+	assert.NotNil(t, oAuth)
+	assert.Equal(t, "an oAuth security scheme", oAuth.Description.Value)
+	assert.NotNil(t, oAuth.Flows.Value.Implicit.Value)
+	assert.NotNil(t, oAuth.Flows.Value.AuthorizationCode.Value)
 
-    scopes := oAuth.Flows.Value.Implicit.Value.Scopes.Value
-    assert.NotNil(t, scopes)
+	scopes := oAuth.Flows.Value.Implicit.Value.Scopes.Value
+	assert.NotNil(t, scopes)
 
-    readScope := oAuth.Flows.Value.Implicit.Value.FindScope("write:burgers")
-    assert.NotNil(t, readScope)
-    assert.Equal(t, "modify and add new burgers", readScope.Value)
+	readScope := oAuth.Flows.Value.Implicit.Value.FindScope("write:burgers")
+	assert.NotNil(t, readScope)
+	assert.Equal(t, "modify and add new burgers", readScope.Value)
 
-    readScope = oAuth.Flows.Value.AuthorizationCode.Value.FindScope("write:burgers")
-    assert.NotNil(t, readScope)
-    assert.Equal(t, "modify burgers and stuff", readScope.Value)
+	readScope = oAuth.Flows.Value.AuthorizationCode.Value.FindScope("write:burgers")
+	assert.NotNil(t, readScope)
+	assert.Equal(t, "modify burgers and stuff", readScope.Value)
 
 }
 
 func TestCreateDocument_Components_Responses(t *testing.T) {
-    initTest()
-    components := doc.Components.Value
-    responses := components.Responses.Value
-    assert.Len(t, responses, 1)
+	initTest()
+	components := doc.Components.Value
+	responses := components.Responses.Value
+	assert.Len(t, responses, 1)
 
-    dressingResponse := components.FindResponse("DressingResponse")
-    assert.NotNil(t, dressingResponse.Value)
-    assert.Equal(t, "all the dressings for a burger.", dressingResponse.Value.Description.Value)
-    assert.Len(t, dressingResponse.Value.Content.Value, 1)
+	dressingResponse := components.FindResponse("DressingResponse")
+	assert.NotNil(t, dressingResponse.Value)
+	assert.Equal(t, "all the dressings for a burger.", dressingResponse.Value.Description.Value)
+	assert.Len(t, dressingResponse.Value.Content.Value, 1)
 
 }
 
 func TestCreateDocument_Components_Examples(t *testing.T) {
-    initTest()
-    components := doc.Components.Value
-    examples := components.Examples.Value
-    assert.Len(t, examples, 1)
+	initTest()
+	components := doc.Components.Value
+	examples := components.Examples.Value
+	assert.Len(t, examples, 1)
 
-    quarterPounder := components.FindExample("QuarterPounder")
-    assert.NotNil(t, quarterPounder.Value)
-    assert.Equal(t, "A juicy two hander sammich", quarterPounder.Value.Summary.Value)
-    assert.NotNil(t, quarterPounder.Value.Value.Value)
+	quarterPounder := components.FindExample("QuarterPounder")
+	assert.NotNil(t, quarterPounder.Value)
+	assert.Equal(t, "A juicy two hander sammich", quarterPounder.Value.Summary.Value)
+	assert.NotNil(t, quarterPounder.Value.Value.Value)
 }
 
 func TestCreateDocument_Components_RequestBodies(t *testing.T) {
-    initTest()
-    components := doc.Components.Value
-    requestBodies := components.RequestBodies.Value
-    assert.Len(t, requestBodies, 1)
+	initTest()
+	components := doc.Components.Value
+	requestBodies := components.RequestBodies.Value
+	assert.Len(t, requestBodies, 1)
 
-    burgerRequest := components.FindRequestBody("BurgerRequest")
-    assert.NotNil(t, burgerRequest.Value)
-    assert.Equal(t, "Give us the new burger!", burgerRequest.Value.Description.Value)
-    assert.Len(t, burgerRequest.Value.Content.Value, 1)
+	burgerRequest := components.FindRequestBody("BurgerRequest")
+	assert.NotNil(t, burgerRequest.Value)
+	assert.Equal(t, "Give us the new burger!", burgerRequest.Value.Description.Value)
+	assert.Len(t, burgerRequest.Value.Content.Value, 1)
 }
 
 func TestCreateDocument_Components_Headers(t *testing.T) {
-    initTest()
-    components := doc.Components.Value
-    headers := components.Headers.Value
-    assert.Len(t, headers, 1)
+	initTest()
+	components := doc.Components.Value
+	headers := components.Headers.Value
+	assert.Len(t, headers, 1)
 
-    useOil := components.FindHeader("UseOil")
-    assert.NotNil(t, useOil.Value)
-    assert.Equal(t, "this is a header example for UseOil", useOil.Value.Description.Value)
-    assert.Equal(t, "string", useOil.Value.Schema.Value.Schema().Type.Value.A)
+	useOil := components.FindHeader("UseOil")
+	assert.NotNil(t, useOil.Value)
+	assert.Equal(t, "this is a header example for UseOil", useOil.Value.Description.Value)
+	assert.Equal(t, "string", useOil.Value.Schema.Value.Schema().Type.Value.A)
 }
 
 func TestCreateDocument_Components_Links(t *testing.T) {
-    initTest()
-    components := doc.Components.Value
-    links := components.Links.Value
-    assert.Len(t, links, 2)
+	initTest()
+	components := doc.Components.Value
+	links := components.Links.Value
+	assert.Len(t, links, 2)
 
-    locateBurger := components.FindLink("LocateBurger")
-    assert.NotNil(t, locateBurger.Value)
-    assert.Equal(t, "Go and get a tasty burger", locateBurger.Value.Description.Value)
+	locateBurger := components.FindLink("LocateBurger")
+	assert.NotNil(t, locateBurger.Value)
+	assert.Equal(t, "Go and get a tasty burger", locateBurger.Value.Description.Value)
 
-    anotherLocateBurger := components.FindLink("AnotherLocateBurger")
-    assert.NotNil(t, anotherLocateBurger.Value)
-    assert.Equal(t, "Go and get another really tasty burger", anotherLocateBurger.Value.Description.Value)
+	anotherLocateBurger := components.FindLink("AnotherLocateBurger")
+	assert.NotNil(t, anotherLocateBurger.Value)
+	assert.Equal(t, "Go and get another really tasty burger", anotherLocateBurger.Value.Description.Value)
 }
 
 func TestCreateDocument_Doc_Security(t *testing.T) {
-    initTest()
-    d := doc
-    oAuth := d.FindSecurityRequirement("OAuthScheme")
-    assert.Len(t, oAuth, 2)
+	initTest()
+	d := doc
+	oAuth := d.FindSecurityRequirement("OAuthScheme")
+	assert.Len(t, oAuth, 2)
 }
 
 func TestCreateDocument_Callbacks(t *testing.T) {
-    initTest()
-    callbacks := doc.Components.Value.Callbacks.Value
-    assert.Len(t, callbacks, 1)
+	initTest()
+	callbacks := doc.Components.Value.Callbacks.Value
+	assert.Len(t, callbacks, 1)
 
-    bCallback := doc.Components.Value.FindCallback("BurgerCallback")
-    assert.NotNil(t, bCallback.Value)
-    assert.Len(t, callbacks, 1)
+	bCallback := doc.Components.Value.FindCallback("BurgerCallback")
+	assert.NotNil(t, bCallback.Value)
+	assert.Len(t, callbacks, 1)
 
-    exp := bCallback.Value.FindExpression("{$request.query.queryUrl}")
-    assert.NotNil(t, exp.Value)
-    assert.NotNil(t, exp.Value.Post.Value)
-    assert.Equal(t, "Callback payload", exp.Value.Post.Value.RequestBody.Value.Description.Value)
+	exp := bCallback.Value.FindExpression("{$request.query.queryUrl}")
+	assert.NotNil(t, exp.Value)
+	assert.NotNil(t, exp.Value.Post.Value)
+	assert.Equal(t, "Callback payload", exp.Value.Post.Value.RequestBody.Value.Description.Value)
 }
 
 func TestCreateDocument_Component_Discriminator(t *testing.T) {
-    initTest()
+	initTest()
 
-    components := doc.Components.Value
-    dsc := components.FindSchema("Drink").Value.Schema().Discriminator.Value
-    assert.NotNil(t, dsc)
-    assert.Equal(t, "drinkType", dsc.PropertyName.Value)
-    assert.Equal(t, "some value", dsc.FindMappingValue("drink").Value)
-    assert.Nil(t, dsc.FindMappingValue("don't exist"))
-    assert.NotNil(t, doc.GetExternalDocs())
-    assert.Nil(t, doc.FindSecurityRequirement("scooby doo"))
+	components := doc.Components.Value
+	dsc := components.FindSchema("Drink").Value.Schema().Discriminator.Value
+	assert.NotNil(t, dsc)
+	assert.Equal(t, "drinkType", dsc.PropertyName.Value)
+	assert.Equal(t, "some value", dsc.FindMappingValue("drink").Value)
+	assert.Nil(t, dsc.FindMappingValue("don't exist"))
+	assert.NotNil(t, doc.GetExternalDocs())
+	assert.Nil(t, doc.FindSecurityRequirement("scooby doo"))
 
 }
 
 func TestCreateDocument_CheckAdditionalProperties_Schema(t *testing.T) {
-    initTest()
-    components := doc.Components.Value
-    d := components.FindSchema("Dressing")
-    assert.NotNil(t, d.Value.Schema().AdditionalProperties.Value)
-    if n, ok := d.Value.Schema().AdditionalProperties.Value.(*base.SchemaProxy); ok {
-        assert.Equal(t, "something in here.", n.Schema().Description.Value)
-    } else {
-        assert.Fail(t, "should be a schema")
-    }
+	initTest()
+	components := doc.Components.Value
+	d := components.FindSchema("Dressing")
+	assert.NotNil(t, d.Value.Schema().AdditionalProperties.Value)
+	if n, ok := d.Value.Schema().AdditionalProperties.Value.(*base.SchemaProxy); ok {
+		assert.Equal(t, "something in here.", n.Schema().Description.Value)
+	} else {
+		assert.Fail(t, "should be a schema")
+	}
 }
 
 func TestCreateDocument_CheckAdditionalProperties_Bool(t *testing.T) {
-    initTest()
-    components := doc.Components.Value
-    d := components.FindSchema("Drink")
-    assert.NotNil(t, d.Value.Schema().AdditionalProperties.Value)
-    assert.True(t, d.Value.Schema().AdditionalProperties.Value.(bool))
+	initTest()
+	components := doc.Components.Value
+	d := components.FindSchema("Drink")
+	assert.NotNil(t, d.Value.Schema().AdditionalProperties.Value)
+	assert.True(t, d.Value.Schema().AdditionalProperties.Value.(bool))
 }
 
 func TestCreateDocument_Components_Error(t *testing.T) {
-    yml := `openapi: 3.0
+	yml := `openapi: 3.0
 components:
   schemas:
     bork:
@@ -520,108 +521,108 @@ components:
         bark:
           $ref: #bork`
 
-    info, _ := datamodel.ExtractSpecInfo([]byte(yml))
-    var err []error
-    doc, err = CreateDocument(info)
-    assert.Len(t, err, 0)
+	info, _ := datamodel.ExtractSpecInfo([]byte(yml))
+	var err []error
+	doc, err = CreateDocument(info)
+	assert.Len(t, err, 0)
 
-    ob := doc.Components.Value.FindSchema("bork").Value
-    ob.Schema()
-    assert.Error(t, ob.GetBuildError())
+	ob := doc.Components.Value.FindSchema("bork").Value
+	ob.Schema()
+	assert.Error(t, ob.GetBuildError())
 }
 
 func TestCreateDocument_Webhooks_Error(t *testing.T) {
-    yml := `openapi: 3.0
+	yml := `openapi: 3.0
 webhooks:
   aHook:
     $ref: #bork`
 
-    info, _ := datamodel.ExtractSpecInfo([]byte(yml))
-    var err []error
-    doc, err = CreateDocument(info)
-    assert.Len(t, err, 1)
+	info, _ := datamodel.ExtractSpecInfo([]byte(yml))
+	var err []error
+	doc, err = CreateDocument(info)
+	assert.Len(t, err, 1)
 }
 
 func TestCreateDocument_Components_Error_Extract(t *testing.T) {
-    yml := `openapi: 3.0
+	yml := `openapi: 3.0
 components:
   parameters:
     bork:
       $ref: #bork`
 
-    info, _ := datamodel.ExtractSpecInfo([]byte(yml))
-    var err []error
-    _, err = CreateDocument(info)
-    assert.Len(t, err, 1)
+	info, _ := datamodel.ExtractSpecInfo([]byte(yml))
+	var err []error
+	_, err = CreateDocument(info)
+	assert.Len(t, err, 1)
 
 }
 
 func TestCreateDocument_Paths_Errors(t *testing.T) {
-    yml := `openapi: 3.0
+	yml := `openapi: 3.0
 paths:
   /p:
     $ref: #bork`
 
-    info, _ := datamodel.ExtractSpecInfo([]byte(yml))
-    var err []error
-    _, err = CreateDocument(info)
-    assert.Len(t, err, 1)
+	info, _ := datamodel.ExtractSpecInfo([]byte(yml))
+	var err []error
+	_, err = CreateDocument(info)
+	assert.Len(t, err, 1)
 }
 
 func TestCreateDocument_Tags_Errors(t *testing.T) {
-    yml := `openapi: 3.0
+	yml := `openapi: 3.0
 tags:
   - $ref: #bork`
 
-    info, _ := datamodel.ExtractSpecInfo([]byte(yml))
-    var err []error
-    _, err = CreateDocument(info)
-    assert.Len(t, err, 1)
+	info, _ := datamodel.ExtractSpecInfo([]byte(yml))
+	var err []error
+	_, err = CreateDocument(info)
+	assert.Len(t, err, 1)
 }
 
 func TestCreateDocument_Security_Error(t *testing.T) {
-    yml := `openapi: 3.0
+	yml := `openapi: 3.0
 security:
   $ref: #bork`
 
-    info, _ := datamodel.ExtractSpecInfo([]byte(yml))
-    var err []error
-    _, err = CreateDocument(info)
-    assert.Len(t, err, 1)
+	info, _ := datamodel.ExtractSpecInfo([]byte(yml))
+	var err []error
+	_, err = CreateDocument(info)
+	assert.Len(t, err, 1)
 }
 
 func TestCreateDocument_ExternalDoc_Error(t *testing.T) {
-    yml := `openapi: 3.0
+	yml := `openapi: 3.0
 externalDocs:
   $ref: #bork`
 
-    info, _ := datamodel.ExtractSpecInfo([]byte(yml))
-    var err []error
-    _, err = CreateDocument(info)
-    assert.Len(t, err, 1)
+	info, _ := datamodel.ExtractSpecInfo([]byte(yml))
+	var err []error
+	_, err = CreateDocument(info)
+	assert.Len(t, err, 1)
 }
 
 func ExampleCreateDocument() {
-    // How to create a low-level OpenAPI 3 Document
+	// How to create a low-level OpenAPI 3 Document
 
-    // load petstore into bytes
-    petstoreBytes, _ := ioutil.ReadFile("../../../test_specs/petstorev3.json")
+	// load petstore into bytes
+	petstoreBytes, _ := ioutil.ReadFile("../../../test_specs/petstorev3.json")
 
-    // read in specification
-    info, _ := datamodel.ExtractSpecInfo(petstoreBytes)
+	// read in specification
+	info, _ := datamodel.ExtractSpecInfo(petstoreBytes)
 
-    // build low-level document model
-    document, errors := CreateDocument(info)
+	// build low-level document model
+	document, errors := CreateDocument(info)
 
-    // if something went wrong, a slice of errors is returned
-    if len(errors) > 0 {
-        for i := range errors {
-            fmt.Printf("error: %s\n", errors[i].Error())
-        }
-        panic("cannot build document")
-    }
+	// if something went wrong, a slice of errors is returned
+	if len(errors) > 0 {
+		for i := range errors {
+			fmt.Printf("error: %s\n", errors[i].Error())
+		}
+		panic("cannot build document")
+	}
 
-    // print out email address from the info > contact object.
-    fmt.Print(document.Info.Value.Contact.Value.Email.Value)
-    // Output: apiteam@swagger.io
+	// print out email address from the info > contact object.
+	fmt.Print(document.Info.Value.Contact.Value.Email.Value)
+	// Output: apiteam@swagger.io
 }

--- a/datamodel/low/v3/paths_test.go
+++ b/datamodel/low/v3/paths_test.go
@@ -376,42 +376,6 @@ func TestPath_Build_Using_CircularRef(t *testing.T) {
 
 }
 
-func TestPath_Build_Using_CircularRef_Invalid(t *testing.T) {
-
-	// first we need an index.
-	yml := `paths:
-  '/something/here':
-    post:
-      $ref: '#/paths/~1something~1there/post'
-  '/something/there':
-    post:
-      $ref: '#/paths/~1something~1here/post'`
-
-	var idxNode yaml.Node
-	mErr := yaml.Unmarshal([]byte(yml), &idxNode)
-	assert.NoError(t, mErr)
-	idx := index.NewSpecIndex(&idxNode)
-
-	resolve := resolver.NewResolver(idx)
-	errs := resolve.CheckForCircularReferences()
-	assert.Len(t, errs, 1)
-
-	yml = `"/some/path":
-  $ref: '#/paths/~1something~1here/post'`
-
-	var rootNode yaml.Node
-	mErr = yaml.Unmarshal([]byte(yml), &rootNode)
-	assert.NoError(t, mErr)
-
-	var n Paths
-	err := low.BuildModel(rootNode.Content[0], &n)
-	assert.NoError(t, err)
-
-	err = n.Build(rootNode.Content[0], idx)
-	assert.Error(t, err)
-
-}
-
 func TestPath_Build_Using_CircularRefWithOp(t *testing.T) {
 
 	// first we need an index.

--- a/document_test.go
+++ b/document_test.go
@@ -4,183 +4,184 @@
 package libopenapi
 
 import (
-    "fmt"
-    "github.com/pb33f/libopenapi/datamodel/high"
-    low "github.com/pb33f/libopenapi/datamodel/low/base"
-    v3 "github.com/pb33f/libopenapi/datamodel/low/v3"
-    "github.com/pb33f/libopenapi/resolver"
-    "github.com/pb33f/libopenapi/utils"
-    "github.com/stretchr/testify/assert"
-    "io/ioutil"
-    "strings"
-    "testing"
+	"fmt"
+	"io/ioutil"
+	"strings"
+	"testing"
+
+	"github.com/pb33f/libopenapi/datamodel/high"
+	low "github.com/pb33f/libopenapi/datamodel/low/base"
+	v3 "github.com/pb33f/libopenapi/datamodel/low/v3"
+	"github.com/pb33f/libopenapi/resolver"
+	"github.com/pb33f/libopenapi/utils"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestLoadDocument_Simple_V2(t *testing.T) {
 
-    yml := `swagger: 2.0.1`
-    doc, err := NewDocument([]byte(yml))
-    assert.NoError(t, err)
-    assert.Equal(t, "2.0.1", doc.GetVersion())
+	yml := `swagger: 2.0.1`
+	doc, err := NewDocument([]byte(yml))
+	assert.NoError(t, err)
+	assert.Equal(t, "2.0.1", doc.GetVersion())
 
-    v2Doc, docErr := doc.BuildV2Model()
-    assert.Len(t, docErr, 0)
-    assert.NotNil(t, v2Doc)
-    assert.NotNil(t, doc.GetSpecInfo())
+	v2Doc, docErr := doc.BuildV2Model()
+	assert.Len(t, docErr, 0)
+	assert.NotNil(t, v2Doc)
+	assert.NotNil(t, doc.GetSpecInfo())
 
-    fmt.Print()
+	fmt.Print()
 
 }
 
 func TestLoadDocument_Simple_V2_Error(t *testing.T) {
 
-    yml := `swagger: 2.0`
-    doc, err := NewDocument([]byte(yml))
-    assert.NoError(t, err)
+	yml := `swagger: 2.0`
+	doc, err := NewDocument([]byte(yml))
+	assert.NoError(t, err)
 
-    v2Doc, docErr := doc.BuildV3Model()
-    assert.Len(t, docErr, 1)
-    assert.Nil(t, v2Doc)
+	v2Doc, docErr := doc.BuildV3Model()
+	assert.Len(t, docErr, 1)
+	assert.Nil(t, v2Doc)
 }
 
 func TestLoadDocument_Simple_V2_Error_BadSpec(t *testing.T) {
 
-    yml := `swagger: 2.0
+	yml := `swagger: 2.0
 definitions:
   thing:
     $ref: bork`
-    doc, err := NewDocument([]byte(yml))
-    assert.NoError(t, err)
+	doc, err := NewDocument([]byte(yml))
+	assert.NoError(t, err)
 
-    v2Doc, docErr := doc.BuildV2Model()
-    assert.Len(t, docErr, 2)
-    assert.Nil(t, v2Doc)
+	v2Doc, docErr := doc.BuildV2Model()
+	assert.Len(t, docErr, 2)
+	assert.Nil(t, v2Doc)
 }
 
 func TestLoadDocument_Simple_V3_Error(t *testing.T) {
 
-    yml := `openapi: 3.0.1`
-    doc, err := NewDocument([]byte(yml))
-    assert.NoError(t, err)
+	yml := `openapi: 3.0.1`
+	doc, err := NewDocument([]byte(yml))
+	assert.NoError(t, err)
 
-    v2Doc, docErr := doc.BuildV2Model()
-    assert.Len(t, docErr, 1)
-    assert.Nil(t, v2Doc)
+	v2Doc, docErr := doc.BuildV2Model()
+	assert.Len(t, docErr, 1)
+	assert.Nil(t, v2Doc)
 }
 
 func TestLoadDocument_Error_V2NoSpec(t *testing.T) {
 
-    doc := new(document) // not how this should be instantiated.
-    _, err := doc.BuildV2Model()
-    assert.Len(t, err, 1)
+	doc := new(document) // not how this should be instantiated.
+	_, err := doc.BuildV2Model()
+	assert.Len(t, err, 1)
 }
 
 func TestLoadDocument_Error_V3NoSpec(t *testing.T) {
 
-    doc := new(document) // not how this should be instantiated.
-    _, err := doc.BuildV3Model()
-    assert.Len(t, err, 1)
+	doc := new(document) // not how this should be instantiated.
+	_, err := doc.BuildV3Model()
+	assert.Len(t, err, 1)
 }
 
 func TestLoadDocument_Empty(t *testing.T) {
-    yml := ``
-    _, err := NewDocument([]byte(yml))
-    assert.Error(t, err)
+	yml := ``
+	_, err := NewDocument([]byte(yml))
+	assert.Error(t, err)
 }
 
 func TestLoadDocument_Simple_V3(t *testing.T) {
 
-    yml := `openapi: 3.0.1`
-    doc, err := NewDocument([]byte(yml))
-    assert.NoError(t, err)
-    assert.Equal(t, "3.0.1", doc.GetVersion())
+	yml := `openapi: 3.0.1`
+	doc, err := NewDocument([]byte(yml))
+	assert.NoError(t, err)
+	assert.Equal(t, "3.0.1", doc.GetVersion())
 
-    v3Doc, docErr := doc.BuildV3Model()
-    assert.Len(t, docErr, 0)
-    assert.NotNil(t, v3Doc)
+	v3Doc, docErr := doc.BuildV3Model()
+	assert.Len(t, docErr, 0)
+	assert.NotNil(t, v3Doc)
 }
 
 func TestLoadDocument_Simple_V3_Error_BadSpec(t *testing.T) {
 
-    yml := `openapi: 3.0
+	yml := `openapi: 3.0
 paths:
   "/some":
     $ref: bork`
-    doc, err := NewDocument([]byte(yml))
-    assert.NoError(t, err)
+	doc, err := NewDocument([]byte(yml))
+	assert.NoError(t, err)
 
-    v3Doc, docErr := doc.BuildV3Model()
-    assert.Len(t, docErr, 1)
-    assert.Nil(t, v3Doc)
+	v3Doc, docErr := doc.BuildV3Model()
+	assert.Len(t, docErr, 1)
+	assert.Nil(t, v3Doc)
 }
 
 func TestDocument_Serialize_Error(t *testing.T) {
-    doc := new(document) // not how this should be instantiated.
-    _, err := doc.Serialize()
-    assert.Error(t, err)
+	doc := new(document) // not how this should be instantiated.
+	_, err := doc.Serialize()
+	assert.Error(t, err)
 }
 
 func TestDocument_Serialize(t *testing.T) {
 
-    yml := `openapi: 3.0
+	yml := `openapi: 3.0
 info:
     title: The magic API
 `
-    doc, _ := NewDocument([]byte(yml))
-    serial, err := doc.Serialize()
-    assert.NoError(t, err)
-    assert.Equal(t, yml, string(serial))
+	doc, _ := NewDocument([]byte(yml))
+	serial, err := doc.Serialize()
+	assert.NoError(t, err)
+	assert.Equal(t, yml, string(serial))
 }
 
 func TestDocument_Serialize_Modified(t *testing.T) {
 
-    yml := `openapi: 3.0
+	yml := `openapi: 3.0
 info:
     title: The magic API
 `
 
-    ymlModified := `openapi: 3.0
+	ymlModified := `openapi: 3.0
 info:
     title: The magic API - but now, altered!
 `
-    doc, _ := NewDocument([]byte(yml))
+	doc, _ := NewDocument([]byte(yml))
 
-    v3Doc, _ := doc.BuildV3Model()
+	v3Doc, _ := doc.BuildV3Model()
 
-    v3Doc.Model.Info.GoLow().Title.Mutate("The magic API - but now, altered!")
+	v3Doc.Model.Info.GoLow().Title.Mutate("The magic API - but now, altered!")
 
-    serial, err := doc.Serialize()
-    assert.NoError(t, err)
-    assert.Equal(t, ymlModified, string(serial))
+	serial, err := doc.Serialize()
+	assert.NoError(t, err)
+	assert.Equal(t, ymlModified, string(serial))
 }
 
 func TestDocument_Serialize_JSON_Modified(t *testing.T) {
 
-    json := `{ 'openapi': '3.0',
+	json := `{ 'openapi': '3.0',
  'info': {
    'title': 'The magic API'
  }
 }
 `
-    jsonModified := `{"info":{"title":"The magic API - but now, altered!"},"openapi":"3.0"}`
-    doc, _ := NewDocument([]byte(json))
+	jsonModified := `{"info":{"title":"The magic API - but now, altered!"},"openapi":"3.0"}`
+	doc, _ := NewDocument([]byte(json))
 
-    v3Doc, _ := doc.BuildV3Model()
+	v3Doc, _ := doc.BuildV3Model()
 
-    // eventually this will be encapsulated up high.
-    // mutation does not replace low model, eventually pointers will be used.
-    newTitle := v3Doc.Model.Info.GoLow().Title.Mutate("The magic API - but now, altered!")
-    v3Doc.Model.Info.GoLow().Title = newTitle
+	// eventually this will be encapsulated up high.
+	// mutation does not replace low model, eventually pointers will be used.
+	newTitle := v3Doc.Model.Info.GoLow().Title.Mutate("The magic API - but now, altered!")
+	v3Doc.Model.Info.GoLow().Title = newTitle
 
-    assert.Equal(t, "The magic API - but now, altered!", v3Doc.Model.Info.GoLow().Title.Value)
+	assert.Equal(t, "The magic API - but now, altered!", v3Doc.Model.Info.GoLow().Title.Value)
 
-    serial, err := doc.Serialize()
-    assert.NoError(t, err)
-    assert.Equal(t, jsonModified, string(serial))
+	serial, err := doc.Serialize()
+	assert.NoError(t, err)
+	assert.Equal(t, jsonModified, string(serial))
 }
 
 func TestExtractReference(t *testing.T) {
-    var data = `
+	var data = `
 openapi: "3.1"
 components:
   parameters:
@@ -192,152 +193,152 @@ paths:
       parameters:
         - $ref: '#/components/parameters/Param1'`
 
-    doc, err := NewDocument([]byte(data))
-    if err != nil {
-        panic(err)
-    }
+	doc, err := NewDocument([]byte(data))
+	if err != nil {
+		panic(err)
+	}
 
-    result, errs := doc.BuildV3Model()
-    if len(errs) > 0 {
-        panic(errs)
-    }
+	result, errs := doc.BuildV3Model()
+	if len(errs) > 0 {
+		panic(errs)
+	}
 
-    // extract operation.
-    operation := result.Model.Paths.PathItems["/something"].Get
+	// extract operation.
+	operation := result.Model.Paths.PathItems["/something"].Get
 
-    // print it out.
-    fmt.Printf("param1: %s, is reference? %t, original reference %s",
-        operation.Parameters[0].Description, operation.GoLow().Parameters.Value[0].IsReference,
-        operation.GoLow().Parameters.Value[0].Reference)
+	// print it out.
+	fmt.Printf("param1: %s, is reference? %t, original reference %s",
+		operation.Parameters[0].Description, operation.GoLow().Parameters.Value[0].IsReference,
+		operation.GoLow().Parameters.Value[0].Reference)
 }
 
 func ExampleNewDocument_fromOpenAPI3Document() {
 
-    // How to read in an OpenAPI 3 Specification, into a Document.
+	// How to read in an OpenAPI 3 Specification, into a Document.
 
-    // load an OpenAPI 3 specification from bytes
-    petstore, _ := ioutil.ReadFile("test_specs/petstorev3.json")
+	// load an OpenAPI 3 specification from bytes
+	petstore, _ := ioutil.ReadFile("test_specs/petstorev3.json")
 
-    // create a new document from specification bytes
-    document, err := NewDocument(petstore)
+	// create a new document from specification bytes
+	document, err := NewDocument(petstore)
 
-    // if anything went wrong, an error is thrown
-    if err != nil {
-        panic(fmt.Sprintf("cannot create new document: %e", err))
-    }
+	// if anything went wrong, an error is thrown
+	if err != nil {
+		panic(fmt.Sprintf("cannot create new document: %e", err))
+	}
 
-    // because we know this is a v3 spec, we can build a ready to go model from it.
-    v3Model, errors := document.BuildV3Model()
+	// because we know this is a v3 spec, we can build a ready to go model from it.
+	v3Model, errors := document.BuildV3Model()
 
-    // if anything went wrong when building the v3 model, a slice of errors will be returned
-    if len(errors) > 0 {
-        for i := range errors {
-            fmt.Printf("error: %e\n", errors[i])
-        }
-        panic(fmt.Sprintf("cannot create v3 model from document: %d errors reported", len(errors)))
-    }
+	// if anything went wrong when building the v3 model, a slice of errors will be returned
+	if len(errors) > 0 {
+		for i := range errors {
+			fmt.Printf("error: %e\n", errors[i])
+		}
+		panic(fmt.Sprintf("cannot create v3 model from document: %d errors reported", len(errors)))
+	}
 
-    // get a count of the number of paths and schemas.
-    paths := len(v3Model.Model.Paths.PathItems)
-    schemas := len(v3Model.Model.Components.Schemas)
+	// get a count of the number of paths and schemas.
+	paths := len(v3Model.Model.Paths.PathItems)
+	schemas := len(v3Model.Model.Components.Schemas)
 
-    // print the number of paths and schemas in the document
-    fmt.Printf("There are %d paths and %d schemas in the document", paths, schemas)
-    // Output: There are 13 paths and 8 schemas in the document
+	// print the number of paths and schemas in the document
+	fmt.Printf("There are %d paths and %d schemas in the document", paths, schemas)
+	// Output: There are 13 paths and 8 schemas in the document
 }
 
 func ExampleNewDocument_fromSwaggerDocument() {
 
-    // How to read in a Swagger / OpenAPI 2 Specification, into a Document.
+	// How to read in a Swagger / OpenAPI 2 Specification, into a Document.
 
-    // load a Swagger specification from bytes
-    petstore, _ := ioutil.ReadFile("test_specs/petstorev2.json")
+	// load a Swagger specification from bytes
+	petstore, _ := ioutil.ReadFile("test_specs/petstorev2.json")
 
-    // create a new document from specification bytes
-    document, err := NewDocument(petstore)
+	// create a new document from specification bytes
+	document, err := NewDocument(petstore)
 
-    // if anything went wrong, an error is thrown
-    if err != nil {
-        panic(fmt.Sprintf("cannot create new document: %e", err))
-    }
+	// if anything went wrong, an error is thrown
+	if err != nil {
+		panic(fmt.Sprintf("cannot create new document: %e", err))
+	}
 
-    // because we know this is a v2 spec, we can build a ready to go model from it.
-    v2Model, errors := document.BuildV2Model()
+	// because we know this is a v2 spec, we can build a ready to go model from it.
+	v2Model, errors := document.BuildV2Model()
 
-    // if anything went wrong when building the v3 model, a slice of errors will be returned
-    if len(errors) > 0 {
-        for i := range errors {
-            fmt.Printf("error: %e\n", errors[i])
-        }
-        panic(fmt.Sprintf("cannot create v3 model from document: %d errors reported", len(errors)))
-    }
+	// if anything went wrong when building the v3 model, a slice of errors will be returned
+	if len(errors) > 0 {
+		for i := range errors {
+			fmt.Printf("error: %e\n", errors[i])
+		}
+		panic(fmt.Sprintf("cannot create v3 model from document: %d errors reported", len(errors)))
+	}
 
-    // get a count of the number of paths and schemas.
-    paths := len(v2Model.Model.Paths.PathItems)
-    schemas := len(v2Model.Model.Definitions.Definitions)
+	// get a count of the number of paths and schemas.
+	paths := len(v2Model.Model.Paths.PathItems)
+	schemas := len(v2Model.Model.Definitions.Definitions)
 
-    // print the number of paths and schemas in the document
-    fmt.Printf("There are %d paths and %d schemas in the document", paths, schemas)
-    // Output: There are 14 paths and 6 schemas in the document
+	// print the number of paths and schemas in the document
+	fmt.Printf("There are %d paths and %d schemas in the document", paths, schemas)
+	// Output: There are 14 paths and 6 schemas in the document
 }
 
 func ExampleNewDocument_fromUnknownVersion() {
 
-    // load an unknown version of an OpenAPI spec
-    petstore, _ := ioutil.ReadFile("test_specs/burgershop.openapi.yaml")
+	// load an unknown version of an OpenAPI spec
+	petstore, _ := ioutil.ReadFile("test_specs/burgershop.openapi.yaml")
 
-    // create a new document from specification bytes
-    document, err := NewDocument(petstore)
+	// create a new document from specification bytes
+	document, err := NewDocument(petstore)
 
-    // if anything went wrong, an error is thrown
-    if err != nil {
-        panic(fmt.Sprintf("cannot create new document: %e", err))
-    }
+	// if anything went wrong, an error is thrown
+	if err != nil {
+		panic(fmt.Sprintf("cannot create new document: %e", err))
+	}
 
-    var paths, schemas int
-    var errors []error
+	var paths, schemas int
+	var errors []error
 
-    // We don't know which type of document this is, so we can use the spec info to inform us
-    if document.GetSpecInfo().SpecType == utils.OpenApi3 {
-        v3Model, errs := document.BuildV3Model()
-        if len(errs) > 0 {
-            errors = errs
-        }
-        if len(errors) <= 0 {
-            paths = len(v3Model.Model.Paths.PathItems)
-            schemas = len(v3Model.Model.Components.Schemas)
-        }
-    }
-    if document.GetSpecInfo().SpecType == utils.OpenApi2 {
-        v2Model, errs := document.BuildV2Model()
-        if len(errs) > 0 {
-            errors = errs
-        }
-        if len(errors) <= 0 {
-            paths = len(v2Model.Model.Paths.PathItems)
-            schemas = len(v2Model.Model.Definitions.Definitions)
-        }
-    }
+	// We don't know which type of document this is, so we can use the spec info to inform us
+	if document.GetSpecInfo().SpecType == utils.OpenApi3 {
+		v3Model, errs := document.BuildV3Model()
+		if len(errs) > 0 {
+			errors = errs
+		}
+		if len(errors) <= 0 {
+			paths = len(v3Model.Model.Paths.PathItems)
+			schemas = len(v3Model.Model.Components.Schemas)
+		}
+	}
+	if document.GetSpecInfo().SpecType == utils.OpenApi2 {
+		v2Model, errs := document.BuildV2Model()
+		if len(errs) > 0 {
+			errors = errs
+		}
+		if len(errors) <= 0 {
+			paths = len(v2Model.Model.Paths.PathItems)
+			schemas = len(v2Model.Model.Definitions.Definitions)
+		}
+	}
 
-    // if anything went wrong when building the model, report errors.
-    if len(errors) > 0 {
-        for i := range errors {
-            fmt.Printf("error: %e\n", errors[i])
-        }
-        panic(fmt.Sprintf("cannot create v3 model from document: %d errors reported", len(errors)))
-    }
+	// if anything went wrong when building the model, report errors.
+	if len(errors) > 0 {
+		for i := range errors {
+			fmt.Printf("error: %e\n", errors[i])
+		}
+		panic(fmt.Sprintf("cannot create v3 model from document: %d errors reported", len(errors)))
+	}
 
-    // print the number of paths and schemas in the document
-    fmt.Printf("There are %d paths and %d schemas in the document", paths, schemas)
-    // Output: There are 5 paths and 6 schemas in the document
+	// print the number of paths and schemas in the document
+	fmt.Printf("There are %d paths and %d schemas in the document", paths, schemas)
+	// Output: There are 5 paths and 6 schemas in the document
 }
 
 func ExampleNewDocument_mutateValuesAndSerialize() {
 
-    // How to mutate values in an OpenAPI Specification, without re-ordering original content.
+	// How to mutate values in an OpenAPI Specification, without re-ordering original content.
 
-    // create very small, and useless spec that does nothing useful, except showcase this feature.
-    spec := `
+	// create very small, and useless spec that does nothing useful, except showcase this feature.
+	spec := `
 openapi: 3.1.0
 info:
   title: This is a title
@@ -347,155 +348,155 @@ info:
   license:
     url: http://some-place-on-the-internet.com/license
 `
-    // create a new document from specification bytes
-    document, err := NewDocument([]byte(spec))
+	// create a new document from specification bytes
+	document, err := NewDocument([]byte(spec))
 
-    // if anything went wrong, an error is thrown
-    if err != nil {
-        panic(fmt.Sprintf("cannot create new document: %e", err))
-    }
+	// if anything went wrong, an error is thrown
+	if err != nil {
+		panic(fmt.Sprintf("cannot create new document: %e", err))
+	}
 
-    // because we know this is a v3 spec, we can build a ready to go model from it.
-    v3Model, errors := document.BuildV3Model()
+	// because we know this is a v3 spec, we can build a ready to go model from it.
+	v3Model, errors := document.BuildV3Model()
 
-    // if anything went wrong when building the v3 model, a slice of errors will be returned
-    if len(errors) > 0 {
-        for i := range errors {
-            fmt.Printf("error: %e\n", errors[i])
-        }
-        panic(fmt.Sprintf("cannot create v3 model from document: %d errors reported", len(errors)))
-    }
+	// if anything went wrong when building the v3 model, a slice of errors will be returned
+	if len(errors) > 0 {
+		for i := range errors {
+			fmt.Printf("error: %e\n", errors[i])
+		}
+		panic(fmt.Sprintf("cannot create v3 model from document: %d errors reported", len(errors)))
+	}
 
-    // mutate the title, to do this we currently need to drop down to the low-level API.
-    v3Model.Model.GoLow().Info.Value.Title.Mutate("A new title for a useless spec")
+	// mutate the title, to do this we currently need to drop down to the low-level API.
+	v3Model.Model.GoLow().Info.Value.Title.Mutate("A new title for a useless spec")
 
-    // mutate the email address in the contact object.
-    v3Model.Model.GoLow().Info.Value.Contact.Value.Email.Mutate("buckaroo@pb33f.io")
+	// mutate the email address in the contact object.
+	v3Model.Model.GoLow().Info.Value.Contact.Value.Email.Mutate("buckaroo@pb33f.io")
 
-    // mutate the name in the contact object.
-    v3Model.Model.GoLow().Info.Value.Contact.Value.Name.Mutate("Buckaroo")
+	// mutate the name in the contact object.
+	v3Model.Model.GoLow().Info.Value.Contact.Value.Name.Mutate("Buckaroo")
 
-    // mutate the URL for the license object.
-    v3Model.Model.GoLow().Info.Value.License.Value.URL.Mutate("https://pb33f.io/license")
+	// mutate the URL for the license object.
+	v3Model.Model.GoLow().Info.Value.License.Value.URL.Mutate("https://pb33f.io/license")
 
-    // serialize the document back into the original YAML or JSON
-    mutatedSpec, serialError := document.Serialize()
+	// serialize the document back into the original YAML or JSON
+	mutatedSpec, serialError := document.Serialize()
 
-    // if something went wrong serializing
-    if serialError != nil {
-        panic(fmt.Sprintf("cannot serialize document: %e", serialError))
-    }
+	// if something went wrong serializing
+	if serialError != nil {
+		panic(fmt.Sprintf("cannot serialize document: %e", serialError))
+	}
 
-    // print our modified spec!
-    fmt.Println(string(mutatedSpec))
-    // Output: openapi: 3.1.0
-    //info:
-    //     title: A new title for a useless spec
-    //     contact:
-    //         name: Buckaroo
-    //         email: buckaroo@pb33f.io
-    //     license:
-    //         url: https://pb33f.io/license
+	// print our modified spec!
+	fmt.Println(string(mutatedSpec))
+	// Output: openapi: 3.1.0
+	//info:
+	//     title: A new title for a useless spec
+	//     contact:
+	//         name: Buckaroo
+	//         email: buckaroo@pb33f.io
+	//     license:
+	//         url: https://pb33f.io/license
 }
 
 func ExampleCompareDocuments_openAPI() {
 
-    // How to compare two different OpenAPI specifications.
+	// How to compare two different OpenAPI specifications.
 
-    // load an original OpenAPI 3 specification from bytes
-    burgerShopOriginal, _ := ioutil.ReadFile("test_specs/burgershop.openapi.yaml")
+	// load an original OpenAPI 3 specification from bytes
+	burgerShopOriginal, _ := ioutil.ReadFile("test_specs/burgershop.openapi.yaml")
 
-    // load an **updated** OpenAPI 3 specification from bytes
-    burgerShopUpdated, _ := ioutil.ReadFile("test_specs/burgershop.openapi-modified.yaml")
+	// load an **updated** OpenAPI 3 specification from bytes
+	burgerShopUpdated, _ := ioutil.ReadFile("test_specs/burgershop.openapi-modified.yaml")
 
-    // create a new document from original specification bytes
-    originalDoc, err := NewDocument(burgerShopOriginal)
+	// create a new document from original specification bytes
+	originalDoc, err := NewDocument(burgerShopOriginal)
 
-    // if anything went wrong, an error is thrown
-    if err != nil {
-        panic(fmt.Sprintf("cannot create new document: %e", err))
-    }
+	// if anything went wrong, an error is thrown
+	if err != nil {
+		panic(fmt.Sprintf("cannot create new document: %e", err))
+	}
 
-    // create a new document from updated specification bytes
-    updatedDoc, err := NewDocument(burgerShopUpdated)
+	// create a new document from updated specification bytes
+	updatedDoc, err := NewDocument(burgerShopUpdated)
 
-    // if anything went wrong, an error is thrown
-    if err != nil {
-        panic(fmt.Sprintf("cannot create new document: %e", err))
-    }
+	// if anything went wrong, an error is thrown
+	if err != nil {
+		panic(fmt.Sprintf("cannot create new document: %e", err))
+	}
 
-    // Compare documents for all changes made
-    documentChanges, errs := CompareDocuments(originalDoc, updatedDoc)
+	// Compare documents for all changes made
+	documentChanges, errs := CompareDocuments(originalDoc, updatedDoc)
 
-    // If anything went wrong when building models for documents.
-    if len(errs) > 0 {
-        for i := range errs {
-            fmt.Printf("error: %e\n", errs[i])
-        }
-        panic(fmt.Sprintf("cannot compare documents: %d errors reported", len(errs)))
-    }
+	// If anything went wrong when building models for documents.
+	if len(errs) > 0 {
+		for i := range errs {
+			fmt.Printf("error: %e\n", errs[i])
+		}
+		panic(fmt.Sprintf("cannot compare documents: %d errors reported", len(errs)))
+	}
 
-    // Extract SchemaChanges from components changes.
-    schemaChanges := documentChanges.ComponentsChanges.SchemaChanges
+	// Extract SchemaChanges from components changes.
+	schemaChanges := documentChanges.ComponentsChanges.SchemaChanges
 
-    // Print out some interesting stats about the OpenAPI document changes.
-    fmt.Printf("There are %d changes, of which %d are breaking. %v schemas have changes.",
-        documentChanges.TotalChanges(), documentChanges.TotalBreakingChanges(), len(schemaChanges))
-    //Output: There are 67 changes, of which 17 are breaking. 5 schemas have changes.
+	// Print out some interesting stats about the OpenAPI document changes.
+	fmt.Printf("There are %d changes, of which %d are breaking. %v schemas have changes.",
+		documentChanges.TotalChanges(), documentChanges.TotalBreakingChanges(), len(schemaChanges))
+	//Output: There are 67 changes, of which 17 are breaking. 5 schemas have changes.
 
 }
 
 func ExampleCompareDocuments_swagger() {
 
-    // How to compare two different Swagger specifications.
+	// How to compare two different Swagger specifications.
 
-    // load an original OpenAPI 3 specification from bytes
-    petstoreOriginal, _ := ioutil.ReadFile("test_specs/petstorev2-complete.yaml")
+	// load an original OpenAPI 3 specification from bytes
+	petstoreOriginal, _ := ioutil.ReadFile("test_specs/petstorev2-complete.yaml")
 
-    // load an **updated** OpenAPI 3 specification from bytes
-    petstoreUpdated, _ := ioutil.ReadFile("test_specs/petstorev2-complete-modified.yaml")
+	// load an **updated** OpenAPI 3 specification from bytes
+	petstoreUpdated, _ := ioutil.ReadFile("test_specs/petstorev2-complete-modified.yaml")
 
-    // create a new document from original specification bytes
-    originalDoc, err := NewDocument(petstoreOriginal)
+	// create a new document from original specification bytes
+	originalDoc, err := NewDocument(petstoreOriginal)
 
-    // if anything went wrong, an error is thrown
-    if err != nil {
-        panic(fmt.Sprintf("cannot create new document: %e", err))
-    }
+	// if anything went wrong, an error is thrown
+	if err != nil {
+		panic(fmt.Sprintf("cannot create new document: %e", err))
+	}
 
-    // create a new document from updated specification bytes
-    updatedDoc, err := NewDocument(petstoreUpdated)
+	// create a new document from updated specification bytes
+	updatedDoc, err := NewDocument(petstoreUpdated)
 
-    // if anything went wrong, an error is thrown
-    if err != nil {
-        panic(fmt.Sprintf("cannot create new document: %e", err))
-    }
+	// if anything went wrong, an error is thrown
+	if err != nil {
+		panic(fmt.Sprintf("cannot create new document: %e", err))
+	}
 
-    // Compare documents for all changes made
-    documentChanges, errs := CompareDocuments(originalDoc, updatedDoc)
+	// Compare documents for all changes made
+	documentChanges, errs := CompareDocuments(originalDoc, updatedDoc)
 
-    // If anything went wrong when building models for documents.
-    if len(errs) > 0 {
-        for i := range errs {
-            fmt.Printf("error: %e\n", errs[i])
-        }
-        panic(fmt.Sprintf("cannot compare documents: %d errors reported", len(errs)))
-    }
+	// If anything went wrong when building models for documents.
+	if len(errs) > 0 {
+		for i := range errs {
+			fmt.Printf("error: %e\n", errs[i])
+		}
+		panic(fmt.Sprintf("cannot compare documents: %d errors reported", len(errs)))
+	}
 
-    // Extract SchemaChanges from components changes.
-    schemaChanges := documentChanges.ComponentsChanges.SchemaChanges
+	// Extract SchemaChanges from components changes.
+	schemaChanges := documentChanges.ComponentsChanges.SchemaChanges
 
-    // Print out some interesting stats about the Swagger document changes.
-    fmt.Printf("There are %d changes, of which %d are breaking. %v schemas have changes.",
-        documentChanges.TotalChanges(), documentChanges.TotalBreakingChanges(), len(schemaChanges))
-    //Output: There are 52 changes, of which 27 are breaking. 5 schemas have changes.
+	// Print out some interesting stats about the Swagger document changes.
+	fmt.Printf("There are %d changes, of which %d are breaking. %v schemas have changes.",
+		documentChanges.TotalChanges(), documentChanges.TotalBreakingChanges(), len(schemaChanges))
+	//Output: There are 52 changes, of which 27 are breaking. 5 schemas have changes.
 
 }
 
 func TestDocument_Paths_As_Array(t *testing.T) {
 
-    // paths can now be wrapped in an array.
-    spec := `{
+	// paths can now be wrapped in an array.
+	spec := `{
     "openapi": "3.1.0",
     "paths": [
         "/": {
@@ -504,24 +505,80 @@ func TestDocument_Paths_As_Array(t *testing.T) {
     ]
 }
 `
-    // create a new document from specification bytes
-    doc, err := NewDocument([]byte(spec))
+	// create a new document from specification bytes
+	doc, err := NewDocument([]byte(spec))
 
-    // if anything went wrong, an error is thrown
-    if err != nil {
-        panic(fmt.Sprintf("cannot create new document: %e", err))
-    }
-    v3Model, _ := doc.BuildV3Model()
-    assert.NotNil(t, v3Model)
+	// if anything went wrong, an error is thrown
+	if err != nil {
+		panic(fmt.Sprintf("cannot create new document: %e", err))
+	}
+	v3Model, _ := doc.BuildV3Model()
+	assert.NotNil(t, v3Model)
 }
 
 // If you want to know more about circular references that have been found
 // during the parsing/indexing/building of a document, you can capture the
 // []errors thrown which are pointers to *resolver.ResolvingError
-func ExampleNewDocument_circular_references() {
+func ExampleNewDocument_infinite_circular_references() {
 
-    // create a specification with an obvious and deliberate circular reference
-    spec := `openapi: "3.1"
+	// create a specification with an obvious and deliberate circular reference
+	spec := `openapi: "3.1"
+components:
+  schemas:
+    One:
+      description: "test one"
+      properties:
+        things:
+          "$ref": "#/components/schemas/Two"
+      required:
+        - things
+    Two:
+      description: "test two"
+      properties:
+        testThing:
+          "$ref": "#/components/schemas/One"
+      required:
+        - testThing
+`
+	// create a new document from specification bytes
+	doc, err := NewDocument([]byte(spec))
+
+	// if anything went wrong, an error is thrown
+	if err != nil {
+		panic(fmt.Sprintf("cannot create new document: %e", err))
+	}
+	_, errs := doc.BuildV3Model()
+
+	// extract resolving error
+	resolvingError := errs[0]
+
+	// resolving error is a pointer to *resolver.ResolvingError
+	// which provides access to rich details about the error.
+	circularReference := resolvingError.(*resolver.ResolvingError).CircularReference
+
+	// capture the journey with all details
+	var buf strings.Builder
+	for n := range circularReference.Journey {
+
+		// add the full definition name to the journey.
+		buf.WriteString(circularReference.Journey[n].Definition)
+		if n < len(circularReference.Journey)-1 {
+			buf.WriteString(" -> ")
+		}
+	}
+
+	// print out the journey and the loop point.
+	fmt.Printf("Journey: %s\n", buf.String())
+	fmt.Printf("Loop Point: %s", circularReference.LoopPoint.Definition)
+	// Output: Journey: #/components/schemas/Two -> #/components/schemas/One -> #/components/schemas/Two
+	// Loop Point: #/components/schemas/Two
+}
+
+// This tests checks that circular references which are _not_ marked as required pass correctly
+func TestNewDocument_terminable_circular_references(t *testing.T) {
+
+	// create a specification with an obvious and deliberate circular reference
+	spec := `openapi: "3.1"
 components:
   schemas:
     One:
@@ -535,38 +592,16 @@ components:
         testThing:
           "$ref": "#/components/schemas/One"
 `
-    // create a new document from specification bytes
-    doc, err := NewDocument([]byte(spec))
+	// create a new document from specification bytes
+	doc, err := NewDocument([]byte(spec))
 
-    // if anything went wrong, an error is thrown
-    if err != nil {
-        panic(fmt.Sprintf("cannot create new document: %e", err))
-    }
-    _, errs := doc.BuildV3Model()
+	// if anything went wrong, an error is thrown
+	if err != nil {
+		panic(fmt.Sprintf("cannot create new document: %e", err))
+	}
+	_, errs := doc.BuildV3Model()
 
-    // extract resolving error
-    resolvingError := errs[0]
-
-    // resolving error is a pointer to *resolver.ResolvingError
-    // which provides access to rich details about the error.
-    circularReference := resolvingError.(*resolver.ResolvingError).CircularReference
-
-    // capture the journey with all details
-    var buf strings.Builder
-    for n := range circularReference.Journey {
-
-        // add the full definition name to the journey.
-        buf.WriteString(circularReference.Journey[n].Definition)
-        if n < len(circularReference.Journey)-1 {
-            buf.WriteString(" -> ")
-        }
-    }
-
-    // print out the journey and the loop point.
-    fmt.Printf("Journey: %s\n", buf.String())
-    fmt.Printf("Loop Point: %s", circularReference.LoopPoint.Definition)
-    // Output: Journey: #/components/schemas/Two -> #/components/schemas/One -> #/components/schemas/Two
-    // Loop Point: #/components/schemas/Two
+	assert.Len(t, errs, 0)
 }
 
 // If you're using complex types with OpenAPI Extensions, it's simple to unpack extensions into complex
@@ -576,33 +611,33 @@ components:
 // This example demonstrates how to use the `UnpackExtensions` with custom OpenAPI extensions.
 func ExampleNewDocument_unpacking_extensions() {
 
-    // define an example struct representing a cake
-    type cake struct {
-        Candles               int    `yaml:"candles"`
-        Frosting              string `yaml:"frosting"`
-        Some_Strange_Var_Name string `yaml:"someStrangeVarName"`
-    }
+	// define an example struct representing a cake
+	type cake struct {
+		Candles               int    `yaml:"candles"`
+		Frosting              string `yaml:"frosting"`
+		Some_Strange_Var_Name string `yaml:"someStrangeVarName"`
+	}
 
-    // define a struct that holds a map of cake pointers.
-    type cakes struct {
-        Description string
-        Cakes       map[string]*cake
-    }
+	// define a struct that holds a map of cake pointers.
+	type cakes struct {
+		Description string
+		Cakes       map[string]*cake
+	}
 
-    // define a struct representing a burger
-    type burger struct {
-        Sauce string
-        Patty string
-    }
+	// define a struct representing a burger
+	type burger struct {
+		Sauce string
+		Patty string
+	}
 
-    // define a struct that holds a map of cake pointers
-    type burgers struct {
-        Description string
-        Burgers     map[string]*burger
-    }
+	// define a struct that holds a map of cake pointers
+	type burgers struct {
+		Description string
+		Burgers     map[string]*burger
+	}
 
-    // create a specification with a schema and parameter that use complex custom cakes and burgers extensions.
-    spec := `openapi: "3.1"
+	// create a specification with a schema and parameter that use complex custom cakes and burgers extensions.
+	spec := `openapi: "3.1"
 components:
   schemas:
     SchemaOne:
@@ -629,62 +664,61 @@ components:
           anotherBurger:
             sauce: mayo
             patty: lamb`
-    // create a new document from specification bytes
-    doc, err := NewDocument([]byte(spec))
+	// create a new document from specification bytes
+	doc, err := NewDocument([]byte(spec))
 
-    // if anything went wrong, an error is thrown
-    if err != nil {
-        panic(fmt.Sprintf("cannot create new document: %e", err))
-    }
+	// if anything went wrong, an error is thrown
+	if err != nil {
+		panic(fmt.Sprintf("cannot create new document: %e", err))
+	}
 
-    // build a v3 model.
-    docModel, errs := doc.BuildV3Model()
+	// build a v3 model.
+	docModel, errs := doc.BuildV3Model()
 
-    // if anything went wrong building, indexing and resolving the model, an error is thrown
-    if errs != nil {
-        panic(fmt.Sprintf("cannot create new document: %e", err))
-    }
+	// if anything went wrong building, indexing and resolving the model, an error is thrown
+	if errs != nil {
+		panic(fmt.Sprintf("cannot create new document: %e", err))
+	}
 
-    // get a reference to SchemaOne and ParameterOne
-    schemaOne := docModel.Model.Components.Schemas["SchemaOne"].Schema()
-    parameterOne := docModel.Model.Components.Parameters["ParameterOne"]
+	// get a reference to SchemaOne and ParameterOne
+	schemaOne := docModel.Model.Components.Schemas["SchemaOne"].Schema()
+	parameterOne := docModel.Model.Components.Parameters["ParameterOne"]
 
-    // unpack schemaOne extensions into complex `cakes` type
-    schemaOneExtensions, schemaUnpackErrors := high.UnpackExtensions[cakes, *low.Schema](schemaOne)
-    if schemaUnpackErrors != nil {
-        panic(fmt.Sprintf("cannot unpack schema extensions: %e", err))
-    }
+	// unpack schemaOne extensions into complex `cakes` type
+	schemaOneExtensions, schemaUnpackErrors := high.UnpackExtensions[cakes, *low.Schema](schemaOne)
+	if schemaUnpackErrors != nil {
+		panic(fmt.Sprintf("cannot unpack schema extensions: %e", err))
+	}
 
-    // unpack parameterOne into complex `burgers` type
-    parameterOneExtensions, paramUnpackErrors := high.UnpackExtensions[burgers, *v3.Parameter](parameterOne)
-    if paramUnpackErrors != nil {
-        panic(fmt.Sprintf("cannot unpack parameter extensions: %e", err))
-    }
+	// unpack parameterOne into complex `burgers` type
+	parameterOneExtensions, paramUnpackErrors := high.UnpackExtensions[burgers, *v3.Parameter](parameterOne)
+	if paramUnpackErrors != nil {
+		panic(fmt.Sprintf("cannot unpack parameter extensions: %e", err))
+	}
 
-    // extract extension by name for schemaOne
-    customCakes := schemaOneExtensions["x-custom-cakes"]
+	// extract extension by name for schemaOne
+	customCakes := schemaOneExtensions["x-custom-cakes"]
 
-    // extract extension by name for schemaOne
-    customBurgers := parameterOneExtensions["x-custom-burgers"]
+	// extract extension by name for schemaOne
+	customBurgers := parameterOneExtensions["x-custom-burgers"]
 
-    // print out schemaOne complex extension details.
-    fmt.Printf("schemaOne 'x-custom-cakes' (%s) has %d cakes, 'someCake' has %d candles and %s frosting\n",
-        customCakes.Description,
-        len(customCakes.Cakes),
-        customCakes.Cakes["someCake"].Candles,
-        customCakes.Cakes["someCake"].Frosting,
-    )
+	// print out schemaOne complex extension details.
+	fmt.Printf("schemaOne 'x-custom-cakes' (%s) has %d cakes, 'someCake' has %d candles and %s frosting\n",
+		customCakes.Description,
+		len(customCakes.Cakes),
+		customCakes.Cakes["someCake"].Candles,
+		customCakes.Cakes["someCake"].Frosting,
+	)
 
-    // print out parameterOne complex extension details.
-    fmt.Printf("parameterOne 'x-custom-burgers' (%s) has %d burgers, 'anotherBurger' has %s sauce and a %s patty\n",
-        customBurgers.Description,
-        len(customBurgers.Burgers),
-        customBurgers.Burgers["anotherBurger"].Sauce,
-        customBurgers.Burgers["anotherBurger"].Patty,
-    )
+	// print out parameterOne complex extension details.
+	fmt.Printf("parameterOne 'x-custom-burgers' (%s) has %d burgers, 'anotherBurger' has %s sauce and a %s patty\n",
+		customBurgers.Description,
+		len(customBurgers.Burgers),
+		customBurgers.Burgers["anotherBurger"].Sauce,
+		customBurgers.Burgers["anotherBurger"].Patty,
+	)
 
-    // Output: schemaOne 'x-custom-cakes' (some cakes) has 2 cakes, 'someCake' has 10 candles and blue frosting
-    //parameterOne 'x-custom-burgers' (some burgers) has 2 burgers, 'anotherBurger' has mayo sauce and a lamb patty
+	// Output: schemaOne 'x-custom-cakes' (some cakes) has 2 cakes, 'someCake' has 10 candles and blue frosting
+	//parameterOne 'x-custom-burgers' (some burgers) has 2 burgers, 'anotherBurger' has mayo sauce and a lamb patty
 
 }
-

--- a/index/circular_reference_result.go
+++ b/index/circular_reference_result.go
@@ -9,15 +9,21 @@ type CircularReferenceResult struct {
 	LoopIndex           int
 	LoopPoint           *Reference
 	IsPolymorphicResult bool // if this result comes from a polymorphic loop.
+	IsInfiniteLoop      bool // if all the definitions in the reference loop are marked as required, this is an infinite circular reference, thus is not allowed.
 }
 
 func (c *CircularReferenceResult) GenerateJourneyPath() string {
 	buf := strings.Builder{}
 	for i, ref := range c.Journey {
-		buf.WriteString(ref.Name)
-		if i+1 < len(c.Journey) {
+		if i > 0 {
 			buf.WriteString(" -> ")
 		}
+
+		buf.WriteString(ref.Name)
+		// buf.WriteString(" (")
+		// buf.WriteString(ref.Definition)
+		// buf.WriteString(")")
 	}
+
 	return buf.String()
 }

--- a/index/spec_index.go
+++ b/index/spec_index.go
@@ -1721,7 +1721,7 @@ func (index *SpecIndex) extractDefinitionRequiredRefProperties(schemaNode *yaml.
 		return reqRefProps
 	}
 
-	// If the path we're looking at is a direct ref to another model without any properties, mark it as required, but still continue to look for required properties
+	// If the node we're looking at is a direct ref to another model without any properties, mark it as required, but still continue to look for required properties
 	isRef, _, defPath := utils.IsNodeRefValue(schemaNode)
 	if isRef {
 		if _, ok := reqRefProps[defPath]; !ok {

--- a/index/spec_index.go
+++ b/index/spec_index.go
@@ -1721,12 +1721,12 @@ func (index *SpecIndex) extractDefinitionRequiredRefProperties(schemaNode *yaml.
 		return reqRefProps
 	}
 
-	_, requiredSeqNode := utils.FindKeyNode("required", schemaNode.Content)
+	_, requiredSeqNode := utils.FindKeyNodeTop("required", schemaNode.Content)
 	if requiredSeqNode == nil {
 		return reqRefProps
 	}
 
-	_, propertiesMapNode := utils.FindKeyNode("properties", schemaNode.Content)
+	_, propertiesMapNode := utils.FindKeyNodeTop("properties", schemaNode.Content)
 	if propertiesMapNode == nil {
 		// TODO: Log a warning on the resolver, because if you have required properties, but no actual properties, something is wrong
 		return reqRefProps
@@ -1739,13 +1739,13 @@ func (index *SpecIndex) extractDefinitionRequiredRefProperties(schemaNode *yaml.
 			continue
 		}
 
-		_, paramPropertiesMapNode := utils.FindKeyNode("properties", param.Content)
+		_, paramPropertiesMapNode := utils.FindKeyNodeTop("properties", param.Content)
 		if paramPropertiesMapNode != nil {
 			reqRefProps = index.extractDefinitionRequiredRefProperties(param, reqRefProps)
 		}
 
 		for _, key := range []string{"allOf", "oneOf", "anyOf"} {
-			_, ofNode := utils.FindKeyNode(key, param.Content)
+			_, ofNode := utils.FindKeyNodeTop(key, param.Content)
 			if ofNode != nil {
 				for _, ofNodeItem := range ofNode.Content {
 					reqRefProps = index.extractRequiredReferenceProperties(ofNodeItem, name, reqRefProps)
@@ -1755,7 +1755,7 @@ func (index *SpecIndex) extractDefinitionRequiredRefProperties(schemaNode *yaml.
 	}
 
 	for _, requiredPropertyNode := range requiredSeqNode.Content {
-		_, requiredPropDefNode := utils.FindKeyNode(requiredPropertyNode.Value, propertiesMapNode.Content)
+		_, requiredPropDefNode := utils.FindKeyNodeTop(requiredPropertyNode.Value, propertiesMapNode.Content)
 		if requiredPropDefNode == nil {
 			continue
 		}
@@ -1770,7 +1770,7 @@ func (index *SpecIndex) extractDefinitionRequiredRefProperties(schemaNode *yaml.
 func (index *SpecIndex) extractRequiredReferenceProperties(requiredPropDefNode *yaml.Node, propName string, reqRefProps map[string][]string) map[string][]string {
 	isRef, _, defPath := utils.IsNodeRefValue(requiredPropDefNode)
 	if !isRef {
-		_, defItems := utils.FindKeyNode("items", requiredPropDefNode.Content)
+		_, defItems := utils.FindKeyNodeTop("items", requiredPropDefNode.Content)
 		if defItems != nil {
 			isRef, _, defPath = utils.IsNodeRefValue(defItems)
 		}

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -169,6 +169,7 @@ components:
 	assert.Len(t, circ, 0)
 }
 
+// TODO: Test for remote and file references with the option switched on and off
 func TestResolver_ResolveComponents_MixedRef(t *testing.T) {
 	mixedref, _ := ioutil.ReadFile("../test_specs/mixedref-burgershop.openapi.yaml")
 	var rootNode yaml.Node
@@ -180,6 +181,7 @@ func TestResolver_ResolveComponents_MixedRef(t *testing.T) {
 	assert.NotNil(t, resolver)
 
 	circ := resolver.Resolve()
+	// TODO: This file seems to import correctly now, but the test fails as it's expecting 10 errors
 	assert.Len(t, circ, 10)
 }
 

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -1,6 +1,7 @@
 package resolver
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"testing"
@@ -225,4 +226,19 @@ func ExampleNewResolver() {
 	fmt.Printf("There are %d circular reference errors, %d of them are polymorphic errors, %d are not",
 		len(circularErrors), len(resolver.GetPolymorphicCircularErrors()), len(resolver.GetNonPolymorphicCircularErrors()))
 	// Output: There are 3 circular reference errors, 0 of them are polymorphic errors, 3 are not
+}
+
+func ExampleResolvingError() {
+	re := ResolvingError{
+		ErrorRef: errors.New("Je suis une erreur"),
+		Node: &yaml.Node{
+			Line:   5,
+			Column: 21,
+		},
+		Path:              "#/definitions/JeSuisUneErreur",
+		CircularReference: &index.CircularReferenceResult{},
+	}
+
+	fmt.Printf("%s", re.Error())
+	// Output: Je suis une erreur: #/definitions/JeSuisUneErreur [5:21]
 }

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -181,7 +181,6 @@ func TestResolver_ResolveComponents_MixedRef(t *testing.T) {
 	assert.NotNil(t, resolver)
 
 	circ := resolver.Resolve()
-	// TODO: This file seems to import correctly now, but the test fails as it's expecting 10 errors
 	assert.Len(t, circ, 10)
 }
 

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -119,7 +119,7 @@ func TestResolver_ResolveComponents_Stripe(t *testing.T) {
 	assert.Len(t, circ, 3)
 
 	assert.Len(t, resolver.GetNonPolymorphicCircularErrors(), 3)
-	assert.Len(t, resolver.GetPolymorphicCircularErrors(), 20)
+	assert.Len(t, resolver.GetPolymorphicCircularErrors(), 0)
 }
 
 func TestResolver_ResolveComponents_BurgerShop(t *testing.T) {
@@ -225,5 +225,5 @@ func ExampleNewResolver() {
 	//
 	fmt.Printf("There are %d circular reference errors, %d of them are polymorphic errors, %d are not",
 		len(circularErrors), len(resolver.GetPolymorphicCircularErrors()), len(resolver.GetNonPolymorphicCircularErrors()))
-	// Output: There are 23 circular reference errors, 20 of them are polymorphic errors, 3 are not
+	// Output: There are 3 circular reference errors, 0 of them are polymorphic errors, 3 are not
 }

--- a/test_specs/circular-tests.yaml
+++ b/test_specs/circular-tests.yaml
@@ -14,6 +14,8 @@ components:
       properties:
         things:
           "$ref": "#/components/schemas/Two"
+      required:
+        - things
     Two:
       description: "test two"
       properties:
@@ -21,6 +23,9 @@ components:
           "$ref": "#/components/schemas/One"
         anyOf:
           - "$ref": "#/components/schemas/Four"
+      required:
+        - testThing
+        - anyOf
     Three:
       description: "test three"
       properties:
@@ -30,30 +35,40 @@ components:
           "$ref": "#/components/schemas/Seven"
         yester:
           "$ref": "#/components/schemas/Seven"
+      required:
+        - tester
+        - bester
+        - yester
     Four:
       description: "test four"
       properties:
         lemons:
           "$ref": "#/components/schemas/Nine"
+      required:
+        - lemons
     Five:
       properties:
         rice:
           "$ref": "#/components/schemas/Six"
+      required:
+        - rice
     Six:
       properties:
         mints:
           "$ref": "#/components/schemas/Nine"
+      required:
+        - mints
     Seven:
       properties:
         wow:
           "$ref": "#/components/schemas/Three"
+      required:
+        - wow
     Nine:
       description: done.
     Ten:
       properties:
         yeah:
           "$ref": "#/components/schemas/Ten"
-
-
-
-
+      required:
+        - yeah

--- a/test_specs/swagger-circular-tests.yaml
+++ b/test_specs/swagger-circular-tests.yaml
@@ -12,11 +12,15 @@ definitions:
     properties:
       things:
         "$ref": "#/definitions/Two"
+    required:
+      - things
   Two:
     description: "test two"
     properties:
       testThing:
         "$ref": "#/definitions/One"
+    required:
+      - testThing
   Three:
     description: "test three"
     properties:
@@ -26,26 +30,40 @@ definitions:
         "$ref": "#/definitions/Seven"
       yester:
         "$ref": "#/definitions/Seven"
+    required:
+      - tester
+      - bester
+      - yester
   Four:
     description: "test four"
     properties:
       lemons:
         "$ref": "#/definitions/Nine"
+    required:
+      - lemons
   Five:
     properties:
       rice:
         "$ref": "#/definitions/Six"
+    required:
+      - rice
   Six:
     properties:
       mints:
         "$ref": "#/definitions/Nine"
+    required:
+      - mints
   Seven:
     properties:
       wow:
         "$ref": "#/definitions/Three"
+    required:
+      - wow
   Nine:
     description: done.
   Ten:
     properties:
       yeah:
         "$ref": "#/definitions/Ten"
+    required:
+      - yeah

--- a/test_specs/swagger-invalid-recursive-model.yaml
+++ b/test_specs/swagger-invalid-recursive-model.yaml
@@ -1,0 +1,99 @@
+schemes:
+  - https
+securityDefinitions:
+  api_token:
+    type: apiKey
+    in: header
+    name: Swagger-Token
+definitions:
+  BaseModel:
+    description: BaseModel is the top-level definition in this example
+    type: object
+    properties:
+      directChildren:
+        description: A nested array of direct recursive models.
+        type: array
+        items:
+          $ref: '#/definitions/DirectRecursiveModel'
+      indirectChildren:
+        description: A nested array of indirect recursive models.
+        type: array
+        items:
+          $ref: '#/definitions/IndirectRecursiveModelOne'
+    additionalProperties: false
+    required:
+      - directChildren
+      - indirectChildren
+  DirectRecursiveModel:
+    description: DirectRecursiveModel is a nested model which can optionally contain itself.
+    type: object
+    properties:
+      children:
+        description: A nested array of direct recursive models.
+        type: array
+        items:
+          $ref: '#/definitions/DirectRecursiveModel'
+    additionalProperties: false
+    required:
+      - children
+  IndirectRecursiveModelOne:
+    description: IndirectRecursiveModelOne is a nested model which can optionally contain IndirectRecursiveModelTwo.
+    type: object
+    properties:
+      children:
+        description: A nested array of indirect recursive models.
+        type: array
+        items:
+          $ref: '#/definitions/IndirectRecursiveModelTwo'
+    additionalProperties: false
+    required:
+      - children
+  IndirectRecursiveModelTwo:
+    description: IndirectRecursiveModelTwo is a nested model which can optionally contain IndirectRecursiveModelOne.
+    type: object
+    properties:
+      children:
+        description: A nested array of indirect recursive models.
+        type: array
+        items:
+          $ref: '#/definitions/IndirectRecursiveModelOne'
+    additionalProperties: false
+    required:
+      - children
+security:
+  - api_token: []
+produces:
+  - application/json
+paths:
+  /baseModels:
+    post:
+      parameters:
+        - in: body
+          name: BaseModel
+          description: ''
+          required: true
+          schema:
+            $ref: '#/definitions/BaseModel'
+      responses:
+        '201':
+          schema:
+            $ref: '#/definitions/BaseModel'
+          description: Resource
+        '400':
+          description: Schema mismatch
+        '404':
+          description: Resource does not exist
+        '422':
+          description: Unprocessable
+      operationId: createBaseModel
+      description: Create BaseModel allows you to create a new BaseModel
+      summary: Create BaseModel
+consumes:
+  - application/json
+host: api.app.example.com
+info:
+  title: Invalid Recursive Definition Example
+  version: '1.0'
+  description: This example contains recursive model definitions which are invalid because their "children", "directChildren", and "indirectChildren" properties are all marked as required.
+swagger: '2.0'
+basePath: /

--- a/test_specs/swagger-valid-recursive-model.yaml
+++ b/test_specs/swagger-valid-recursive-model.yaml
@@ -1,0 +1,93 @@
+schemes:
+  - https
+securityDefinitions:
+  api_token:
+    type: apiKey
+    in: header
+    name: Swagger-Token
+definitions:
+  BaseModel:
+    description: BaseModel is the top-level definition in this example
+    type: object
+    properties:
+      directChildren:
+        description: A nested array of direct recursive models.
+        type: array
+        items:
+          $ref: '#/definitions/DirectRecursiveModel'
+      indirectChildren:
+        description: A nested array of indirect recursive models.
+        type: array
+        items:
+          $ref: '#/definitions/IndirectRecursiveModelOne'
+    additionalProperties: false
+    required:
+      - directChildren
+      - indirectChildren
+  DirectRecursiveModel:
+    description: DirectRecursiveModel is a nested model which can optionally contain itself.
+    type: object
+    properties:
+      children:
+        description: A nested array of direct recursive models.
+        type: array
+        items:
+          $ref: '#/definitions/DirectRecursiveModel'
+    additionalProperties: false
+  IndirectRecursiveModelOne:
+    description: IndirectRecursiveModelOne is a nested model which can optionally contain IndirectRecursiveModelTwo.
+    type: object
+    properties:
+      children:
+        description: A nested array of indirect recursive models.
+        type: array
+        items:
+          $ref: '#/definitions/IndirectRecursiveModelTwo'
+    additionalProperties: false
+  IndirectRecursiveModelTwo:
+    description: IndirectRecursiveModelTwo is a nested model which can optionally contain IndirectRecursiveModelOne.
+    type: object
+    properties:
+      children:
+        description: A nested array of indirect recursive models.
+        type: array
+        items:
+          $ref: '#/definitions/IndirectRecursiveModelOne'
+    additionalProperties: false
+security:
+  - api_token: []
+produces:
+  - application/json
+paths:
+  /baseModels:
+    post:
+      parameters:
+        - in: body
+          name: BaseModel
+          description: ''
+          required: true
+          schema:
+            $ref: '#/definitions/BaseModel'
+      responses:
+        '201':
+          schema:
+            $ref: '#/definitions/BaseModel'
+          description: Resource
+        '400':
+          description: Schema mismatch
+        '404':
+          description: Resource does not exist
+        '422':
+          description: Unprocessable
+      operationId: createBaseModel
+      description: Create BaseModel allows you to create a new BaseModel
+      summary: Create BaseModel
+consumes:
+  - application/json
+host: api.app.example.com
+info:
+  title: Valid Recursive Definition Example
+  version: '1.0'
+  description: This example contains a recursive model definition which is valid because DirectRecursiveModel's "children" property is optional.
+swagger: '2.0'
+basePath: /

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -405,6 +405,12 @@ func IsNodeRefValue(node *yaml.Node) (bool, *yaml.Node, string) {
 
 // IsPropertyNodeRequired will check if a node is required within circular references
 func IsPropertyNodeRequired(node *yaml.Node, propertyName string) bool {
+	// If the node we're looking at is a direct ref to another model without any properties, mark it as required
+	isRef, _, _ := IsNodeRefValue(node)
+	if isRef {
+		return true
+	}
+
 	_, requiredSeqNode := FindKeyNodeTop("required", node.Content)
 	if requiredSeqNode == nil {
 		return false

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -405,18 +405,18 @@ func IsNodeRefValue(node *yaml.Node) (bool, *yaml.Node, string) {
 
 // IsPropertyNodeRequired will check if a node is required within circular references
 func IsPropertyNodeRequired(node *yaml.Node, propertyName string) bool {
-	_, requiredSeqNode := FindKeyNode("required", node.Content)
+	_, requiredSeqNode := FindKeyNodeTop("required", node.Content)
 	if requiredSeqNode == nil {
 		return false
 	}
 
-	_, propertiesMapNode := FindKeyNode("properties", node.Content)
+	_, propertiesMapNode := FindKeyNodeTop("properties", node.Content)
 	if propertiesMapNode == nil {
 		return false
 	}
 
 	for _, requiredPropertyNode := range requiredSeqNode.Content {
-		_, requiredPropDefNode := FindKeyNode(requiredPropertyNode.Value, propertiesMapNode.Content)
+		_, requiredPropDefNode := FindKeyNodeTop(requiredPropertyNode.Value, propertiesMapNode.Content)
 		if requiredPropDefNode == nil {
 			continue
 		}
@@ -426,7 +426,7 @@ func IsPropertyNodeRequired(node *yaml.Node, propertyName string) bool {
 			return true
 		}
 
-		_, defItems := FindKeyNode("items", requiredPropDefNode.Content)
+		_, defItems := FindKeyNodeTop("items", requiredPropDefNode.Content)
 		if defItems == nil {
 			continue
 		}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -403,49 +403,6 @@ func IsNodeRefValue(node *yaml.Node) (bool, *yaml.Node, string) {
 	return false, nil, ""
 }
 
-// IsPropertyNodeRequired will check if a node is required within circular references
-func IsPropertyNodeRequired(node *yaml.Node, propertyName string) bool {
-	// If the node we're looking at is a direct ref to another model without any properties, mark it as required
-	isRef, _, _ := IsNodeRefValue(node)
-	if isRef {
-		return true
-	}
-
-	_, requiredSeqNode := FindKeyNodeTop("required", node.Content)
-	if requiredSeqNode == nil {
-		return false
-	}
-
-	_, propertiesMapNode := FindKeyNodeTop("properties", node.Content)
-	if propertiesMapNode == nil {
-		return false
-	}
-
-	for _, requiredPropertyNode := range requiredSeqNode.Content {
-		_, requiredPropDefNode := FindKeyNodeTop(requiredPropertyNode.Value, propertiesMapNode.Content)
-		if requiredPropDefNode == nil {
-			continue
-		}
-
-		isRef, _, defPath := IsNodeRefValue(requiredPropDefNode)
-		if isRef && defPath == propertyName {
-			return true
-		}
-
-		_, defItems := FindKeyNodeTop("items", requiredPropDefNode.Content)
-		if defItems == nil {
-			continue
-		}
-
-		isRef, _, defPath = IsNodeRefValue(defItems)
-		if isRef && defPath == propertyName {
-			return true
-		}
-	}
-
-	return false
-}
-
 // FixContext will clean up a JSONpath string to be correctly traversable.
 func FixContext(context string) string {
 	tokens := strings.Split(context, ".")


### PR DESCRIPTION
This PR contains an initial fix for pb33f/libopenapi#49.

It adds the following features to the library:

* `index.CircularReferenceResult.IsInfiniteLoop` - Set to true if each definition in the journey is marked as required
* `index.Reference.RequiredRefProperties` - Contains a map of definition references to the property name(s) which use it

`resolver.Resolver.CheckForCircularReferences()` and `resolver.Resolver.Resolve()` now check for `circRef.IsInfiniteLoop` when iterating through `resolver.Resolver.circularReferences`. If the value is `false`, then this is now accepted and no error is added to `resolver.Resolver.resolvingErrors`, as optional items within circular references allow a termination point, thus it's a valid spec.

## Areas for further improvement

### Remote and file refs

I noticed whilst reading through the code that it will automatically load references from remote URLs should they exist in the specs (eg, as shown in `mixedref-burgershop.openapi.yaml`. This is a potential security hole, and should be switched off by default, exposed via an option either passed in to `resolver.NewResolver()`, or set via a receiver function, eg `resolver.Resolver.SetAllowRemoteReferences(true)`. This should probably also be done for file refs as well. The fiasco with `log4j` ([CVE-2021-44228](https://nvd.nist.gov/vuln/detail/CVE-2021-44228)) happened because exactly this sort of on-by-default behaviour, so I think we should learn from their mistake!

### Option to treat errors as warnings

Currently, circular references where the whole chain is marked as required cause a hard error, and the spec doesn't import, however they _are_ theoretically loadable since subschemas are only built on request. I've tested this by commenting out the loops in `resolver.Resolver.Resolve()` and `resolver.Resolver.CheckForCircularReferences()`, and the Stripe spec successfully imports into our system.

## Tests

I've added two additional files to `test_specs`:
* `swagger-invalid-recursive-model.yaml` - Contains a minimal *invalid* Swagger 2.0 example (based on the Shortcut spec) where each child reference is marked as required
* `swagger-valid-recursive-model.yaml` - Contains a minimal *valid* Swagger 2.0 example (also based on the Shortcut spec) where each child reference is optional

The Stripe test was expecting 23 errors, however 20 of these were terminable loops, thus are now valid. The remaining three are:

```plain
#/components/schemas/payment_intent
  -> #/components/schemas/payment_intent
  -> #/components/schemas/customer
  -> #/components/schemas/invoice_setting_customer_setting
  -> #/components/schemas/payment_method
  -> #/components/schemas/payment_method_card
  -> #/components/schemas/payment_method_card_generated_card
  -> #/components/schemas/setup_attempt
  -> #/components/schemas/api_errors
  -> #/components/schemas/payment_intent
```

```plain
#/components/schemas/balance_transaction
  -> #/components/schemas/dispute
  -> #/components/schemas/balance_transaction
```

```plain
#/components/schemas/transfer_reversal
  -> #/components/schemas/transfer
  -> #/components/schemas/transfer_reversal
```

Thus, I've updated the Stripe test to expect these three invalid circular references, as the others are all valid since they can all terminate at least once in the chain.

### TestResolver_ResolveComponents_MixedRef

This test is currently failing in `main`. I've added a couple of TODOs around it relating to the remote refs note above, and the line which is causing the failing test. I did have a look into what's going on, but I'm not sure what the expected 10 errors would've been, so have left it in its current state.

Shoutout to @taylow for helping with this. :)