### PR TITLE
fix: callbacks not being populated in high model

### DIFF
--- a/datamodel/high/v3/operation.go
+++ b/datamodel/high/v3/operation.go
@@ -75,6 +75,13 @@ func NewOperation(operation *low.Operation) *Operation {
 	}
 	o.Servers = servers
 	o.Extensions = high.ExtractExtensions(operation.Extensions)
+	if !operation.Callbacks.IsEmpty() {
+		callbacks := make(map[string]*Callback)
+		for k, v := range operation.Callbacks.Value {
+			callbacks[k.Value] = NewCallback(v.Value)
+		}
+		o.Callbacks = callbacks
+	}
 	return o
 }
 

--- a/datamodel/high/v3/operation_test.go
+++ b/datamodel/high/v3/operation_test.go
@@ -4,12 +4,13 @@
 package v3
 
 import (
+	"testing"
+
 	"github.com/pb33f/libopenapi/datamodel/low"
 	v3 "github.com/pb33f/libopenapi/datamodel/low/v3"
 	"github.com/pb33f/libopenapi/index"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"
-	"testing"
 )
 
 // this test exists because the sample contract doesn't contain an
@@ -18,9 +19,20 @@ import (
 // create pointless test changes. So here is a standalone test. you know... for science.
 
 func TestOperation(t *testing.T) {
-
 	yml := `externalDocs:
-  url: https://pb33f.io`
+  url: https://pb33f.io
+callbacks:
+  testCallback:
+    '{$request.body#/callbackUrl}':
+      post:
+        requestBody:
+          content:
+            application/json:
+              schema:
+                type: object
+        responses:
+          '200':
+            description: OK`
 
 	var idxNode yaml.Node
 	_ = yaml.Unmarshal([]byte(yml), &idxNode)
@@ -34,5 +46,7 @@ func TestOperation(t *testing.T) {
 
 	assert.Equal(t, "https://pb33f.io", r.ExternalDocs.URL)
 	assert.Equal(t, 1, r.GoLow().ExternalDocs.KeyNode.Line)
-
+	assert.Contains(t, r.Callbacks, "testCallback")
+	assert.Contains(t, r.Callbacks["testCallback"].Expression, "{$request.body#/callbackUrl}")
+	assert.Equal(t, 3, r.GoLow().Callbacks.KeyNode.Line)
 }


### PR DESCRIPTION
addresses https://github.com/pb33f/libopenapi/issues/70