### PR TITLE
feat: Add index for getting all "schema" objects #50 (Breaking Change)

### DIFF
--- a/datamodel/low/extraction_functions.go
+++ b/datamodel/low/extraction_functions.go
@@ -31,7 +31,7 @@ func FindItemInMap[T any](item string, collection map[KeyReference[string]]Value
 // helper function to generate a list of all the things an index should be searched for.
 func generateIndexCollection(idx *index.SpecIndex) []func() map[string]*index.Reference {
 	return []func() map[string]*index.Reference{
-		idx.GetAllSchemas,
+		idx.GetAllComponentSchemas,
 		idx.GetMappedReferences,
 		idx.GetAllExternalDocuments,
 		idx.GetAllParameters,

--- a/document.go
+++ b/document.go
@@ -15,6 +15,7 @@ package libopenapi
 
 import (
 	"fmt"
+	"github.com/pb33f/libopenapi/index"
 
 	"github.com/pb33f/libopenapi/datamodel"
 	v2high "github.com/pb33f/libopenapi/datamodel/high/v2"
@@ -68,6 +69,7 @@ type document struct {
 // built from a parent Document.
 type DocumentModel[T v2high.Swagger | v3high.Document] struct {
 	Model T
+	Index *index.SpecIndex // index created from the document.
 }
 
 // NewDocument will create a new OpenAPI instance from an OpenAPI specification []byte array. If anything goes
@@ -133,6 +135,7 @@ func (d *document) BuildV2Model() (*DocumentModel[v2high.Swagger], []error) {
 	highDoc := v2high.NewSwaggerDocument(lowDoc)
 	return &DocumentModel[v2high.Swagger]{
 		Model: *highDoc,
+		Index: lowDoc.Index,
 	}, errs
 }
 
@@ -162,6 +165,7 @@ func (d *document) BuildV3Model() (*DocumentModel[v3high.Document], []error) {
 	highDoc := v3high.NewDocument(lowDoc)
 	return &DocumentModel[v3high.Document]{
 		Model: *highDoc,
+		Index: lowDoc.Index,
 	}, errs
 }
 

--- a/index/spec_index_test.go
+++ b/index/spec_index_test.go
@@ -191,7 +191,8 @@ func TestSpecIndex_BurgerShop(t *testing.T) {
 	assert.Equal(t, 6, index.pathCount)
 	assert.Equal(t, 6, index.GetPathCount())
 
-	assert.Equal(t, 6, len(index.GetAllSchemas()))
+	assert.Equal(t, 6, len(index.GetAllComponentSchemas()))
+	assert.Equal(t, 15, len(index.GetAllSchemas()))
 
 	assert.Equal(t, 34, len(index.GetAllSequencedReferences()))
 	assert.NotNil(t, index.GetSchemasNode())
@@ -833,19 +834,28 @@ func ExampleNewSpecIndex() {
 	fmt.Printf("There are %d references\n"+
 		"%d paths\n"+
 		"%d operations\n"+
-		"%d schemas\n"+
+		"%d component schemas\n"+
+		"%d inline schemas\n"+
+		"%d inline schemas that are objects or arrays\n"+
+		"%d total schemas\n"+
 		"%d enums\n"+
 		"%d polymorphic references",
 		len(index.GetAllCombinedReferences()),
 		len(index.GetAllPaths()),
 		index.GetOperationCount(),
+		len(index.GetAllComponentSchemas()),
+		len(index.GetAllInlineSchemas()),
+		len(index.GetAllInlineSchemaObjects()),
 		len(index.GetAllSchemas()),
 		len(index.GetAllEnums()),
 		len(index.GetPolyOneOfReferences())+len(index.GetPolyAnyOfReferences()))
 	// Output: There are 537 references
 	// 246 paths
 	// 402 operations
-	// 537 schemas
+	// 537 component schemas
+	// 1530 inline schemas
+	// 711 inline schemas that are objects or arrays
+	// 2067 total schemas
 	// 1516 enums
 	// 828 polymorphic references
 }

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -107,7 +107,7 @@ func (resolver *Resolver) Resolve() []*ResolvingError {
 		ref.Reference.Node.Content = resolver.VisitReference(ref.Reference, seenReferences, journey, true)
 	}
 
-	schemas := resolver.specIndex.GetAllSchemas()
+	schemas := resolver.specIndex.GetAllComponentSchemas()
 	for s, schemaRef := range schemas {
 		if mappedIndex[s] == nil {
 			seenReferences := make(map[string]bool)
@@ -152,7 +152,7 @@ func (resolver *Resolver) CheckForCircularReferences() []*ResolvingError {
 		resolver.VisitReference(ref.Reference, seenReferences, journey, false)
 	}
 
-	schemas := resolver.specIndex.GetAllSchemas()
+	schemas := resolver.specIndex.GetAllComponentSchemas()
 	for s, schemaRef := range schemas {
 		if mappedIndex[s] == nil {
 			seenReferences := make(map[string]bool)


### PR DESCRIPTION
There is new code that looks for inline `schema` definitions and collects them, as well as a further subset of references that are precisely `object` or `array` types. 

### This is a breaking change

The `index.GetAllSchemas()` method now returns a slice of *Reference pointers, rather than a map of them. The original behavior of `GetAllSchemas()` has been replaced with `GetAllComponentSchemas()` which retains the signature.

Two new additional methods `GetAllInlineSchemas()` and `GetAllInlineSchemaObjects()`. The former will return everything in the spec marked with `schema` that is not a reference. The latter will return everything the former does, except filtered down by `object` or `array` types.

Also, the index is now bubbled up through the document model. There isn't a simple way to get access to it. A small non breaking change that attaches a reference to the index, returned by `DocumentModel`