### PR TITLE
fix: add missing summary for OpenAPI 3.X docs

### DIFF
--- a/datamodel/high/base/info.go
+++ b/datamodel/high/base/info.go
@@ -17,6 +17,7 @@ import (
 //	v3 - https://spec.openapis.org/oas/v3.1.0#info-object
 type Info struct {
 	Title          string
+	Summary        string
 	Description    string
 	TermsOfService string
 	Contact        *Contact

--- a/datamodel/high/base/info.go
+++ b/datamodel/high/base/info.go
@@ -34,6 +34,9 @@ func NewInfo(info *low.Info) *Info {
 	if !info.Title.IsEmpty() {
 		i.Title = info.Title.Value
 	}
+	if !info.Summary.IsEmpty() {
+		i.Summary = info.Summary.Value
+	}
 	if !info.Description.IsEmpty() {
 		i.Description = info.Description.Value
 	}

--- a/datamodel/high/base/info_test.go
+++ b/datamodel/high/base/info_test.go
@@ -14,10 +14,10 @@ import (
 )
 
 func TestNewInfo(t *testing.T) {
-
 	var cNode yaml.Node
 
 	yml := `title: chicken
+summary: a chicken nugget
 description: nugget
 termsOfService: chicken soup
 contact:
@@ -37,6 +37,7 @@ x-cli-name: chicken cli`
 	highInfo := NewInfo(&lowInfo)
 
 	assert.Equal(t, "chicken", highInfo.Title)
+	assert.Equal(t, "a chicken nugget", highInfo.Summary)
 	assert.Equal(t, "nugget", highInfo.Description)
 	assert.Equal(t, "chicken soup", highInfo.TermsOfService)
 	assert.Equal(t, "buckaroo", highInfo.Contact.Name)
@@ -46,18 +47,17 @@ x-cli-name: chicken cli`
 	assert.Equal(t, "chicken cli", highInfo.Extensions["x-cli-name"])
 
 	wentLow := highInfo.GoLow()
-	assert.Equal(t, 9, wentLow.Version.ValueNode.Line)
+	assert.Equal(t, 10, wentLow.Version.ValueNode.Line)
 
 	wentLower := highInfo.License.GoLow()
-	assert.Equal(t, 8, wentLower.URL.ValueNode.Line)
-
+	assert.Equal(t, 9, wentLower.URL.ValueNode.Line)
 }
 
 func ExampleNewInfo() {
-
 	// create an example info object (including contact and license)
 	// this can be either JSON or YAML.
 	yml := `title: some spec by some company
+summary: this is a summary
 description: this is a specification, for an API, by a company.
 termsOfService: https://pb33f.io/tos
 contact:
@@ -85,7 +85,6 @@ version: 1.2.3`
 }
 
 func ExampleNewLicense() {
-
 	// create an example license object
 	// this can be either JSON or YAML.
 	yml := `name: MIT

--- a/datamodel/low/base/info.go
+++ b/datamodel/low/base/info.go
@@ -6,11 +6,12 @@ package base
 import (
 	"crypto/sha256"
 	"fmt"
+	"sort"
+	"strings"
+
 	"github.com/pb33f/libopenapi/datamodel/low"
 	"github.com/pb33f/libopenapi/index"
 	"gopkg.in/yaml.v3"
-	"sort"
-	"strings"
 )
 
 // Info represents a low-level Info object as defined by both OpenAPI 2 and OpenAPI 3.
@@ -22,6 +23,7 @@ import (
 //	v3 - https://spec.openapis.org/oas/v3.1.0#info-object
 type Info struct {
 	Title          low.NodeReference[string]
+	Summary        low.NodeReference[string]
 	Description    low.NodeReference[string]
 	TermsOfService low.NodeReference[string]
 	Contact        low.NodeReference[*Contact]
@@ -60,6 +62,9 @@ func (i *Info) Hash() [32]byte {
 
 	if !i.Title.IsEmpty() {
 		f = append(f, i.Title.Value)
+	}
+	if !i.Summary.IsEmpty() {
+		f = append(f, i.Summary.Value)
 	}
 	if !i.Description.IsEmpty() {
 		f = append(f, i.Description.Value)

--- a/datamodel/low/base/info_test.go
+++ b/datamodel/low/base/info_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 func TestInfo_Build(t *testing.T) {
-
 	yml := `title: pizza
+summary: a pizza pie
 description: pie
 termsOfService: yes indeed.
 contact:
@@ -38,6 +38,7 @@ x-cli-name: pizza cli`
 	assert.NoError(t, err)
 
 	assert.Equal(t, "pizza", n.Title.Value)
+	assert.Equal(t, "a pizza pie", n.Summary.Value)
 	assert.Equal(t, "pie", n.Description.Value)
 	assert.Equal(t, "yes indeed.", n.TermsOfService.Value)
 
@@ -71,7 +72,6 @@ func TestLicense_Build(t *testing.T) {
 }
 
 func TestInfo_Hash(t *testing.T) {
-
 	left := `title: princess b33f
 description: a thing
 termsOfService: https://pb33f.io
@@ -109,5 +109,4 @@ x-b33f: princess`
 	_ = rDoc.Build(rNode.Content[0], nil)
 
 	assert.Equal(t, lDoc.Hash(), rDoc.Hash())
-
 }

--- a/what-changed/model/info.go
+++ b/what-changed/model/info.go
@@ -4,121 +4,131 @@
 package model
 
 import (
-    "github.com/pb33f/libopenapi/datamodel/low/base"
-    "github.com/pb33f/libopenapi/datamodel/low/v3"
+	"github.com/pb33f/libopenapi/datamodel/low/base"
+	v3 "github.com/pb33f/libopenapi/datamodel/low/v3"
 )
 
 // InfoChanges represents the number of changes to an Info object. Part of an OpenAPI document
 type InfoChanges struct {
-    *PropertyChanges
-    ContactChanges *ContactChanges `json:"contact,omitempty" yaml:"contact,omitempty"`
-    LicenseChanges *LicenseChanges `json:"license,omitempty" yaml:"license,omitempty"`
+	*PropertyChanges
+	ContactChanges *ContactChanges `json:"contact,omitempty" yaml:"contact,omitempty"`
+	LicenseChanges *LicenseChanges `json:"license,omitempty" yaml:"license,omitempty"`
 }
 
 // TotalChanges represents the total number of changes made to an Info object.
 func (i *InfoChanges) TotalChanges() int {
-    t := i.PropertyChanges.TotalChanges()
-    if i.ContactChanges != nil {
-        t += i.ContactChanges.TotalChanges()
-    }
-    if i.LicenseChanges != nil {
-        t += i.LicenseChanges.TotalChanges()
-    }
-    return t
+	t := i.PropertyChanges.TotalChanges()
+	if i.ContactChanges != nil {
+		t += i.ContactChanges.TotalChanges()
+	}
+	if i.LicenseChanges != nil {
+		t += i.LicenseChanges.TotalChanges()
+	}
+	return t
 }
 
 // TotalBreakingChanges always returns 0 for Info objects, they are non-binding.
 func (i *InfoChanges) TotalBreakingChanges() int {
-    return 0
+	return 0
 }
 
 // CompareInfo will compare a left (original) and a right (new) Info object. Any changes
 // will be returned in a pointer to InfoChanges, otherwise if nothing is found, then nil is
 // returned instead.
 func CompareInfo(l, r *base.Info) *InfoChanges {
+	var changes []*Change
+	var props []*PropertyCheck
 
-    var changes []*Change
-    var props []*PropertyCheck
+	// Title
+	props = append(props, &PropertyCheck{
+		LeftNode:  l.Title.ValueNode,
+		RightNode: r.Title.ValueNode,
+		Label:     v3.TitleLabel,
+		Changes:   &changes,
+		Breaking:  false,
+		Original:  l,
+		New:       r,
+	})
 
-    // Title
-    props = append(props, &PropertyCheck{
-        LeftNode:  l.Title.ValueNode,
-        RightNode: r.Title.ValueNode,
-        Label:     v3.TitleLabel,
-        Changes:   &changes,
-        Breaking:  false,
-        Original:  l,
-        New:       r,
-    })
+	// Summary
+	props = append(props, &PropertyCheck{
+		LeftNode:  l.Summary.ValueNode,
+		RightNode: r.Summary.ValueNode,
+		Label:     v3.SummaryLabel,
+		Changes:   &changes,
+		Breaking:  false,
+		Original:  l,
+		New:       r,
+	})
 
-    // Description
-    props = append(props, &PropertyCheck{
-        LeftNode:  l.Description.ValueNode,
-        RightNode: r.Description.ValueNode,
-        Label:     v3.DescriptionLabel,
-        Changes:   &changes,
-        Breaking:  false,
-        Original:  l,
-        New:       r,
-    })
+	// Description
+	props = append(props, &PropertyCheck{
+		LeftNode:  l.Description.ValueNode,
+		RightNode: r.Description.ValueNode,
+		Label:     v3.DescriptionLabel,
+		Changes:   &changes,
+		Breaking:  false,
+		Original:  l,
+		New:       r,
+	})
 
-    // TermsOfService
-    props = append(props, &PropertyCheck{
-        LeftNode:  l.TermsOfService.ValueNode,
-        RightNode: r.TermsOfService.ValueNode,
-        Label:     v3.TermsOfServiceLabel,
-        Changes:   &changes,
-        Breaking:  false,
-        Original:  l,
-        New:       r,
-    })
+	// TermsOfService
+	props = append(props, &PropertyCheck{
+		LeftNode:  l.TermsOfService.ValueNode,
+		RightNode: r.TermsOfService.ValueNode,
+		Label:     v3.TermsOfServiceLabel,
+		Changes:   &changes,
+		Breaking:  false,
+		Original:  l,
+		New:       r,
+	})
 
-    // Version
-    props = append(props, &PropertyCheck{
-        LeftNode:  l.Version.ValueNode,
-        RightNode: r.Version.ValueNode,
-        Label:     v3.VersionLabel,
-        Changes:   &changes,
-        Breaking:  false,
-        Original:  l,
-        New:       r,
-    })
+	// Version
+	props = append(props, &PropertyCheck{
+		LeftNode:  l.Version.ValueNode,
+		RightNode: r.Version.ValueNode,
+		Label:     v3.VersionLabel,
+		Changes:   &changes,
+		Breaking:  false,
+		Original:  l,
+		New:       r,
+	})
 
-    // check properties
-    CheckProperties(props)
+	// check properties
+	CheckProperties(props)
 
-    i := new(InfoChanges)
+	i := new(InfoChanges)
 
-    // compare contact.
-    if l.Contact.Value != nil && r.Contact.Value != nil {
-        i.ContactChanges = CompareContact(l.Contact.Value, r.Contact.Value)
-    } else {
-        if l.Contact.Value == nil && r.Contact.Value != nil {
-            CreateChange(&changes, ObjectAdded, v3.ContactLabel,
-                nil, r.Contact.ValueNode, false, nil, r.Contact.Value)
-        }
-        if l.Contact.Value != nil && r.Contact.Value == nil {
-            CreateChange(&changes, ObjectRemoved, v3.ContactLabel,
-                l.Contact.ValueNode, nil, false, l.Contact.Value, nil)
-        }
-    }
+	// compare contact.
+	if l.Contact.Value != nil && r.Contact.Value != nil {
+		i.ContactChanges = CompareContact(l.Contact.Value, r.Contact.Value)
+	} else {
+		if l.Contact.Value == nil && r.Contact.Value != nil {
+			CreateChange(&changes, ObjectAdded, v3.ContactLabel,
+				nil, r.Contact.ValueNode, false, nil, r.Contact.Value)
+		}
+		if l.Contact.Value != nil && r.Contact.Value == nil {
+			CreateChange(&changes, ObjectRemoved, v3.ContactLabel,
+				l.Contact.ValueNode, nil, false, l.Contact.Value, nil)
+		}
+	}
 
-    // compare license.
-    if l.License.Value != nil && r.License.Value != nil {
-        i.LicenseChanges = CompareLicense(l.License.Value, r.License.Value)
-    } else {
-        if l.License.Value == nil && r.License.Value != nil {
-            CreateChange(&changes, ObjectAdded, v3.LicenseLabel,
-                nil, r.License.ValueNode, false, nil, r.License.Value)
-        }
-        if l.License.Value != nil && r.License.Value == nil {
-            CreateChange(&changes, ObjectRemoved, v3.LicenseLabel,
-                l.License.ValueNode, nil, false, r.License.Value, nil)
-        }
-    }
-    i.PropertyChanges = NewPropertyChanges(changes)
-    if i.TotalChanges() <= 0 {
-        return nil
-    }
-    return i
+	// compare license.
+	if l.License.Value != nil && r.License.Value != nil {
+		i.LicenseChanges = CompareLicense(l.License.Value, r.License.Value)
+	} else {
+		if l.License.Value == nil && r.License.Value != nil {
+			CreateChange(&changes, ObjectAdded, v3.LicenseLabel,
+				nil, r.License.ValueNode, false, nil, r.License.Value)
+		}
+		if l.License.Value != nil && r.License.Value == nil {
+			CreateChange(&changes, ObjectRemoved, v3.LicenseLabel,
+				l.License.ValueNode, nil, false, r.License.Value, nil)
+		}
+	}
+	i.PropertyChanges = NewPropertyChanges(changes)
+	if i.TotalChanges() <= 0 {
+		return nil
+	}
+	return i
 }


### PR DESCRIPTION
This adds the missing Summary attribute to the doc.Info object for 3.X specs, this isn't present for OpenAPI 2 specs which means that it will always be empty but I think that is okay and avoided the need to have a v2 and v3 version of this object.

Also the TestSpecIndex_SearchIndexForReference_ExternalSpecs test was failing which I believe is unrelated to this change and it failed non-deterministically sometimes timing out all together