### PR TITLE
fix: DynamicValue in high model schema missing N value

### DIFF
--- a/datamodel/high/base/schema.go
+++ b/datamodel/high/base/schema.go
@@ -149,6 +149,7 @@ func NewSchema(schema *base.Schema) *Schema {
 	// if we're dealing with a 3.1 spec using an int
 	if !schema.ExclusiveMaximum.IsEmpty() && schema.ExclusiveMaximum.Value.IsB() {
 		s.ExclusiveMaximum = &DynamicValue[bool, int64]{
+			N: 1,
 			B: schema.ExclusiveMaximum.Value.B,
 		}
 	}
@@ -161,6 +162,7 @@ func NewSchema(schema *base.Schema) *Schema {
 	// if we're dealing with a 3.1 spec, using an int
 	if !schema.ExclusiveMinimum.IsEmpty() && schema.ExclusiveMinimum.Value.IsB() {
 		s.ExclusiveMinimum = &DynamicValue[bool, int64]{
+			N: 1,
 			B: schema.ExclusiveMinimum.Value.B,
 		}
 	}
@@ -418,7 +420,7 @@ func NewSchema(schema *base.Schema) *Schema {
 				KeyNode:   schema.Items.KeyNode,
 			}}}
 		} else {
-			items = &DynamicValue[*SchemaProxy, bool]{B: schema.Items.Value.B}
+			items = &DynamicValue[*SchemaProxy, bool]{N: 1, B: schema.Items.Value.B}
 		}
 	}
 	if !schema.PrefixItems.IsEmpty() {

--- a/datamodel/high/base/schema_test.go
+++ b/datamodel/high/base/schema_test.go
@@ -561,6 +561,7 @@ exclusiveMinimum: 5
 
 	value := int64(5)
 	assert.EqualValues(t, value, highSchema.ExclusiveMinimum.B)
+	assert.True(t, highSchema.ExclusiveMinimum.IsB())
 }
 
 func TestSchemaNumberMaximum(t *testing.T) {
@@ -594,6 +595,7 @@ exclusiveMaximum: 5
 
 	value := int64(5)
 	assert.EqualValues(t, value, highSchema.ExclusiveMaximum.B)
+	assert.True(t, highSchema.ExclusiveMaximum.IsB())
 }
 
 func TestSchema_Items_Boolean(t *testing.T) {


### PR DESCRIPTION
Found a small issue while upgrading to the latest libopenapi. The new `DynamicValue.N` field is not copied over from the low-level model, so for example `schema.ExclusiveMinimum.IsB()` will *always* return `false`. This PR fixes it and adds a small test to assert the values get set. For the boolean case it is left alone as `N` will default to zero.

Note: this is important as the exclusive minimum can be zero, in which case it's currently not possible to determine whether a value was set or which one was set.

Sorry for the delay in upgrading BTW, I got side-tracked shipping https://rest.sh/#/bulk