### PR TITLE
Fixed race conditions in index #91

### DIFF
--- a/index/extract_refs.go
+++ b/index/extract_refs.go
@@ -384,7 +384,9 @@ func (index *SpecIndex) ExtractComponentsFromRefs(refs []*Reference) []*Referenc
                 Node: ref.Node,
                 Path: path,
             }
+            index.errorLock.Lock()
             index.refErrors = append(index.refErrors, indexError)
+            index.errorLock.Unlock()
         }
         c <- true
     }

--- a/index/index_model.go
+++ b/index/index_model.go
@@ -206,6 +206,9 @@ type SpecIndex struct {
     seenLocalSources                    map[string]*yaml.Node
     refLock                             sync.Mutex
     sourceLock                          sync.Mutex
+    componentLock                       sync.RWMutex
+    externalLock                        sync.RWMutex
+    errorLock                           sync.RWMutex
     circularReferences                  []*CircularReferenceResult // only available when the resolver has been used.
     allowCircularReferences             bool                       // decide if you want to error out, or allow circular references, default is false.
     relativePath                        string                     // relative path of the spec file.

--- a/index/spec_index.go
+++ b/index/spec_index.go
@@ -752,7 +752,9 @@ func (index *SpecIndex) GetComponentSchemaCount() int {
 				// extract parameters
 				if parametersNode != nil {
 					index.extractComponentParameters(parametersNode, "#/components/parameters/")
+					index.componentLock.Lock()
 					index.parametersNode = parametersNode
+					index.componentLock.Unlock()
 				}
 
 				// extract requestBodies
@@ -815,10 +817,11 @@ func (index *SpecIndex) GetComponentSchemaCount() int {
 			if n.Value == "parameters" {
 				parametersNode := index.root.Content[0].Content[i+1]
 				if parametersNode != nil {
-
 					// extract params
 					index.extractComponentParameters(parametersNode, "#/parameters/")
+					index.componentLock.Lock()
 					index.parametersNode = parametersNode
+					index.componentLock.Unlock()
 				}
 			}
 
@@ -863,16 +866,20 @@ func (index *SpecIndex) GetComponentParameterCount() int {
 			if n.Value == "components" {
 				_, parametersNode := utils.FindKeyNode("parameters", index.root.Content[0].Content[i+1].Content)
 				if parametersNode != nil {
+					index.componentLock.Lock()
 					index.parametersNode = parametersNode
 					index.componentParamCount = len(parametersNode.Content) / 2
+					index.componentLock.Unlock()
 				}
 			}
 			// openapi 2
 			if n.Value == "parameters" {
 				parametersNode := index.root.Content[0].Content[i+1]
 				if parametersNode != nil {
+					index.componentLock.Lock()
 					index.parametersNode = parametersNode
 					index.componentParamCount = len(parametersNode.Content) / 2
+					index.componentLock.Unlock()
 				}
 			}
 		}


### PR DESCRIPTION
Different race conditions popped up at different times, depending on how complex the nesting of indexes was. After running tests with `-race` I've knocked out all the concurrency issues being reported and now there are no race conditions reported by the tests. This should knock out all known race conditions with some targeted mutex locks.

Non breaking change.