### PR TITLE
Fix ref object parsing

### DIFF
--- a/datamodel/low/base/schema.go
+++ b/datamodel/low/base/schema.go
@@ -482,6 +482,11 @@ func (s *Schema) Build(root *yaml.Node, idx *index.SpecIndex) error {
 		}
 	}
 
+	// Build model using possibly dereferenced root
+	if err := low.BuildModel(root, s); err != nil {
+		return err
+	}
+
 	s.extractExtensions(root)
 
 	// determine schema type, singular (3.0) or multiple (3.1), use a variable value

--- a/datamodel/low/base/schema_proxy.go
+++ b/datamodel/low/base/schema_proxy.go
@@ -5,7 +5,7 @@ package base
 
 import (
 	"crypto/sha256"
-	"github.com/pb33f/libopenapi/datamodel/low"
+
 	"github.com/pb33f/libopenapi/index"
 	"github.com/pb33f/libopenapi/utils"
 	"gopkg.in/yaml.v3"
@@ -35,8 +35,8 @@ import (
 // and slow things down when building. By preventing recursion through every polymorphic item, building models is kept
 // fast and snappy, which is desired for realtime processing of specs.
 //
-//  - Q: Yeah, but, why not just use state to avoiding re-visiting seen polymorphic nodes?
-//  - A: It's slow, takes up memory and still has runaway potential in very, very long chains.
+//   - Q: Yeah, but, why not just use state to avoiding re-visiting seen polymorphic nodes?
+//   - A: It's slow, takes up memory and still has runaway potential in very, very long chains.
 //
 // 3. Short Circuit Errors.
 //
@@ -80,7 +80,6 @@ func (sp *SchemaProxy) Schema() *Schema {
 		return sp.rendered
 	}
 	schema := new(Schema)
-	_ = low.BuildModel(sp.vn, schema)
 	err := schema.Build(sp.vn, sp.idx)
 	if err != nil {
 		sp.buildError = err

--- a/test_specs/ref-followed.yaml
+++ b/test_specs/ref-followed.yaml
@@ -1,0 +1,37 @@
+openapi: 3.1.0
+info:
+  title: All scalar types
+  version: 1.0.0
+  description: These types used in testing
+servers:
+  - url: https://api.server.test/v1
+
+paths:
+  /test:
+    get:
+      operationId: 20CBF3CA-4F9F-455E-8A3E-3C2B2CD9849A
+      responses:
+        "200":
+          type: string
+          description: This is my schema that is great!
+
+components:
+  schemas:
+    FBSRef:
+      $ref: "#/components/schemas/FP"
+
+    FP:
+      type: string
+      description: Always use full F{
+      example: asd asd asd
+      pattern: '^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[\+-]\d{2}:\d{2})$'
+
+    UInt64:
+      type: integer
+      format: uint64
+      nullable: true
+      example: 1
+      minimum: 1
+
+    Byte:
+      $ref: "#/components/schemas/UInt64"


### PR DESCRIPTION
If schemas item is a `$ref` then it wasn't parsed using BuildModel.

This PR moves BuildModel to lo schema.Build and works on possible dereferenced root yaml node.