### PR TITLE
Fixed async issues with index #91

### DIFF
--- a/datamodel/low/v3/create_document.go
+++ b/datamodel/low/v3/create_document.go
@@ -8,6 +8,7 @@ import (
     "github.com/pb33f/libopenapi/index"
     "github.com/pb33f/libopenapi/resolver"
     "github.com/pb33f/libopenapi/utils"
+    "os"
     "sync"
 )
 
@@ -37,13 +38,17 @@ func createDocument(info *datamodel.SpecInfo, config *datamodel.DocumentConfigur
     version = low.NodeReference[string]{Value: versionNode.Value, KeyNode: labelNode, ValueNode: versionNode}
     doc := Document{Version: version}
 
+    // get current working directory
+    cwd, _ := os.Getwd()
+
     // build an index
     idx := index.NewSpecIndexWithConfig(info.RootNode, &index.SpecIndexConfig{
         BaseURL:           config.BaseURL,
+        BasePath:          cwd,
         AllowFileLookup:   config.AllowFileReferences,
         AllowRemoteLookup: config.AllowRemoteReferences,
     })
-     doc.Index = idx
+    doc.Index = idx
 
     var errs []error
 

--- a/index/extract_refs.go
+++ b/index/extract_refs.go
@@ -411,6 +411,7 @@ func (index *SpecIndex) ExtractComponentsFromRefs(refs []*Reference) []*Referenc
     for r := range refsToCheck {
         // expand our index of all mapped refs
         go locate(refsToCheck[r], r, mappedRefsInSequence)
+        //locate(refsToCheck[r], r, mappedRefsInSequence) // used for sync testing.
     }
 
     completedRefs := 0

--- a/index/find_component.go
+++ b/index/find_component.go
@@ -178,9 +178,7 @@ func (index *SpecIndex) lookupRemoteReference(ref string) (*yaml.Node, *yaml.Nod
 func (index *SpecIndex) lookupFileReference(ref string) (*yaml.Node, *yaml.Node, error) {
     // split string to remove file reference
     uri := strings.Split(ref, "#")
-
     file := strings.ReplaceAll(uri[0], "file:", "")
-
     filePath := filepath.Dir(file)
     fileName := filepath.Base(file)
 
@@ -188,7 +186,6 @@ func (index *SpecIndex) lookupFileReference(ref string) (*yaml.Node, *yaml.Node,
 
     if index.seenRemoteSources[file] != nil {
         parsedRemoteDocument = index.seenRemoteSources[file]
-
     } else {
 
         base := index.config.BasePath
@@ -306,7 +303,6 @@ func (index *SpecIndex) performExternalLookup(uri []string, componentId string,
 
             // cool, cool, lets index this spec also. This is a recursive action and will keep going
             // until all remote references have been found.
-
             var bp *url.URL
             var bd string
 
@@ -327,20 +323,18 @@ func (index *SpecIndex) performExternalLookup(uri []string, componentId string,
             }
             if bd != "" {
                 newBasePath = filepath.Dir(filepath.Join(bd, uri[0]))
-
             }
 
             if newUrl != nil || newBasePath != "" {
                 newConfig := &SpecIndexConfig{
                     BaseURL:  newUrl,
                     BasePath: newBasePath,
-
                     AllowRemoteLookup: index.config.AllowRemoteLookup,
                     AllowFileLookup:   index.config.AllowFileLookup,
                     seenRemoteSources: index.config.seenRemoteSources,
                     remoteLock:        index.config.remoteLock,
                 }
-
+                
                 var newIndex *SpecIndex
                 newIndex = NewSpecIndexWithConfig(newRoot, newConfig)
                 index.refLock.Lock()

--- a/index/spec_index.go
+++ b/index/spec_index.go
@@ -32,6 +32,9 @@ func NewSpecIndexWithConfig(rootNode *yaml.Node, config *SpecIndexConfig) *SpecI
 	}
 	config.remoteLock = &sync.Mutex{}
 	index.config = config
+	if rootNode == nil || len(rootNode.Content) <= 0 {
+		return index
+	}
 	boostrapIndexCollections(rootNode, index)
 	return createNewIndex(rootNode, index)
 }

--- a/index/spec_index_test.go
+++ b/index/spec_index_test.go
@@ -324,6 +324,33 @@ func TestSpecIndex_BurgerShop(t *testing.T) {
 	assert.Equal(t, 3, len(index.GetAllParametersFromOperations()))
 }
 
+func TestSpecIndex_GetAllParametersFromOperations(t *testing.T) {
+
+	yml := `openapi: 3.0.0
+servers:
+  - url: http://localhost:8080
+paths:
+  /test:
+    get:
+      parameters:
+        - name: action
+          in: query
+          schema:
+            type: string
+        - name: action
+          in: query
+          schema:
+            type: string`
+
+	var rootNode yaml.Node
+	_ = yaml.Unmarshal([]byte(yml), &rootNode)
+
+	index := NewSpecIndexWithConfig(&rootNode, CreateOpenAPIIndexConfig())
+
+	assert.Equal(t, 1, len(index.GetAllParametersFromOperations()))
+	assert.Equal(t, 1, len(index.GetOperationParametersIndexErrors()))
+}
+
 func TestSpecIndex_BurgerShop_AllTheComponents(t *testing.T) {
 	burgershop, _ := ioutil.ReadFile("../test_specs/all-the-components.yaml")
 	var rootNode yaml.Node

--- a/index/utility_methods.go
+++ b/index/utility_methods.go
@@ -433,7 +433,12 @@ func GenerateCleanSpecConfigBaseURL(baseURL *url.URL, dir string, includeFile bo
     if baseURL.Scheme != "" && !strings.HasPrefix(dir, "http") {
         p = fmt.Sprintf("%s://%s%s", baseURL.Scheme, baseURL.Host, cleanedPath)
     } else {
-        p = cleanedPath
+        if !strings.Contains(cleanedPath, "/") {
+            p = ""
+        } else {
+            p = cleanedPath
+        }
+
     }
     if strings.HasSuffix(p, "/") {
         p = p[:len(p)-1]

--- a/index/utility_methods.go
+++ b/index/utility_methods.go
@@ -405,7 +405,7 @@ func GenerateCleanSpecConfigBaseURL(baseURL *url.URL, dir string, includeFile bo
     if !includeFile {
         dirSegs = dirSegs[:len(dirSegs)-1]
     }
-
+    
     // relative paths are a pain in the ass, damn you digital ocean, use a single spec, and break them
     // down into services, please don't blast apart specs into a billion shards.
     if strings.Contains(dir, "../") {

--- a/index/utility_methods_test.go
+++ b/index/utility_methods_test.go
@@ -26,6 +26,28 @@ func TestGenerateCleanSpecConfigBaseURL_RelativeDeep(t *testing.T) {
         GenerateCleanSpecConfigBaseURL(u, path, true))
 }
 
+func TestGenerateCleanSpecConfigBaseURL_NoBaseURL(t *testing.T) {
+
+    u, _ := url.Parse("/things/stuff/jazz/cakes/winter/oil")
+    path := "../../../../foo/bar/baz/crap.yaml#thang"
+    assert.Equal(t, "/things/stuff/foo/bar/baz",
+        GenerateCleanSpecConfigBaseURL(u, path, false))
+
+    assert.Equal(t, "/things/stuff/foo/bar/baz/crap.yaml#thang",
+        GenerateCleanSpecConfigBaseURL(u, path, true))
+}
+
+func TestGenerateCleanSpecConfigBaseURL_HttpStrip(t *testing.T) {
+
+    u, _ := url.Parse(".")
+    path := "http://thing.com/crap.yaml#thang"
+    assert.Equal(t, "http://thing.com",
+        GenerateCleanSpecConfigBaseURL(u, path, false))
+
+    assert.Equal(t, "",
+        GenerateCleanSpecConfigBaseURL(u, "crap.yaml#thing", true))
+}
+
 func TestSpecIndex_extractDefinitionRequiredRefProperties(t *testing.T) {
     c := CreateOpenAPIIndexConfig()
     idx := NewSpecIndexWithConfig(nil, c)


### PR DESCRIPTION
The index runs async everywhere, it's kind of impossible to know which path with resolve first, so testing is hard. Sometimes a race condition is hit. Well, it was. Now that map has a mutex on it.

Also fully fixed handling files with relative links. A basepath property has been added to the index configuration to allow a local root to be set when resolving files.

Added a full checkout test for the digital ocean spec so that complete remote and full local testing is performed.