### PR TITLE
Updated embedded OAS schemas and fixed UniqueValues

### DIFF
--- a/datamodel/high/base/schema.go
+++ b/datamodel/high/base/schema.go
@@ -4,7 +4,6 @@
 package base
 
 import (
-    "fmt"
     "gopkg.in/yaml.v3"
     "sync"
 
@@ -288,7 +287,7 @@ func NewSchema(schema *base.Schema) *Schema {
 
     // TODO: check this behavior.
     for i := range schema.Enum.Value {
-        enum = append(enum, fmt.Sprint(schema.Enum.Value[i].Value))
+        enum = append(enum, schema.Enum.Value[i].Value)
     }
     s.Enum = enum
 

--- a/datamodel/high/base/schema.go
+++ b/datamodel/high/base/schema.go
@@ -84,7 +84,7 @@ type Schema struct {
     Format               string                  `json:"format,omitempty" yaml:"format,omitempty"`
     MaxItems             *int64                  `json:"maxItems,omitempty" yaml:"maxItems,omitempty"`
     MinItems             *int64                  `json:"minItems,omitempty" yaml:"minItems,omitempty"`
-    UniqueItems          *int64                  `json:"uniqueItems,omitempty" yaml:"uniqueItems,omitempty"`
+    UniqueItems          *bool                   `json:"uniqueItems,omitempty" yaml:"uniqueItems,omitempty"`
     MaxProperties        *int64                  `json:"maxProperties,omitempty" yaml:"maxProperties,omitempty"`
     MinProperties        *int64                  `json:"minProperties,omitempty" yaml:"minProperties,omitempty"`
     Required             []string                `json:"required,omitempty" yaml:"required,omitempty"`
@@ -171,13 +171,15 @@ func NewSchema(schema *base.Schema) *Schema {
     if !schema.MinContains.IsEmpty() {
         s.MinContains = &schema.MinContains.Value
     }
+    if !schema.UniqueItems.IsEmpty() {
+        s.UniqueItems = &schema.UniqueItems.Value
+    }
     if !schema.Contains.IsEmpty() {
         s.Contains = &SchemaProxy{schema: &lowmodel.NodeReference[*base.SchemaProxy]{
             ValueNode: schema.Contains.ValueNode,
             Value:     schema.Contains.Value,
         }}
     }
-
     if !schema.If.IsEmpty() {
         s.If = &SchemaProxy{schema: &lowmodel.NodeReference[*base.SchemaProxy]{
             ValueNode: schema.If.ValueNode,

--- a/datamodel/high/base/schema_test.go
+++ b/datamodel/high/base/schema_test.go
@@ -4,27 +4,27 @@
 package base
 
 import (
-	"fmt"
-	"strings"
-	"testing"
+    "fmt"
+    "strings"
+    "testing"
 
-	"github.com/pb33f/libopenapi/datamodel/low"
-	lowbase "github.com/pb33f/libopenapi/datamodel/low/base"
-	"github.com/pb33f/libopenapi/index"
-	"github.com/pb33f/libopenapi/utils"
-	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
+    "github.com/pb33f/libopenapi/datamodel/low"
+    lowbase "github.com/pb33f/libopenapi/datamodel/low/base"
+    "github.com/pb33f/libopenapi/index"
+    "github.com/pb33f/libopenapi/utils"
+    "github.com/stretchr/testify/assert"
+    "gopkg.in/yaml.v3"
 )
 
 func TestDynamicValue_IsA(t *testing.T) {
-	dv := &DynamicValue[int, bool]{N: 0, A: 23}
-	assert.True(t, dv.IsA())
-	assert.False(t, dv.IsB())
+    dv := &DynamicValue[int, bool]{N: 0, A: 23}
+    assert.True(t, dv.IsA())
+    assert.False(t, dv.IsB())
 }
 
 func TestNewSchemaProxy(t *testing.T) {
-	// check proxy
-	yml := `components:
+    // check proxy
+    yml := `components:
     schemas:
      rice:
        type: string
@@ -37,85 +37,85 @@ func TestNewSchemaProxy(t *testing.T) {
          rice:
            $ref: '#/components/schemas/rice'`
 
-	var idxNode, compNode yaml.Node
-	mErr := yaml.Unmarshal([]byte(yml), &idxNode)
-	assert.NoError(t, mErr)
-	idx := index.NewSpecIndex(&idxNode)
+    var idxNode, compNode yaml.Node
+    mErr := yaml.Unmarshal([]byte(yml), &idxNode)
+    assert.NoError(t, mErr)
+    idx := index.NewSpecIndex(&idxNode)
 
-	yml = `properties:
+    yml = `properties:
     rice:
      $ref: '#/components/schemas/I-do-not-exist'`
 
-	_ = yaml.Unmarshal([]byte(yml), &compNode)
+    _ = yaml.Unmarshal([]byte(yml), &compNode)
 
-	sp := new(lowbase.SchemaProxy)
-	err := sp.Build(compNode.Content[0], idx)
-	assert.NoError(t, err)
+    sp := new(lowbase.SchemaProxy)
+    err := sp.Build(compNode.Content[0], idx)
+    assert.NoError(t, err)
 
-	lowproxy := low.NodeReference[*lowbase.SchemaProxy]{
-		Value:     sp,
-		ValueNode: idxNode.Content[0],
-	}
+    lowproxy := low.NodeReference[*lowbase.SchemaProxy]{
+        Value:     sp,
+        ValueNode: idxNode.Content[0],
+    }
 
-	sch1 := SchemaProxy{schema: &lowproxy}
-	assert.Nil(t, sch1.Schema())
-	assert.Error(t, sch1.GetBuildError())
+    sch1 := SchemaProxy{schema: &lowproxy}
+    assert.Nil(t, sch1.Schema())
+    assert.Error(t, sch1.GetBuildError())
 
-	rend, rendErr := sch1.Render()
-	assert.Nil(t, rend)
-	assert.Error(t, rendErr)
+    rend, rendErr := sch1.Render()
+    assert.Nil(t, rend)
+    assert.Error(t, rendErr)
 
-	g, o := sch1.BuildSchema()
-	assert.Nil(t, g)
-	assert.Error(t, o)
+    g, o := sch1.BuildSchema()
+    assert.Nil(t, g)
+    assert.Error(t, o)
 }
 
 func TestNewSchemaProxyRender(t *testing.T) {
-	// check proxy
-	yml := `components:
+    // check proxy
+    yml := `components:
     schemas:
         rice:
             type: string
             description: a rice`
 
-	var idxNode, compNode yaml.Node
-	mErr := yaml.Unmarshal([]byte(yml), &idxNode)
-	assert.NoError(t, mErr)
-	idx := index.NewSpecIndexWithConfig(&idxNode, index.CreateOpenAPIIndexConfig())
+    var idxNode, compNode yaml.Node
+    mErr := yaml.Unmarshal([]byte(yml), &idxNode)
+    assert.NoError(t, mErr)
+    idx := index.NewSpecIndexWithConfig(&idxNode, index.CreateOpenAPIIndexConfig())
 
-	yml = `properties:
+    yml = `properties:
     rice:
      $ref: '#/components/schemas/rice'`
 
-	_ = yaml.Unmarshal([]byte(yml), &compNode)
+    _ = yaml.Unmarshal([]byte(yml), &compNode)
 
-	sp := new(lowbase.SchemaProxy)
-	err := sp.Build(compNode.Content[0], idx)
-	assert.NoError(t, err)
+    sp := new(lowbase.SchemaProxy)
+    err := sp.Build(compNode.Content[0], idx)
+    assert.NoError(t, err)
 
-	lowproxy := low.NodeReference[*lowbase.SchemaProxy]{
-		Value:     sp,
-		ValueNode: idxNode.Content[0],
-	}
+    lowproxy := low.NodeReference[*lowbase.SchemaProxy]{
+        Value:     sp,
+        ValueNode: idxNode.Content[0],
+    }
 
-	sch1 := SchemaProxy{schema: &lowproxy}
-	assert.NotNil(t, sch1.Schema())
-	assert.NoError(t, sch1.GetBuildError())
+    sch1 := SchemaProxy{schema: &lowproxy}
+    assert.NotNil(t, sch1.Schema())
+    assert.NoError(t, sch1.GetBuildError())
 
-	g, o := sch1.BuildSchema()
-	assert.NotNil(t, g)
-	assert.NoError(t, o)
+    g, o := sch1.BuildSchema()
+    assert.NotNil(t, g)
+    assert.NoError(t, o)
 
-	rend, _ := sch1.Render()
-	desired := `properties:
+    rend, _ := sch1.Render()
+    desired := `properties:
     rice:
         $ref: '#/components/schemas/rice'`
-	assert.Equal(t, desired, strings.TrimSpace(string(rend)))
+    assert.Equal(t, desired, strings.TrimSpace(string(rend)))
 
 }
 
 func TestNewSchemaProxy_WithObject(t *testing.T) {
-	testSpec := `type: object
+    testSpec := `type: object
 description: something object
 if:
     type: string
@@ -259,6 +259,7 @@ maxContains: 10
 minContains: 1
 deprecated: true
 writeOnly: true
+uniqueItems: true
 readOnly: true
 nullable: true
 maxLength: 10
@@ -269,111 +270,111 @@ maxProperties: 30
 minProperties: 1
 $anchor: anchor`
 
-	var compNode yaml.Node
-	_ = yaml.Unmarshal([]byte(testSpec), &compNode)
+    var compNode yaml.Node
+    _ = yaml.Unmarshal([]byte(testSpec), &compNode)
 
-	sp := new(lowbase.SchemaProxy)
-	err := sp.Build(compNode.Content[0], nil)
-	assert.NoError(t, err)
+    sp := new(lowbase.SchemaProxy)
+    err := sp.Build(compNode.Content[0], nil)
+    assert.NoError(t, err)
 
-	lowproxy := low.NodeReference[*lowbase.SchemaProxy]{
-		Value:     sp,
-		ValueNode: compNode.Content[0],
-	}
+    lowproxy := low.NodeReference[*lowbase.SchemaProxy]{
+        Value:     sp,
+        ValueNode: compNode.Content[0],
+    }
 
-	schemaProxy := NewSchemaProxy(&lowproxy)
-	compiled := schemaProxy.Schema()
+    schemaProxy := NewSchemaProxy(&lowproxy)
+    compiled := schemaProxy.Schema()
 
-	assert.Equal(t, schemaProxy, compiled.ParentProxy)
+    assert.Equal(t, schemaProxy, compiled.ParentProxy)
 
-	assert.NotNil(t, compiled)
-	assert.Nil(t, schemaProxy.GetBuildError())
+    assert.NotNil(t, compiled)
+    assert.Nil(t, schemaProxy.GetBuildError())
 
-	// check 3.1 properties
-	assert.Equal(t, "int", compiled.Contains.Schema().Type[0])
-	assert.Equal(t, int64(10), *compiled.MaxContains)
-	assert.Equal(t, int64(1), *compiled.MinContains)
-	assert.Equal(t, int64(10), *compiled.MaxLength)
-	assert.Equal(t, int64(1), *compiled.MinLength)
-	assert.Equal(t, int64(20), *compiled.MaxItems)
-	assert.Equal(t, int64(10), *compiled.MinItems)
-	assert.Equal(t, int64(30), *compiled.MaxProperties)
-	assert.Equal(t, int64(1), *compiled.MinProperties)
-	assert.Equal(t, "string", compiled.If.Schema().Type[0])
-	assert.Equal(t, "integer", compiled.Else.Schema().Type[0])
-	assert.Equal(t, "boolean", compiled.Then.Schema().Type[0])
-	assert.Equal(t, "string", compiled.PatternProperties["patternOne"].Schema().Type[0])
-	assert.Equal(t, "string", compiled.DependentSchemas["schemaOne"].Schema().Type[0])
-	assert.Equal(t, "string", compiled.PropertyNames.Schema().Type[0])
-	assert.Equal(t, "boolean", compiled.UnevaluatedItems.Schema().Type[0])
-	assert.Equal(t, "integer", compiled.UnevaluatedProperties.Schema().Type[0])
-	assert.True(t, compiled.ReadOnly)
-	assert.True(t, compiled.WriteOnly)
-	assert.True(t, *compiled.Deprecated)
-	assert.True(t, *compiled.Nullable)
-	assert.Equal(t, "anchor", compiled.Anchor)
+    // check 3.1 properties
+    assert.Equal(t, "int", compiled.Contains.Schema().Type[0])
+    assert.Equal(t, int64(10), *compiled.MaxContains)
+    assert.Equal(t, int64(1), *compiled.MinContains)
+    assert.Equal(t, int64(10), *compiled.MaxLength)
+    assert.Equal(t, int64(1), *compiled.MinLength)
+    assert.Equal(t, int64(20), *compiled.MaxItems)
+    assert.Equal(t, int64(10), *compiled.MinItems)
+    assert.Equal(t, int64(30), *compiled.MaxProperties)
+    assert.Equal(t, int64(1), *compiled.MinProperties)
+    assert.Equal(t, "string", compiled.If.Schema().Type[0])
+    assert.Equal(t, "integer", compiled.Else.Schema().Type[0])
+    assert.Equal(t, "boolean", compiled.Then.Schema().Type[0])
+    assert.Equal(t, "string", compiled.PatternProperties["patternOne"].Schema().Type[0])
+    assert.Equal(t, "string", compiled.DependentSchemas["schemaOne"].Schema().Type[0])
+    assert.Equal(t, "string", compiled.PropertyNames.Schema().Type[0])
+    assert.Equal(t, "boolean", compiled.UnevaluatedItems.Schema().Type[0])
+    assert.Equal(t, "integer", compiled.UnevaluatedProperties.Schema().Type[0])
+    assert.True(t, compiled.ReadOnly)
+    assert.True(t, compiled.WriteOnly)
+    assert.True(t, *compiled.Deprecated)
+    assert.True(t, *compiled.Nullable)
+    assert.Equal(t, "anchor", compiled.Anchor)
 
-	wentLow := compiled.GoLow()
-	assert.Equal(t, 129, wentLow.AdditionalProperties.ValueNode.Line)
-	assert.NotNil(t, compiled.GoLowUntyped())
+    wentLow := compiled.GoLow()
+    assert.Equal(t, 129, wentLow.AdditionalProperties.ValueNode.Line)
+    assert.NotNil(t, compiled.GoLowUntyped())
 
-	// now render it out!
-	schemaBytes, _ := compiled.Render()
-	assert.Len(t, schemaBytes, 3476)
+    // now render it out!
+    schemaBytes, _ := compiled.Render()
+    assert.Len(t, schemaBytes, 3494)
 }
 
 func TestSchemaObjectWithAllOfSequenceOrder(t *testing.T) {
-	testSpec := test_get_allOf_schema_blob()
+    testSpec := test_get_allOf_schema_blob()
 
-	var compNode yaml.Node
-	_ = yaml.Unmarshal([]byte(testSpec), &compNode)
+    var compNode yaml.Node
+    _ = yaml.Unmarshal([]byte(testSpec), &compNode)
 
-	// test data is a map with one node
-	mapContent := compNode.Content[0].Content
+    // test data is a map with one node
+    mapContent := compNode.Content[0].Content
 
-	_, vn := utils.FindKeyNodeTop(lowbase.AllOfLabel, mapContent)
-	assert.True(t, utils.IsNodeArray(vn))
+    _, vn := utils.FindKeyNodeTop(lowbase.AllOfLabel, mapContent)
+    assert.True(t, utils.IsNodeArray(vn))
 
-	want := []string{}
+    want := []string{}
 
-	// Go over every element in AllOf and grab description
-	// Odd: object
-	// Event: description
-	for i := range vn.Content {
-		assert.True(t, utils.IsNodeMap(vn.Content[i]))
-		_, vn := utils.FindKeyNodeTop("description", vn.Content[i].Content)
-		assert.True(t, utils.IsNodeStringValue(vn))
-		want = append(want, vn.Value)
-	}
+    // Go over every element in AllOf and grab description
+    // Odd: object
+    // Event: description
+    for i := range vn.Content {
+        assert.True(t, utils.IsNodeMap(vn.Content[i]))
+        _, vn := utils.FindKeyNodeTop("description", vn.Content[i].Content)
+        assert.True(t, utils.IsNodeStringValue(vn))
+        want = append(want, vn.Value)
+    }
 
-	sp := new(lowbase.SchemaProxy)
-	err := sp.Build(compNode.Content[0], nil)
-	assert.NoError(t, err)
+    sp := new(lowbase.SchemaProxy)
+    err := sp.Build(compNode.Content[0], nil)
+    assert.NoError(t, err)
 
-	lowproxy := low.NodeReference[*lowbase.SchemaProxy]{
-		Value:     sp,
-		ValueNode: compNode.Content[0],
-	}
+    lowproxy := low.NodeReference[*lowbase.SchemaProxy]{
+        Value:     sp,
+        ValueNode: compNode.Content[0],
+    }
 
-	schemaProxy := NewSchemaProxy(&lowproxy)
-	compiled := schemaProxy.Schema()
+    schemaProxy := NewSchemaProxy(&lowproxy)
+    compiled := schemaProxy.Schema()
 
-	assert.Equal(t, schemaProxy, compiled.ParentProxy)
+    assert.Equal(t, schemaProxy, compiled.ParentProxy)
 
-	assert.NotNil(t, compiled)
-	assert.Nil(t, schemaProxy.GetBuildError())
+    assert.NotNil(t, compiled)
+    assert.Nil(t, schemaProxy.GetBuildError())
 
-	got := []string{}
-	for i := range compiled.AllOf {
-		v := compiled.AllOf[i]
-		got = append(got, v.Schema().Description)
-	}
+    got := []string{}
+    for i := range compiled.AllOf {
+        v := compiled.AllOf[i]
+        got = append(got, v.Schema().Description)
+    }
 
-	assert.Equal(t, want, got)
+    assert.Equal(t, want, got)
 }
 
 func TestNewSchemaProxy_WithObject_FinishPoly(t *testing.T) {
-	testSpec := `type: object
+    testSpec := `type: object
 description: something object
 discriminator:
   propertyName: athing
@@ -480,41 +481,41 @@ externalDocs:
 enum: [fish, cake]
 required: [cake, fish]`
 
-	var compNode yaml.Node
-	_ = yaml.Unmarshal([]byte(testSpec), &compNode)
+    var compNode yaml.Node
+    _ = yaml.Unmarshal([]byte(testSpec), &compNode)
 
-	sp := new(lowbase.SchemaProxy)
-	err := sp.Build(compNode.Content[0], nil)
-	assert.NoError(t, err)
+    sp := new(lowbase.SchemaProxy)
+    err := sp.Build(compNode.Content[0], nil)
+    assert.NoError(t, err)
 
-	lowproxy := low.NodeReference[*lowbase.SchemaProxy]{
-		Value:     sp,
-		ValueNode: compNode.Content[0],
-	}
+    lowproxy := low.NodeReference[*lowbase.SchemaProxy]{
+        Value:     sp,
+        ValueNode: compNode.Content[0],
+    }
 
-	schemaProxy := NewSchemaProxy(&lowproxy)
-	compiled := schemaProxy.Schema()
+    schemaProxy := NewSchemaProxy(&lowproxy)
+    compiled := schemaProxy.Schema()
 
-	assert.NotNil(t, compiled)
-	assert.Nil(t, schemaProxy.GetBuildError())
+    assert.NotNil(t, compiled)
+    assert.Nil(t, schemaProxy.GetBuildError())
 
-	assert.True(t, compiled.ExclusiveMaximum.A)
-	assert.Equal(t, int64(123), compiled.Properties["somethingB"].Schema().ExclusiveMinimum.B)
-	assert.Equal(t, int64(334), compiled.Properties["somethingB"].Schema().ExclusiveMaximum.B)
-	assert.Len(t, compiled.Properties["somethingB"].Schema().Properties["somethingBProp"].Schema().Type, 2)
+    assert.True(t, compiled.ExclusiveMaximum.A)
+    assert.Equal(t, int64(123), compiled.Properties["somethingB"].Schema().ExclusiveMinimum.B)
+    assert.Equal(t, int64(334), compiled.Properties["somethingB"].Schema().ExclusiveMaximum.B)
+    assert.Len(t, compiled.Properties["somethingB"].Schema().Properties["somethingBProp"].Schema().Type, 2)
 
-	assert.Equal(t, "nice", compiled.AdditionalProperties.(*SchemaProxy).Schema().Description)
+    assert.Equal(t, "nice", compiled.AdditionalProperties.(*SchemaProxy).Schema().Description)
 
-	wentLow := compiled.GoLow()
-	assert.Equal(t, 97, wentLow.AdditionalProperties.ValueNode.Line)
-	assert.Equal(t, 102, wentLow.XML.ValueNode.Line)
+    wentLow := compiled.GoLow()
+    assert.Equal(t, 97, wentLow.AdditionalProperties.ValueNode.Line)
+    assert.Equal(t, 102, wentLow.XML.ValueNode.Line)
 
-	wentLower := compiled.XML.GoLow()
-	assert.Equal(t, 102, wentLower.Name.ValueNode.Line)
+    wentLower := compiled.XML.GoLow()
+    assert.Equal(t, 102, wentLower.Name.ValueNode.Line)
 }
 
 func TestSchemaProxy_GoLow(t *testing.T) {
-	const ymlComponents = `components:
+    const ymlComponents = `components:
     schemas:
      rice:
        type: string
@@ -527,169 +528,169 @@ func TestSchemaProxy_GoLow(t *testing.T) {
          rice:
            $ref: '#/components/schemas/rice'`
 
-	idx := func() *index.SpecIndex {
-		var idxNode yaml.Node
-		err := yaml.Unmarshal([]byte(ymlComponents), &idxNode)
-		assert.NoError(t, err)
-		return index.NewSpecIndex(&idxNode)
-	}()
+    idx := func() *index.SpecIndex {
+        var idxNode yaml.Node
+        err := yaml.Unmarshal([]byte(ymlComponents), &idxNode)
+        assert.NoError(t, err)
+        return index.NewSpecIndex(&idxNode)
+    }()
 
-	const ref = "#/components/schemas/nice"
-	const ymlSchema = `$ref: '` + ref + `'`
-	var node yaml.Node
-	_ = yaml.Unmarshal([]byte(ymlSchema), &node)
+    const ref = "#/components/schemas/nice"
+    const ymlSchema = `$ref: '` + ref + `'`
+    var node yaml.Node
+    _ = yaml.Unmarshal([]byte(ymlSchema), &node)
 
-	lowProxy := new(lowbase.SchemaProxy)
-	err := lowProxy.Build(node.Content[0], idx)
-	assert.NoError(t, err)
+    lowProxy := new(lowbase.SchemaProxy)
+    err := lowProxy.Build(node.Content[0], idx)
+    assert.NoError(t, err)
 
-	lowRef := low.NodeReference[*lowbase.SchemaProxy]{
-		Value: lowProxy,
-	}
+    lowRef := low.NodeReference[*lowbase.SchemaProxy]{
+        Value: lowProxy,
+    }
 
-	sp := NewSchemaProxy(&lowRef)
-	assert.Equal(t, lowProxy, sp.GoLow())
-	assert.Equal(t, ref, sp.GoLow().GetSchemaReference())
-	assert.Equal(t, ref, sp.GoLow().GetReference())
+    sp := NewSchemaProxy(&lowRef)
+    assert.Equal(t, lowProxy, sp.GoLow())
+    assert.Equal(t, ref, sp.GoLow().GetSchemaReference())
+    assert.Equal(t, ref, sp.GoLow().GetReference())
 
-	spNil := NewSchemaProxy(nil)
-	assert.Nil(t, spNil.GoLow())
-	assert.Nil(t, spNil.GoLowUntyped())
+    spNil := NewSchemaProxy(nil)
+    assert.Nil(t, spNil.GoLow())
+    assert.Nil(t, spNil.GoLowUntyped())
 
 }
 
 func getHighSchema(t *testing.T, yml string) *Schema {
-	// unmarshal raw bytes
-	var node yaml.Node
-	assert.NoError(t, yaml.Unmarshal([]byte(yml), &node))
+    // unmarshal raw bytes
+    var node yaml.Node
+    assert.NoError(t, yaml.Unmarshal([]byte(yml), &node))
 
-	// build out the low-level model
-	var lowSchema lowbase.Schema
-	assert.NoError(t, low.BuildModel(node.Content[0], &lowSchema))
-	assert.NoError(t, lowSchema.Build(node.Content[0], nil))
+    // build out the low-level model
+    var lowSchema lowbase.Schema
+    assert.NoError(t, low.BuildModel(node.Content[0], &lowSchema))
+    assert.NoError(t, lowSchema.Build(node.Content[0], nil))
 
-	// build the high level model
-	return NewSchema(&lowSchema)
+    // build the high level model
+    return NewSchema(&lowSchema)
 }
 
 func TestSchemaNumberNoValidation(t *testing.T) {
-	yml := `
+    yml := `
 type: number
 `
-	highSchema := getHighSchema(t, yml)
+    highSchema := getHighSchema(t, yml)
 
-	assert.Nil(t, highSchema.MultipleOf)
-	assert.Nil(t, highSchema.Minimum)
-	assert.Nil(t, highSchema.ExclusiveMinimum)
-	assert.Nil(t, highSchema.Maximum)
-	assert.Nil(t, highSchema.ExclusiveMaximum)
+    assert.Nil(t, highSchema.MultipleOf)
+    assert.Nil(t, highSchema.Minimum)
+    assert.Nil(t, highSchema.ExclusiveMinimum)
+    assert.Nil(t, highSchema.Maximum)
+    assert.Nil(t, highSchema.ExclusiveMaximum)
 }
 
 func TestSchemaNumberMultipleOf(t *testing.T) {
-	yml := `
+    yml := `
 type: number
 multipleOf: 5
 `
-	highSchema := getHighSchema(t, yml)
+    highSchema := getHighSchema(t, yml)
 
-	value := int64(5)
-	assert.EqualValues(t, &value, highSchema.MultipleOf)
+    value := int64(5)
+    assert.EqualValues(t, &value, highSchema.MultipleOf)
 }
 
 func TestSchemaNumberMinimum(t *testing.T) {
-	yml := `
+    yml := `
 type: number
 minimum: 5
 `
-	highSchema := getHighSchema(t, yml)
+    highSchema := getHighSchema(t, yml)
 
-	value := int64(5)
-	assert.EqualValues(t, &value, highSchema.Minimum)
+    value := int64(5)
+    assert.EqualValues(t, &value, highSchema.Minimum)
 }
 
 func TestSchemaNumberMinimumZero(t *testing.T) {
-	yml := `
+    yml := `
 type: number
 minimum: 0
 `
-	highSchema := getHighSchema(t, yml)
+    highSchema := getHighSchema(t, yml)
 
-	value := int64(0)
-	assert.EqualValues(t, &value, highSchema.Minimum)
+    value := int64(0)
+    assert.EqualValues(t, &value, highSchema.Minimum)
 }
 
 func TestSchemaNumberExclusiveMinimum(t *testing.T) {
-	yml := `
+    yml := `
 type: number
 exclusiveMinimum: 5
 `
-	highSchema := getHighSchema(t, yml)
+    highSchema := getHighSchema(t, yml)
 
-	value := int64(5)
-	assert.EqualValues(t, value, highSchema.ExclusiveMinimum.B)
-	assert.True(t, highSchema.ExclusiveMinimum.IsB())
+    value := int64(5)
+    assert.EqualValues(t, value, highSchema.ExclusiveMinimum.B)
+    assert.True(t, highSchema.ExclusiveMinimum.IsB())
 }
 
 func TestSchemaNumberMaximum(t *testing.T) {
-	yml := `
+    yml := `
 type: number
 maximum: 5
 `
-	highSchema := getHighSchema(t, yml)
+    highSchema := getHighSchema(t, yml)
 
-	value := int64(5)
-	assert.EqualValues(t, &value, highSchema.Maximum)
+    value := int64(5)
+    assert.EqualValues(t, &value, highSchema.Maximum)
 }
 
 func TestSchemaNumberMaximumZero(t *testing.T) {
-	yml := `
+    yml := `
 type: number
 maximum: 0
 `
-	highSchema := getHighSchema(t, yml)
+    highSchema := getHighSchema(t, yml)
 
-	value := int64(0)
-	assert.EqualValues(t, &value, highSchema.Maximum)
+    value := int64(0)
+    assert.EqualValues(t, &value, highSchema.Maximum)
 }
 
 func TestSchemaNumberExclusiveMaximum(t *testing.T) {
-	yml := `
+    yml := `
 type: number
 exclusiveMaximum: 5
 `
-	highSchema := getHighSchema(t, yml)
+    highSchema := getHighSchema(t, yml)
 
-	value := int64(5)
-	assert.EqualValues(t, value, highSchema.ExclusiveMaximum.B)
-	assert.True(t, highSchema.ExclusiveMaximum.IsB())
+    value := int64(5)
+    assert.EqualValues(t, value, highSchema.ExclusiveMaximum.B)
+    assert.True(t, highSchema.ExclusiveMaximum.IsB())
 }
 
 func TestSchema_Items_Boolean(t *testing.T) {
-	yml := `
+    yml := `
 type: number
 items: true
 `
-	highSchema := getHighSchema(t, yml)
+    highSchema := getHighSchema(t, yml)
 
-	assert.True(t, highSchema.Items.B)
+    assert.True(t, highSchema.Items.B)
 }
 
 func TestSchemaExamples(t *testing.T) {
-	yml := `
+    yml := `
 type: number
 examples:
 - 5
 - 10
 `
-	highSchema := getHighSchema(t, yml)
+    highSchema := getHighSchema(t, yml)
 
-	assert.Equal(t, []any{int64(5), int64(10)}, highSchema.Examples)
+    assert.Equal(t, []any{int64(5), int64(10)}, highSchema.Examples)
 }
 
 func ExampleNewSchema() {
-	// create an example schema object
-	// this can be either JSON or YAML.
-	yml := `
+    // create an example schema object
+    // this can be either JSON or YAML.
+    yml := `
 title: this is a schema
 type: object
 properties:
@@ -698,27 +699,27 @@ properties:
     type: integer
     format: int64`
 
-	// unmarshal raw bytes
-	var node yaml.Node
-	_ = yaml.Unmarshal([]byte(yml), &node)
+    // unmarshal raw bytes
+    var node yaml.Node
+    _ = yaml.Unmarshal([]byte(yml), &node)
 
-	// build out the low-level model
-	var lowSchema lowbase.Schema
-	_ = low.BuildModel(node.Content[0], &lowSchema)
-	_ = lowSchema.Build(node.Content[0], nil)
+    // build out the low-level model
+    var lowSchema lowbase.Schema
+    _ = low.BuildModel(node.Content[0], &lowSchema)
+    _ = lowSchema.Build(node.Content[0], nil)
 
-	// build the high level model
-	highSchema := NewSchema(&lowSchema)
+    // build the high level model
+    highSchema := NewSchema(&lowSchema)
 
-	// print out the description of 'aProperty'
-	fmt.Print(highSchema.Properties["aProperty"].Schema().Description)
-	// Output: this is an integer property
+    // print out the description of 'aProperty'
+    fmt.Print(highSchema.Properties["aProperty"].Schema().Description)
+    // Output: this is an integer property
 }
 
 func ExampleNewSchemaProxy() {
-	// create an example schema object
-	// this can be either JSON or YAML.
-	yml := `
+    // create an example schema object
+    // this can be either JSON or YAML.
+    yml := `
 title: this is a schema
 type: object
 properties:
@@ -727,27 +728,27 @@ properties:
     type: integer
     format: int64`
 
-	// unmarshal raw bytes
-	var node yaml.Node
-	_ = yaml.Unmarshal([]byte(yml), &node)
+    // unmarshal raw bytes
+    var node yaml.Node
+    _ = yaml.Unmarshal([]byte(yml), &node)
 
-	// build out the low-level model
-	var lowSchema lowbase.SchemaProxy
-	_ = low.BuildModel(node.Content[0], &lowSchema)
-	_ = lowSchema.Build(node.Content[0], nil)
+    // build out the low-level model
+    var lowSchema lowbase.SchemaProxy
+    _ = low.BuildModel(node.Content[0], &lowSchema)
+    _ = lowSchema.Build(node.Content[0], nil)
 
-	// build the high level schema proxy
-	highSchema := NewSchemaProxy(&low.NodeReference[*lowbase.SchemaProxy]{
-		Value: &lowSchema,
-	})
+    // build the high level schema proxy
+    highSchema := NewSchemaProxy(&low.NodeReference[*lowbase.SchemaProxy]{
+        Value: &lowSchema,
+    })
 
-	// print out the description of 'aProperty'
-	fmt.Print(highSchema.Schema().Properties["aProperty"].Schema().Description)
-	// Output: this is an integer property
+    // print out the description of 'aProperty'
+    fmt.Print(highSchema.Schema().Properties["aProperty"].Schema().Description)
+    // Output: this is an integer property
 }
 
 func test_get_allOf_schema_blob() string {
-	return `type: object
+    return `type: object
 description: allOf sequence check
 allOf:
   - type: object
@@ -769,7 +770,7 @@ properties:
 }
 
 func TestNewSchemaProxy_RenderSchema(t *testing.T) {
-	testSpec := `type: object
+    testSpec := `type: object
 description: something object
 discriminator:
     propertyName: athing
@@ -790,34 +791,34 @@ allOf:
             example: allOfBExp
 `
 
-	var compNode yaml.Node
-	_ = yaml.Unmarshal([]byte(testSpec), &compNode)
+    var compNode yaml.Node
+    _ = yaml.Unmarshal([]byte(testSpec), &compNode)
 
-	sp := new(lowbase.SchemaProxy)
-	err := sp.Build(compNode.Content[0], nil)
-	assert.NoError(t, err)
+    sp := new(lowbase.SchemaProxy)
+    err := sp.Build(compNode.Content[0], nil)
+    assert.NoError(t, err)
 
-	lowproxy := low.NodeReference[*lowbase.SchemaProxy]{
-		Value:     sp,
-		ValueNode: compNode.Content[0],
-	}
+    lowproxy := low.NodeReference[*lowbase.SchemaProxy]{
+        Value:     sp,
+        ValueNode: compNode.Content[0],
+    }
 
-	schemaProxy := NewSchemaProxy(&lowproxy)
-	compiled := schemaProxy.Schema()
+    schemaProxy := NewSchemaProxy(&lowproxy)
+    compiled := schemaProxy.Schema()
 
-	assert.Equal(t, schemaProxy, compiled.ParentProxy)
+    assert.Equal(t, schemaProxy, compiled.ParentProxy)
 
-	assert.NotNil(t, compiled)
-	assert.Nil(t, schemaProxy.GetBuildError())
+    assert.NotNil(t, compiled)
+    assert.Nil(t, schemaProxy.GetBuildError())
 
-	// now render it out, it should be identical.
-	schemaBytes, _ := compiled.Render()
-	assert.Equal(t, testSpec, string(schemaBytes))
+    // now render it out, it should be identical.
+    schemaBytes, _ := compiled.Render()
+    assert.Equal(t, testSpec, string(schemaBytes))
 
 }
 
 func TestNewSchemaProxy_RenderSchemaWithMultipleObjectTypes(t *testing.T) {
-	testSpec := `type: object
+    testSpec := `type: object
 description: something object
 oneOf:
     - type: object
@@ -854,33 +855,33 @@ items:
             example: itemsBExp
 `
 
-	var compNode yaml.Node
-	_ = yaml.Unmarshal([]byte(testSpec), &compNode)
+    var compNode yaml.Node
+    _ = yaml.Unmarshal([]byte(testSpec), &compNode)
 
-	sp := new(lowbase.SchemaProxy)
-	err := sp.Build(compNode.Content[0], nil)
-	assert.NoError(t, err)
+    sp := new(lowbase.SchemaProxy)
+    err := sp.Build(compNode.Content[0], nil)
+    assert.NoError(t, err)
 
-	lowproxy := low.NodeReference[*lowbase.SchemaProxy]{
-		Value:     sp,
-		ValueNode: compNode.Content[0],
-	}
+    lowproxy := low.NodeReference[*lowbase.SchemaProxy]{
+        Value:     sp,
+        ValueNode: compNode.Content[0],
+    }
 
-	schemaProxy := NewSchemaProxy(&lowproxy)
-	compiled := schemaProxy.Schema()
+    schemaProxy := NewSchemaProxy(&lowproxy)
+    compiled := schemaProxy.Schema()
 
-	assert.Equal(t, schemaProxy, compiled.ParentProxy)
+    assert.Equal(t, schemaProxy, compiled.ParentProxy)
 
-	assert.NotNil(t, compiled)
-	assert.Nil(t, schemaProxy.GetBuildError())
+    assert.NotNil(t, compiled)
+    assert.Nil(t, schemaProxy.GetBuildError())
 
-	// now render it out, it should be identical.
-	schemaBytes, _ := compiled.Render()
-	assert.Equal(t, testSpec, string(schemaBytes))
+    // now render it out, it should be identical.
+    schemaBytes, _ := compiled.Render()
+    assert.Equal(t, testSpec, string(schemaBytes))
 }
 
 func TestNewSchemaProxy_RenderSchemaEnsurePropertyOrdering(t *testing.T) {
-	testSpec := `properties:
+    testSpec := `properties:
     somethingBee:
         type: number
     somethingThree:
@@ -917,28 +918,28 @@ additionalProperties: true
 xml:
     name: XML Thing`
 
-	var compNode yaml.Node
-	_ = yaml.Unmarshal([]byte(testSpec), &compNode)
+    var compNode yaml.Node
+    _ = yaml.Unmarshal([]byte(testSpec), &compNode)
 
-	sp := new(lowbase.SchemaProxy)
-	err := sp.Build(compNode.Content[0], nil)
-	assert.NoError(t, err)
+    sp := new(lowbase.SchemaProxy)
+    err := sp.Build(compNode.Content[0], nil)
+    assert.NoError(t, err)
 
-	lowproxy := low.NodeReference[*lowbase.SchemaProxy]{
-		Value:     sp,
-		ValueNode: compNode.Content[0],
-	}
+    lowproxy := low.NodeReference[*lowbase.SchemaProxy]{
+        Value:     sp,
+        ValueNode: compNode.Content[0],
+    }
 
-	schemaProxy := NewSchemaProxy(&lowproxy)
-	compiled := schemaProxy.Schema()
+    schemaProxy := NewSchemaProxy(&lowproxy)
+    compiled := schemaProxy.Schema()
 
-	// now render it out, it should be identical.
-	schemaBytes, _ := compiled.Render()
-	assert.Equal(t, testSpec, strings.TrimSpace(string(schemaBytes)))
+    // now render it out, it should be identical.
+    schemaBytes, _ := compiled.Render()
+    assert.Equal(t, testSpec, strings.TrimSpace(string(schemaBytes)))
 }
 
 func TestNewSchemaProxy_RenderSchemaCheckDiscriminatorMappingOrder(t *testing.T) {
-	testSpec := `discriminator:
+    testSpec := `discriminator:
     mapping:
         log: cat
         pizza: party
@@ -946,134 +947,134 @@ func TestNewSchemaProxy_RenderSchemaCheckDiscriminatorMappingOrder(t *testing.T)
         warm: soup
         cold: heart`
 
-	var compNode yaml.Node
-	_ = yaml.Unmarshal([]byte(testSpec), &compNode)
+    var compNode yaml.Node
+    _ = yaml.Unmarshal([]byte(testSpec), &compNode)
 
-	sp := new(lowbase.SchemaProxy)
-	err := sp.Build(compNode.Content[0], nil)
-	assert.NoError(t, err)
+    sp := new(lowbase.SchemaProxy)
+    err := sp.Build(compNode.Content[0], nil)
+    assert.NoError(t, err)
 
-	lowproxy := low.NodeReference[*lowbase.SchemaProxy]{
-		Value:     sp,
-		ValueNode: compNode.Content[0],
-	}
+    lowproxy := low.NodeReference[*lowbase.SchemaProxy]{
+        Value:     sp,
+        ValueNode: compNode.Content[0],
+    }
 
-	schemaProxy := NewSchemaProxy(&lowproxy)
-	compiled := schemaProxy.Schema()
+    schemaProxy := NewSchemaProxy(&lowproxy)
+    compiled := schemaProxy.Schema()
 
-	// now render it out, it should be identical.
-	schemaBytes, _ := compiled.Render()
-	assert.Equal(t, testSpec, strings.TrimSpace(string(schemaBytes)))
+    // now render it out, it should be identical.
+    schemaBytes, _ := compiled.Render()
+    assert.Equal(t, testSpec, strings.TrimSpace(string(schemaBytes)))
 }
 
 func TestNewSchemaProxy_RenderSchemaCheckAdditionalPropertiesSlice(t *testing.T) {
-	testSpec := `additionalProperties:
+    testSpec := `additionalProperties:
     - one
     - two
     - miss a few
     - ninety nine
     - hundred`
 
-	var compNode yaml.Node
-	_ = yaml.Unmarshal([]byte(testSpec), &compNode)
+    var compNode yaml.Node
+    _ = yaml.Unmarshal([]byte(testSpec), &compNode)
 
-	sp := new(lowbase.SchemaProxy)
-	err := sp.Build(compNode.Content[0], nil)
-	assert.NoError(t, err)
+    sp := new(lowbase.SchemaProxy)
+    err := sp.Build(compNode.Content[0], nil)
+    assert.NoError(t, err)
 
-	lowproxy := low.NodeReference[*lowbase.SchemaProxy]{
-		Value:     sp,
-		ValueNode: compNode.Content[0],
-	}
+    lowproxy := low.NodeReference[*lowbase.SchemaProxy]{
+        Value:     sp,
+        ValueNode: compNode.Content[0],
+    }
 
-	schemaProxy := NewSchemaProxy(&lowproxy)
-	compiled := schemaProxy.Schema()
+    schemaProxy := NewSchemaProxy(&lowproxy)
+    compiled := schemaProxy.Schema()
 
-	// now render it out, it should be identical.
-	schemaBytes, _ := compiled.Render()
-	assert.Len(t, schemaBytes, 91)
+    // now render it out, it should be identical.
+    schemaBytes, _ := compiled.Render()
+    assert.Len(t, schemaBytes, 91)
 }
 
 func TestNewSchemaProxy_RenderSchemaCheckAdditionalPropertiesSliceMap(t *testing.T) {
-	testSpec := `additionalProperties:
+    testSpec := `additionalProperties:
     - nice: cake
     - yummy: beer
     - hot: coffee`
 
-	var compNode yaml.Node
-	_ = yaml.Unmarshal([]byte(testSpec), &compNode)
+    var compNode yaml.Node
+    _ = yaml.Unmarshal([]byte(testSpec), &compNode)
 
-	sp := new(lowbase.SchemaProxy)
-	err := sp.Build(compNode.Content[0], nil)
-	assert.NoError(t, err)
+    sp := new(lowbase.SchemaProxy)
+    err := sp.Build(compNode.Content[0], nil)
+    assert.NoError(t, err)
 
-	lowproxy := low.NodeReference[*lowbase.SchemaProxy]{
-		Value:     sp,
-		ValueNode: compNode.Content[0],
-	}
+    lowproxy := low.NodeReference[*lowbase.SchemaProxy]{
+        Value:     sp,
+        ValueNode: compNode.Content[0],
+    }
 
-	schemaProxy := NewSchemaProxy(&lowproxy)
-	compiled := schemaProxy.Schema()
+    schemaProxy := NewSchemaProxy(&lowproxy)
+    compiled := schemaProxy.Schema()
 
-	// now render it out, it should be identical.
-	schemaBytes, _ := compiled.Render()
-	assert.Len(t, schemaBytes, 75)
+    // now render it out, it should be identical.
+    schemaBytes, _ := compiled.Render()
+    assert.Len(t, schemaBytes, 75)
 }
 
 func TestNewSchemaProxy_CheckDefaultBooleanFalse(t *testing.T) {
-	testSpec := `default: false`
+    testSpec := `default: false`
 
-	var compNode yaml.Node
-	_ = yaml.Unmarshal([]byte(testSpec), &compNode)
+    var compNode yaml.Node
+    _ = yaml.Unmarshal([]byte(testSpec), &compNode)
 
-	sp := new(lowbase.SchemaProxy)
-	err := sp.Build(compNode.Content[0], nil)
-	assert.NoError(t, err)
+    sp := new(lowbase.SchemaProxy)
+    err := sp.Build(compNode.Content[0], nil)
+    assert.NoError(t, err)
 
-	lowproxy := low.NodeReference[*lowbase.SchemaProxy]{
-		Value:     sp,
-		ValueNode: compNode.Content[0],
-	}
+    lowproxy := low.NodeReference[*lowbase.SchemaProxy]{
+        Value:     sp,
+        ValueNode: compNode.Content[0],
+    }
 
-	schemaProxy := NewSchemaProxy(&lowproxy)
-	compiled := schemaProxy.Schema()
+    schemaProxy := NewSchemaProxy(&lowproxy)
+    compiled := schemaProxy.Schema()
 
-	// now render it out, it should be identical.
-	schemaBytes, _ := compiled.Render()
-	assert.Equal(t, testSpec, strings.TrimSpace(string(schemaBytes)))
+    // now render it out, it should be identical.
+    schemaBytes, _ := compiled.Render()
+    assert.Equal(t, testSpec, strings.TrimSpace(string(schemaBytes)))
 }
 
 func TestNewSchemaProxy_RenderAdditionalPropertiesFalse(t *testing.T) {
-	testSpec := `additionalProperties: false`
+    testSpec := `additionalProperties: false`
 
-	var compNode yaml.Node
-	_ = yaml.Unmarshal([]byte(testSpec), &compNode)
+    var compNode yaml.Node
+    _ = yaml.Unmarshal([]byte(testSpec), &compNode)
 
-	sp := new(lowbase.SchemaProxy)
-	err := sp.Build(compNode.Content[0], nil)
-	assert.NoError(t, err)
+    sp := new(lowbase.SchemaProxy)
+    err := sp.Build(compNode.Content[0], nil)
+    assert.NoError(t, err)
 
-	lowproxy := low.NodeReference[*lowbase.SchemaProxy]{
-		Value:     sp,
-		ValueNode: compNode.Content[0],
-	}
+    lowproxy := low.NodeReference[*lowbase.SchemaProxy]{
+        Value:     sp,
+        ValueNode: compNode.Content[0],
+    }
 
-	schemaProxy := NewSchemaProxy(&lowproxy)
-	compiled := schemaProxy.Schema()
+    schemaProxy := NewSchemaProxy(&lowproxy)
+    compiled := schemaProxy.Schema()
 
-	// now render it out, it should be identical.
-	schemaBytes, _ := compiled.Render()
-	assert.Equal(t, testSpec, strings.TrimSpace(string(schemaBytes)))
+    // now render it out, it should be identical.
+    schemaBytes, _ := compiled.Render()
+    assert.Equal(t, testSpec, strings.TrimSpace(string(schemaBytes)))
 }
 
 func TestNewSchemaProxy_RenderMultiplePoly(t *testing.T) {
-	idxYaml := `openapi: 3.1.0
+    idxYaml := `openapi: 3.1.0
 components:
     schemas:
         balance_transaction:
           description: A balance transaction`
 
-	testSpec := `properties:
+    testSpec := `properties:
     bigBank:
         type: object
         properties:
@@ -1086,32 +1087,32 @@ components:
                     oneOf:
                         - $ref: '#/components/schemas/balance_transaction'`
 
-	var compNode, idxNode yaml.Node
-	_ = yaml.Unmarshal([]byte(testSpec), &compNode)
-	_ = yaml.Unmarshal([]byte(idxYaml), &idxNode)
+    var compNode, idxNode yaml.Node
+    _ = yaml.Unmarshal([]byte(testSpec), &compNode)
+    _ = yaml.Unmarshal([]byte(idxYaml), &idxNode)
 
-	idx := index.NewSpecIndexWithConfig(&idxNode, index.CreateOpenAPIIndexConfig())
+    idx := index.NewSpecIndexWithConfig(&idxNode, index.CreateOpenAPIIndexConfig())
 
-	sp := new(lowbase.SchemaProxy)
+    sp := new(lowbase.SchemaProxy)
 
-	err := sp.Build(compNode.Content[0], idx)
-	assert.NoError(t, err)
+    err := sp.Build(compNode.Content[0], idx)
+    assert.NoError(t, err)
 
-	lowproxy := low.NodeReference[*lowbase.SchemaProxy]{
-		Value:     sp,
-		ValueNode: idxNode.Content[0],
-	}
+    lowproxy := low.NodeReference[*lowbase.SchemaProxy]{
+        Value:     sp,
+        ValueNode: idxNode.Content[0],
+    }
 
-	sch1 := SchemaProxy{schema: &lowproxy}
-	compiled := sch1.Schema()
+    sch1 := SchemaProxy{schema: &lowproxy}
+    compiled := sch1.Schema()
 
-	// now render it out, it should be identical.
-	schemaBytes, _ := compiled.Render()
-	assert.Equal(t, testSpec, strings.TrimSpace(string(schemaBytes)))
+    // now render it out, it should be identical.
+    schemaBytes, _ := compiled.Render()
+    assert.Equal(t, testSpec, strings.TrimSpace(string(schemaBytes)))
 }
 
 func TestNewSchemaProxy_RenderInline(t *testing.T) {
-	idxYaml := `openapi: 3.1.0
+    idxYaml := `openapi: 3.1.0
 components:
     schemas:
         balance_transaction:
@@ -1126,7 +1127,7 @@ components:
           anyOf:
             - $ref: '#/components/schemas/balance_transaction'`
 
-	testSpec := `properties:
+    testSpec := `properties:
     bigBank:
         type: object
         properties:
@@ -1138,26 +1139,26 @@ components:
                       type: string
                     - $ref: '#/components/schemas/balance_transaction'`
 
-	var compNode, idxNode yaml.Node
-	_ = yaml.Unmarshal([]byte(testSpec), &compNode)
-	_ = yaml.Unmarshal([]byte(idxYaml), &idxNode)
+    var compNode, idxNode yaml.Node
+    _ = yaml.Unmarshal([]byte(testSpec), &compNode)
+    _ = yaml.Unmarshal([]byte(idxYaml), &idxNode)
 
-	idx := index.NewSpecIndexWithConfig(&idxNode, index.CreateOpenAPIIndexConfig())
+    idx := index.NewSpecIndexWithConfig(&idxNode, index.CreateOpenAPIIndexConfig())
 
-	sp := new(lowbase.SchemaProxy)
+    sp := new(lowbase.SchemaProxy)
 
-	err := sp.Build(compNode.Content[0], idx)
-	assert.NoError(t, err)
+    err := sp.Build(compNode.Content[0], idx)
+    assert.NoError(t, err)
 
-	lowproxy := low.NodeReference[*lowbase.SchemaProxy]{
-		Value:     sp,
-		ValueNode: idxNode.Content[0],
-	}
+    lowproxy := low.NodeReference[*lowbase.SchemaProxy]{
+        Value:     sp,
+        ValueNode: idxNode.Content[0],
+    }
 
-	sch1 := SchemaProxy{schema: &lowproxy}
-	compiled := sch1.Schema()
+    sch1 := SchemaProxy{schema: &lowproxy}
+    compiled := sch1.Schema()
 
-	// now render it out, it should be identical.
-	schemaBytes, _ := compiled.RenderInline()
-	assert.Len(t, schemaBytes, 585)
+    // now render it out, it should be identical.
+    schemaBytes, _ := compiled.RenderInline()
+    assert.Len(t, schemaBytes, 585)
 }

--- a/datamodel/high/node_builder.go
+++ b/datamodel/high/node_builder.go
@@ -321,12 +321,10 @@ func (n *NodeBuilder) AddYAMLNode(parent *yaml.Node, entry *NodeEntry) *yaml.Nod
         break
 
     case reflect.Float64:
-
         precision := -1
         if entry.StringValue != "" && strings.Contains(entry.StringValue, ".") {
             precision = len(strings.Split(fmt.Sprint(entry.StringValue), ".")[1])
         }
-
         val := strconv.FormatFloat(value.(float64), 'f', precision, 64)
         valueNode = utils.CreateFloatNode(val)
         valueNode.Line = line

--- a/datamodel/high/node_builder.go
+++ b/datamodel/high/node_builder.go
@@ -4,32 +4,32 @@
 package high
 
 import (
-	"github.com/pb33f/libopenapi/datamodel/low"
-	"github.com/pb33f/libopenapi/utils"
-	"gopkg.in/yaml.v3"
-	"reflect"
-	"sort"
-	"strconv"
-	"strings"
-	"unicode"
+    "github.com/pb33f/libopenapi/datamodel/low"
+    "github.com/pb33f/libopenapi/utils"
+    "gopkg.in/yaml.v3"
+    "reflect"
+    "sort"
+    "strconv"
+    "strings"
+    "unicode"
 )
 
 // NodeEntry represents a single node used by NodeBuilder.
 type NodeEntry struct {
-	Tag        string
-	Key        string
-	Value      any
-	Line       int
-	RenderZero bool
+    Tag        string
+    Key        string
+    Value      any
+    Line       int
+    RenderZero bool
 }
 
 // NodeBuilder is a structure used by libopenapi high-level objects, to render themselves back to YAML.
 // this allows high-level objects to be 'mutable' because all changes will be rendered out.
 type NodeBuilder struct {
-	Nodes   []*NodeEntry
-	High    any
-	Low     any
-	Resolve bool // If set to true, all references will be rendered inline
+    Nodes   []*NodeEntry
+    High    any
+    Low     any
+    Resolve bool // If set to true, all references will be rendered inline
 }
 
 const renderZero = "renderZero"
@@ -39,606 +39,608 @@ const renderZero = "renderZero"
 //
 // Using reflection, a map of every field in the high level object is created, ready to be rendered.
 func NewNodeBuilder(high any, low any) *NodeBuilder {
-	// create a new node builder
-	nb := new(NodeBuilder)
-	nb.High = high
-	if low != nil {
-		nb.Low = low
-	}
+    // create a new node builder
+    nb := new(NodeBuilder)
+    nb.High = high
+    if low != nil {
+        nb.Low = low
+    }
 
-	// extract fields from the high level object and add them into our node builder.
-	// this will allow us to extract the line numbers from the low level object as well.
-	v := reflect.ValueOf(high).Elem()
-	num := v.NumField()
-	for i := 0; i < num; i++ {
-		nb.add(v.Type().Field(i).Name, i)
-	}
-	return nb
+    // extract fields from the high level object and add them into our node builder.
+    // this will allow us to extract the line numbers from the low level object as well.
+    v := reflect.ValueOf(high).Elem()
+    num := v.NumField()
+    for i := 0; i < num; i++ {
+        nb.add(v.Type().Field(i).Name, i)
+    }
+    return nb
 }
 
 func (n *NodeBuilder) add(key string, i int) {
 
-	// only operate on exported fields.
-	if unicode.IsLower(rune(key[0])) {
-		return
-	}
+    // only operate on exported fields.
+    if unicode.IsLower(rune(key[0])) {
+        return
+    }
 
-	// if the key is 'Extensions' then we need to extract the keys from the map
-	// and add them to the node builder.
-	if key == "Extensions" {
-		extensions := reflect.ValueOf(n.High).Elem().FieldByName(key)
-		for b, e := range extensions.MapKeys() {
-			v := extensions.MapIndex(e)
+    // if the key is 'Extensions' then we need to extract the keys from the map
+    // and add them to the node builder.
+    if key == "Extensions" {
+        extensions := reflect.ValueOf(n.High).Elem().FieldByName(key)
+        for b, e := range extensions.MapKeys() {
+            v := extensions.MapIndex(e)
 
-			extKey := e.String()
-			extValue := v.Interface()
-			nodeEntry := &NodeEntry{Tag: extKey, Key: extKey, Value: extValue, Line: 9999 + b}
+            extKey := e.String()
+            extValue := v.Interface()
+            nodeEntry := &NodeEntry{Tag: extKey, Key: extKey, Value: extValue, Line: 9999 + b}
 
-			if n.Low != nil && !reflect.ValueOf(n.Low).IsZero() {
-				fieldValue := reflect.ValueOf(n.Low).Elem().FieldByName("Extensions")
-				f := fieldValue.Interface()
-				value := reflect.ValueOf(f)
-				switch value.Kind() {
-				case reflect.Map:
-					if j, ok := n.Low.(low.HasExtensionsUntyped); ok {
-						originalExtensions := j.GetExtensions()
-						u := 0
-						for k := range originalExtensions {
-							if k.Value == extKey {
-								if originalExtensions[k].ValueNode.Line != 0 {
-									nodeEntry.Line = originalExtensions[k].ValueNode.Line + u
-								} else {
-									nodeEntry.Line = 999999 + b + u
-								}
-							}
-							u++
-						}
-					}
-				}
-			}
-			n.Nodes = append(n.Nodes, nodeEntry)
-		}
-		// done, extensions are handled separately.
-		return
-	}
+            if n.Low != nil && !reflect.ValueOf(n.Low).IsZero() {
+                fieldValue := reflect.ValueOf(n.Low).Elem().FieldByName("Extensions")
+                f := fieldValue.Interface()
+                value := reflect.ValueOf(f)
+                switch value.Kind() {
+                case reflect.Map:
+                    if j, ok := n.Low.(low.HasExtensionsUntyped); ok {
+                        originalExtensions := j.GetExtensions()
+                        u := 0
+                        for k := range originalExtensions {
+                            if k.Value == extKey {
+                                if originalExtensions[k].ValueNode.Line != 0 {
+                                    nodeEntry.Line = originalExtensions[k].ValueNode.Line + u
+                                } else {
+                                    nodeEntry.Line = 999999 + b + u
+                                }
+                            }
+                            u++
+                        }
+                    }
+                }
+            }
+            n.Nodes = append(n.Nodes, nodeEntry)
+        }
+        // done, extensions are handled separately.
+        return
+    }
 
-	// find the field with the tag supplied.
-	field, _ := reflect.TypeOf(n.High).Elem().FieldByName(key)
-	tag := string(field.Tag.Get("yaml"))
-	tagName := strings.Split(tag, ",")[0]
+    // find the field with the tag supplied.
+    field, _ := reflect.TypeOf(n.High).Elem().FieldByName(key)
+    tag := string(field.Tag.Get("yaml"))
+    tagName := strings.Split(tag, ",")[0]
 
-	if tag == "-" {
-		return
-	}
+    if tag == "-" {
+        return
+    }
 
-	renderZeroVal := strings.Split(tag, ",")[1]
+    renderZeroVal := strings.Split(tag, ",")[1]
 
-	// extract the value of the field
-	fieldValue := reflect.ValueOf(n.High).Elem().FieldByName(key)
-	f := fieldValue.Interface()
-	value := reflect.ValueOf(f)
+    // extract the value of the field
+    fieldValue := reflect.ValueOf(n.High).Elem().FieldByName(key)
+    f := fieldValue.Interface()
+    value := reflect.ValueOf(f)
 
-	if renderZeroVal != renderZero && (f == nil || value.IsZero()) {
-		return
-	}
+    if renderZeroVal != renderZero && (f == nil || value.IsZero()) {
+        return
+    }
 
-	// create a new node entry
-	nodeEntry := &NodeEntry{Tag: tagName, Key: key}
-	if renderZeroVal == renderZero {
-		nodeEntry.RenderZero = true
-	}
+    // create a new node entry
+    nodeEntry := &NodeEntry{Tag: tagName, Key: key}
+    if renderZeroVal == renderZero {
+        nodeEntry.RenderZero = true
+    }
 
-	switch value.Kind() {
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		nodeEntry.Value = strconv.FormatInt(value.Int(), 10)
-	case reflect.String:
-		nodeEntry.Value = value.String()
-	case reflect.Bool:
-		nodeEntry.Value = value.Bool()
-	case reflect.Slice:
-		if tagName == "type" {
-			if value.Len() == 1 {
-				nodeEntry.Value = value.Index(0).String()
-			} else {
-				nodeEntry.Value = f
-			}
-		} else {
-			if (renderZeroVal == renderZero) || (!value.IsNil() && !value.IsZero()) {
-				nodeEntry.Value = f
-			}
-		}
-	case reflect.Ptr:
-		if !value.IsNil() {
-			nodeEntry.Value = f
-		}
-	case reflect.Map:
-		if !value.IsNil() && value.Len() > 0 {
-			nodeEntry.Value = f
-		}
-	default:
-		nodeEntry.Value = f
-	}
+    switch value.Kind() {
+    case reflect.Float64, reflect.Float32:
+        nodeEntry.Value = value.Float()
+    case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+        nodeEntry.Value = value.Int()
+    case reflect.String:
+        nodeEntry.Value = value.String()
+    case reflect.Bool:
+        nodeEntry.Value = value.Bool()
+    case reflect.Slice:
+        if tagName == "type" {
+            if value.Len() == 1 {
+                nodeEntry.Value = value.Index(0).String()
+            } else {
+                nodeEntry.Value = f
+            }
+        } else {
+            if (renderZeroVal == renderZero) || (!value.IsNil() && !value.IsZero()) {
+                nodeEntry.Value = f
+            }
+        }
+    case reflect.Ptr:
+        if !value.IsNil() {
+            nodeEntry.Value = f
+        }
+    case reflect.Map:
+        if !value.IsNil() && value.Len() > 0 {
+            nodeEntry.Value = f
+        }
+    default:
+        nodeEntry.Value = f
+    }
 
-	// if there is no low level object, then we cannot extract line numbers,
-	// so skip and default to 0, which means a new entry to the spec.
-	// this will place new content and the top of the rendered object.
-	if n.Low != nil && !reflect.ValueOf(n.Low).IsZero() {
-		lowFieldValue := reflect.ValueOf(n.Low).Elem().FieldByName(key)
-		fLow := lowFieldValue.Interface()
-		value = reflect.ValueOf(fLow)
-		switch value.Kind() {
+    // if there is no low level object, then we cannot extract line numbers,
+    // so skip and default to 0, which means a new entry to the spec.
+    // this will place new content and the top of the rendered object.
+    if n.Low != nil && !reflect.ValueOf(n.Low).IsZero() {
+        lowFieldValue := reflect.ValueOf(n.Low).Elem().FieldByName(key)
+        fLow := lowFieldValue.Interface()
+        value = reflect.ValueOf(fLow)
+        switch value.Kind() {
 
-		case reflect.Slice:
-			l := value.Len()
-			lines := make([]int, l)
-			for g := 0; g < l; g++ {
-				qw := value.Index(g).Interface()
-				if we, wok := qw.(low.HasKeyNode); wok {
-					lines[g] = we.GetKeyNode().Line
-				}
-			}
-			sort.Ints(lines)
-			nodeEntry.Line = lines[0] // pick the lowest line number so this key is sorted in order.
-			break
-		case reflect.Map:
+        case reflect.Slice:
+            l := value.Len()
+            lines := make([]int, l)
+            for g := 0; g < l; g++ {
+                qw := value.Index(g).Interface()
+                if we, wok := qw.(low.HasKeyNode); wok {
+                    lines[g] = we.GetKeyNode().Line
+                }
+            }
+            sort.Ints(lines)
+            nodeEntry.Line = lines[0] // pick the lowest line number so this key is sorted in order.
+            break
+        case reflect.Map:
 
-			l := value.Len()
-			lines := make([]int, l)
-			for q, ky := range value.MapKeys() {
-				if we, wok := ky.Interface().(low.HasKeyNode); wok {
-					lines[q] = we.GetKeyNode().Line
-				}
-			}
-			sort.Ints(lines)
-			nodeEntry.Line = lines[0] // pick the lowest line number, sort in order
+            l := value.Len()
+            lines := make([]int, l)
+            for q, ky := range value.MapKeys() {
+                if we, wok := ky.Interface().(low.HasKeyNode); wok {
+                    lines[q] = we.GetKeyNode().Line
+                }
+            }
+            sort.Ints(lines)
+            nodeEntry.Line = lines[0] // pick the lowest line number, sort in order
 
-		case reflect.Struct:
-			y := value.Interface()
-			nodeEntry.Line = 9999 + i
-			if nb, ok := y.(low.HasValueNodeUntyped); ok {
-				if nb.IsReference() {
-					if jk, kj := y.(low.HasKeyNode); kj {
-						nodeEntry.Line = jk.GetKeyNode().Line
-						break
-					}
-				}
-				if nb.GetValueNode() != nil {
-					nodeEntry.Line = nb.GetValueNode().Line
-				}
-			}
-		default:
-			// everything else, weight it to the bottom of the rendered object.
-			// this is things that we have no way of knowing where they should be placed.
-			nodeEntry.Line = 9999 + i
-		}
-	}
-	if nodeEntry.Value != nil {
-		n.Nodes = append(n.Nodes, nodeEntry)
-	}
+        case reflect.Struct:
+            y := value.Interface()
+            nodeEntry.Line = 9999 + i
+            if nb, ok := y.(low.HasValueNodeUntyped); ok {
+                if nb.IsReference() {
+                    if jk, kj := y.(low.HasKeyNode); kj {
+                        nodeEntry.Line = jk.GetKeyNode().Line
+                        break
+                    }
+                }
+                if nb.GetValueNode() != nil {
+                    nodeEntry.Line = nb.GetValueNode().Line
+                }
+            }
+        default:
+            // everything else, weight it to the bottom of the rendered object.
+            // this is things that we have no way of knowing where they should be placed.
+            nodeEntry.Line = 9999 + i
+        }
+    }
+    if nodeEntry.Value != nil {
+        n.Nodes = append(n.Nodes, nodeEntry)
+    }
 }
 
 func (n *NodeBuilder) renderReference() []*yaml.Node {
-	fg := n.Low.(low.IsReferenced)
-	nodes := make([]*yaml.Node, 2)
-	nodes[0] = utils.CreateStringNode("$ref")
-	nodes[1] = utils.CreateStringNode(fg.GetReference())
-	return nodes
+    fg := n.Low.(low.IsReferenced)
+    nodes := make([]*yaml.Node, 2)
+    nodes[0] = utils.CreateStringNode("$ref")
+    nodes[1] = utils.CreateStringNode(fg.GetReference())
+    return nodes
 }
 
 // Render will render the NodeBuilder back to a YAML node, iterating over every NodeEntry defined
 func (n *NodeBuilder) Render() *yaml.Node {
-	if len(n.Nodes) == 0 {
-		return utils.CreateEmptyMapNode()
-	}
+    if len(n.Nodes) == 0 {
+        return utils.CreateEmptyMapNode()
+    }
 
-	// order nodes by line number, retain original order
-	m := utils.CreateEmptyMapNode()
-	if fg, ok := n.Low.(low.IsReferenced); ok {
-		g := reflect.ValueOf(fg)
-		if !g.IsNil() {
-			if fg.IsReference() && !n.Resolve {
-				m.Content = append(m.Content, n.renderReference()...)
-				return m
-			}
-		}
-	}
+    // order nodes by line number, retain original order
+    m := utils.CreateEmptyMapNode()
+    if fg, ok := n.Low.(low.IsReferenced); ok {
+        g := reflect.ValueOf(fg)
+        if !g.IsNil() {
+            if fg.IsReference() && !n.Resolve {
+                m.Content = append(m.Content, n.renderReference()...)
+                return m
+            }
+        }
+    }
 
-	sort.Slice(n.Nodes, func(i, j int) bool {
-		if n.Nodes[i].Line != n.Nodes[j].Line {
-			return n.Nodes[i].Line < n.Nodes[j].Line
-		}
-		return false
-	})
+    sort.Slice(n.Nodes, func(i, j int) bool {
+        if n.Nodes[i].Line != n.Nodes[j].Line {
+            return n.Nodes[i].Line < n.Nodes[j].Line
+        }
+        return false
+    })
 
-	for i := range n.Nodes {
-		node := n.Nodes[i]
-		n.AddYAMLNode(m, node)
-	}
-	return m
+    for i := range n.Nodes {
+        node := n.Nodes[i]
+        n.AddYAMLNode(m, node)
+    }
+    return m
 }
 
 // AddYAMLNode will add a new *yaml.Node to the parent node, using the tag, key and value provided.
 // If the value is nil, then the node will not be added. This method is recursive, so it will dig down
 // into any non-scalar types.
 func (n *NodeBuilder) AddYAMLNode(parent *yaml.Node, entry *NodeEntry) *yaml.Node {
-	if entry.Value == nil {
-		return parent
-	}
+    if entry.Value == nil {
+        return parent
+    }
 
-	// check the type
-	t := reflect.TypeOf(entry.Value)
-	var l *yaml.Node
-	if entry.Tag != "" {
-		l = utils.CreateStringNode(entry.Tag)
-	}
+    // check the type
+    t := reflect.TypeOf(entry.Value)
+    var l *yaml.Node
+    if entry.Tag != "" {
+        l = utils.CreateStringNode(entry.Tag)
+    }
 
-	value := entry.Value
-	line := entry.Line
-	key := entry.Key
+    value := entry.Value
+    line := entry.Line
+    key := entry.Key
 
-	var valueNode *yaml.Node
-	switch t.Kind() {
+    var valueNode *yaml.Node
+    switch t.Kind() {
 
-	case reflect.String:
-		val := value.(string)
-		valueNode = utils.CreateStringNode(val)
-		valueNode.Line = line
-		break
+    case reflect.String:
+        val := value.(string)
+        valueNode = utils.CreateStringNode(val)
+        valueNode.Line = line
+        break
 
-	case reflect.Bool:
-		val := value.(bool)
-		if !val {
-			valueNode = utils.CreateBoolNode("false")
-		} else {
-			valueNode = utils.CreateBoolNode("true")
-		}
-		valueNode.Line = line
-		break
+    case reflect.Bool:
+        val := value.(bool)
+        if !val {
+            valueNode = utils.CreateBoolNode("false")
+        } else {
+            valueNode = utils.CreateBoolNode("true")
+        }
+        valueNode.Line = line
+        break
 
-	case reflect.Int:
-		val := strconv.Itoa(value.(int))
-		valueNode = utils.CreateIntNode(val)
-		valueNode.Line = line
-		break
+    case reflect.Int:
+        val := strconv.Itoa(value.(int))
+        valueNode = utils.CreateIntNode(val)
+        valueNode.Line = line
+        break
 
-	case reflect.Int64:
-		val := strconv.FormatInt(value.(int64), 10)
-		valueNode = utils.CreateIntNode(val)
-		valueNode.Line = line
-		break
+    case reflect.Int64:
+        val := strconv.FormatInt(value.(int64), 10)
+        valueNode = utils.CreateIntNode(val)
+        valueNode.Line = line
+        break
 
-	case reflect.Float32:
-		val := strconv.FormatFloat(float64(value.(float32)), 'f', 2, 64)
-		valueNode = utils.CreateFloatNode(val)
-		valueNode.Line = line
-		break
+    case reflect.Float32:
+        val := strconv.FormatFloat(float64(value.(float32)), 'f', 2, 64)
+        valueNode = utils.CreateFloatNode(val)
+        valueNode.Line = line
+        break
 
-	case reflect.Float64:
-		val := strconv.FormatFloat(value.(float64), 'f', -1, 64)
-		valueNode = utils.CreateFloatNode(val)
-		valueNode.Line = line
-		break
+    case reflect.Float64:
+        val := strconv.FormatFloat(value.(float64), 'f', -1, 64)
+        valueNode = utils.CreateFloatNode(val)
+        valueNode.Line = line
+        break
 
-	case reflect.Map:
+    case reflect.Map:
 
-		// the keys will be rendered randomly, if we don't find out the original line
-		// number of the tag.
+        // the keys will be rendered randomly, if we don't find out the original line
+        // number of the tag.
 
-		var orderedCollection []*NodeEntry
-		m := reflect.ValueOf(value)
-		for g, k := range m.MapKeys() {
-			var x string
-			// extract key
-			yu := k.Interface()
-			if o, ok := yu.(low.HasKeyNode); ok {
-				x = o.GetKeyNode().Value
-			} else {
-				x = k.String()
-			}
+        var orderedCollection []*NodeEntry
+        m := reflect.ValueOf(value)
+        for g, k := range m.MapKeys() {
+            var x string
+            // extract key
+            yu := k.Interface()
+            if o, ok := yu.(low.HasKeyNode); ok {
+                x = o.GetKeyNode().Value
+            } else {
+                x = k.String()
+            }
 
-			// go low and pull out the line number.
-			lowProps := reflect.ValueOf(n.Low)
-			if n.Low != nil && !lowProps.IsZero() && !lowProps.IsNil() {
-				gu := lowProps.Elem()
-				gi := gu.FieldByName(key)
-				jl := reflect.ValueOf(gi)
-				if !jl.IsZero() && gi.Interface() != nil {
-					gh := gi.Interface()
-					// extract low level key line number
-					if pr, ok := gh.(low.HasValueUnTyped); ok {
-						fg := reflect.ValueOf(pr.GetValueUntyped())
-						found := false
-						found, orderedCollection = n.extractLowMapKeys(fg, x, found, orderedCollection, m, k)
-						if found != true {
-							// this is something new, add it.
-							orderedCollection = append(orderedCollection, &NodeEntry{
-								Tag:   x,
-								Key:   x,
-								Line:  9999 + g,
-								Value: m.MapIndex(k).Interface(),
-							})
-						}
-					} else {
-						// this is a map, but it may be wrapped still.
-						bj := reflect.ValueOf(gh)
-						orderedCollection = n.extractLowMapKeysWrapped(bj, x, orderedCollection, g)
-					}
-				} else {
-					// this is a map, without any low level details available (probably an extension map).
-					orderedCollection = append(orderedCollection, &NodeEntry{
-						Tag:   x,
-						Key:   x,
-						Line:  9999 + g,
-						Value: m.MapIndex(k).Interface(),
-					})
-				}
-			} else {
-				// this is a map, without any low level details available (probably an extension map).
-				orderedCollection = append(orderedCollection, &NodeEntry{
-					Tag:   x,
-					Key:   x,
-					Line:  9999 + g,
-					Value: m.MapIndex(k).Interface(),
-				})
-			}
-		}
+            // go low and pull out the line number.
+            lowProps := reflect.ValueOf(n.Low)
+            if n.Low != nil && !lowProps.IsZero() && !lowProps.IsNil() {
+                gu := lowProps.Elem()
+                gi := gu.FieldByName(key)
+                jl := reflect.ValueOf(gi)
+                if !jl.IsZero() && gi.Interface() != nil {
+                    gh := gi.Interface()
+                    // extract low level key line number
+                    if pr, ok := gh.(low.HasValueUnTyped); ok {
+                        fg := reflect.ValueOf(pr.GetValueUntyped())
+                        found := false
+                        found, orderedCollection = n.extractLowMapKeys(fg, x, found, orderedCollection, m, k)
+                        if found != true {
+                            // this is something new, add it.
+                            orderedCollection = append(orderedCollection, &NodeEntry{
+                                Tag:   x,
+                                Key:   x,
+                                Line:  9999 + g,
+                                Value: m.MapIndex(k).Interface(),
+                            })
+                        }
+                    } else {
+                        // this is a map, but it may be wrapped still.
+                        bj := reflect.ValueOf(gh)
+                        orderedCollection = n.extractLowMapKeysWrapped(bj, x, orderedCollection, g)
+                    }
+                } else {
+                    // this is a map, without any low level details available (probably an extension map).
+                    orderedCollection = append(orderedCollection, &NodeEntry{
+                        Tag:   x,
+                        Key:   x,
+                        Line:  9999 + g,
+                        Value: m.MapIndex(k).Interface(),
+                    })
+                }
+            } else {
+                // this is a map, without any low level details available (probably an extension map).
+                orderedCollection = append(orderedCollection, &NodeEntry{
+                    Tag:   x,
+                    Key:   x,
+                    Line:  9999 + g,
+                    Value: m.MapIndex(k).Interface(),
+                })
+            }
+        }
 
-		// sort the slice by line number to ensure everything is rendered in order.
-		sort.Slice(orderedCollection, func(i, j int) bool {
-			return orderedCollection[i].Line < orderedCollection[j].Line
-		})
+        // sort the slice by line number to ensure everything is rendered in order.
+        sort.Slice(orderedCollection, func(i, j int) bool {
+            return orderedCollection[i].Line < orderedCollection[j].Line
+        })
 
-		// create an empty map.
-		p := utils.CreateEmptyMapNode()
+        // create an empty map.
+        p := utils.CreateEmptyMapNode()
 
-		// build out each map node in original order.
-		for _, cv := range orderedCollection {
-			n.AddYAMLNode(p, cv)
-		}
-		if len(p.Content) > 0 {
-			valueNode = p
-		}
+        // build out each map node in original order.
+        for _, cv := range orderedCollection {
+            n.AddYAMLNode(p, cv)
+        }
+        if len(p.Content) > 0 {
+            valueNode = p
+        }
 
-	case reflect.Slice:
+    case reflect.Slice:
 
-		var rawNode yaml.Node
-		m := reflect.ValueOf(value)
-		sl := utils.CreateEmptySequenceNode()
-		skip := false
-		for i := 0; i < m.Len(); i++ {
-			sqi := m.Index(i).Interface()
-			// check if this is a reference.
-			if glu, ok := sqi.(GoesLowUntyped); ok {
-				if glu != nil {
-					ut := glu.GoLowUntyped()
-					if !reflect.ValueOf(ut).IsNil() {
-						r := ut.(low.IsReferenced)
-						if ut != nil && r.GetReference() != "" &&
-							ut.(low.IsReferenced).IsReference() {
-							if !n.Resolve {
-								refNode := utils.CreateRefNode(glu.GoLowUntyped().(low.IsReferenced).GetReference())
-								sl.Content = append(sl.Content, refNode)
-								skip = true
-							} else {
-								skip = false
-							}
-						} else {
-							skip = false
-						}
-					}
-				}
-			}
-			if !skip {
-				if er, ko := sqi.(Renderable); ko {
-					var rend interface{}
-					if !n.Resolve {
-						rend, _ = er.(Renderable).MarshalYAML()
-					} else {
-						// try and render inline, if we can, otherwise treat as normal.
-						if _, ko := er.(RenderableInline); ko {
-							rend, _ = er.(RenderableInline).MarshalYAMLInline()
-						} else {
-							rend, _ = er.(Renderable).MarshalYAML()
-						}
-					}
-					// check if this is a pointer or not.
-					if _, ok := rend.(*yaml.Node); ok {
-						sl.Content = append(sl.Content, rend.(*yaml.Node))
-					}
-					if _, ok := rend.(yaml.Node); ok {
-						k := rend.(yaml.Node)
-						sl.Content = append(sl.Content, &k)
-					}
-				}
-			}
-		}
+        var rawNode yaml.Node
+        m := reflect.ValueOf(value)
+        sl := utils.CreateEmptySequenceNode()
+        skip := false
+        for i := 0; i < m.Len(); i++ {
+            sqi := m.Index(i).Interface()
+            // check if this is a reference.
+            if glu, ok := sqi.(GoesLowUntyped); ok {
+                if glu != nil {
+                    ut := glu.GoLowUntyped()
+                    if !reflect.ValueOf(ut).IsNil() {
+                        r := ut.(low.IsReferenced)
+                        if ut != nil && r.GetReference() != "" &&
+                            ut.(low.IsReferenced).IsReference() {
+                            if !n.Resolve {
+                                refNode := utils.CreateRefNode(glu.GoLowUntyped().(low.IsReferenced).GetReference())
+                                sl.Content = append(sl.Content, refNode)
+                                skip = true
+                            } else {
+                                skip = false
+                            }
+                        } else {
+                            skip = false
+                        }
+                    }
+                }
+            }
+            if !skip {
+                if er, ko := sqi.(Renderable); ko {
+                    var rend interface{}
+                    if !n.Resolve {
+                        rend, _ = er.(Renderable).MarshalYAML()
+                    } else {
+                        // try and render inline, if we can, otherwise treat as normal.
+                        if _, ko := er.(RenderableInline); ko {
+                            rend, _ = er.(RenderableInline).MarshalYAMLInline()
+                        } else {
+                            rend, _ = er.(Renderable).MarshalYAML()
+                        }
+                    }
+                    // check if this is a pointer or not.
+                    if _, ok := rend.(*yaml.Node); ok {
+                        sl.Content = append(sl.Content, rend.(*yaml.Node))
+                    }
+                    if _, ok := rend.(yaml.Node); ok {
+                        k := rend.(yaml.Node)
+                        sl.Content = append(sl.Content, &k)
+                    }
+                }
+            }
+        }
 
-		if len(sl.Content) > 0 {
-			valueNode = sl
-			break
-		}
-		if skip {
-			break
-		}
+        if len(sl.Content) > 0 {
+            valueNode = sl
+            break
+        }
+        if skip {
+            break
+        }
 
-		err := rawNode.Encode(value)
-		if err != nil {
-			return parent
-		} else {
-			valueNode = &rawNode
-		}
+        err := rawNode.Encode(value)
+        if err != nil {
+            return parent
+        } else {
+            valueNode = &rawNode
+        }
 
-	case reflect.Struct:
-		if r, ok := value.(low.ValueReference[any]); ok {
-			valueNode = r.GetValueNode()
-			break
-		}
-		if r, ok := value.(low.ValueReference[string]); ok {
-			valueNode = r.GetValueNode()
-			break
-		}
-		if r, ok := value.(low.NodeReference[string]); ok {
-			valueNode = r.GetValueNode()
-			break
-		}
-		return parent
+    case reflect.Struct:
+        if r, ok := value.(low.ValueReference[any]); ok {
+            valueNode = r.GetValueNode()
+            break
+        }
+        if r, ok := value.(low.ValueReference[string]); ok {
+            valueNode = r.GetValueNode()
+            break
+        }
+        if r, ok := value.(low.NodeReference[string]); ok {
+            valueNode = r.GetValueNode()
+            break
+        }
+        return parent
 
-	case reflect.Ptr:
-		if r, ok := value.(Renderable); ok {
-			if gl, lg := value.(GoesLowUntyped); lg {
-				if gl.GoLowUntyped() != nil {
-					ut := reflect.ValueOf(gl.GoLowUntyped())
-					if !ut.IsNil() {
-						if gl.GoLowUntyped().(low.IsReferenced).IsReference() {
-							if !n.Resolve {
-								// TODO: use renderReference here.
-								rvn := utils.CreateEmptyMapNode()
-								rvn.Content = append(rvn.Content, utils.CreateStringNode("$ref"))
-								rvn.Content = append(rvn.Content, utils.CreateStringNode(gl.GoLowUntyped().(low.IsReferenced).GetReference()))
-								valueNode = rvn
-								break
-							}
-						}
-					}
-				}
-			}
-			var rawRender interface{}
-			if !n.Resolve {
-				rawRender, _ = r.MarshalYAML()
-			} else {
-				// try an inline render if we can, otherwise there is no option but to default to the
-				// full render.
-				if _, ko := r.(RenderableInline); ko {
-					rawRender, _ = r.(RenderableInline).MarshalYAMLInline()
-				} else {
-					rawRender, _ = r.MarshalYAML()
-				}
-			}
-			if rawRender != nil {
-				if _, ko := rawRender.(*yaml.Node); ko {
-					valueNode = rawRender.(*yaml.Node)
-				}
-				if _, ko := rawRender.(yaml.Node); ko {
-					d := rawRender.(yaml.Node)
-					valueNode = &d
-				}
-			}
-		} else {
+    case reflect.Ptr:
+        if r, ok := value.(Renderable); ok {
+            if gl, lg := value.(GoesLowUntyped); lg {
+                if gl.GoLowUntyped() != nil {
+                    ut := reflect.ValueOf(gl.GoLowUntyped())
+                    if !ut.IsNil() {
+                        if gl.GoLowUntyped().(low.IsReferenced).IsReference() {
+                            if !n.Resolve {
+                                // TODO: use renderReference here.
+                                rvn := utils.CreateEmptyMapNode()
+                                rvn.Content = append(rvn.Content, utils.CreateStringNode("$ref"))
+                                rvn.Content = append(rvn.Content, utils.CreateStringNode(gl.GoLowUntyped().(low.IsReferenced).GetReference()))
+                                valueNode = rvn
+                                break
+                            }
+                        }
+                    }
+                }
+            }
+            var rawRender interface{}
+            if !n.Resolve {
+                rawRender, _ = r.MarshalYAML()
+            } else {
+                // try an inline render if we can, otherwise there is no option but to default to the
+                // full render.
+                if _, ko := r.(RenderableInline); ko {
+                    rawRender, _ = r.(RenderableInline).MarshalYAMLInline()
+                } else {
+                    rawRender, _ = r.MarshalYAML()
+                }
+            }
+            if rawRender != nil {
+                if _, ko := rawRender.(*yaml.Node); ko {
+                    valueNode = rawRender.(*yaml.Node)
+                }
+                if _, ko := rawRender.(yaml.Node); ko {
+                    d := rawRender.(yaml.Node)
+                    valueNode = &d
+                }
+            }
+        } else {
 
-			encodeSkip := false
-			// check if the value is a bool, int or float
-			if b, bok := value.(*bool); bok {
-				encodeSkip = true
-				if *b {
-					valueNode = utils.CreateBoolNode("true")
-					valueNode.Line = line
-				} else {
-					if entry.RenderZero {
-						valueNode = utils.CreateBoolNode("false")
-						valueNode.Line = line
-					}
-				}
-			}
-			if b, bok := value.(*int64); bok {
-				encodeSkip = true
-				if *b > 0 {
-					valueNode = utils.CreateIntNode(strconv.Itoa(int(*b)))
-					valueNode.Line = line
-				}
-			}
-			if b, bok := value.(*float64); bok {
-				encodeSkip = true
-				if *b > 0 {
-					valueNode = utils.CreateFloatNode(strconv.FormatFloat(*b, 'f', -1, 64))
-					valueNode.Line = line
-				}
-			}
-			if !encodeSkip {
-				var rawNode yaml.Node
-				err := rawNode.Encode(value)
-				if err != nil {
-					return parent
-				} else {
-					valueNode = &rawNode
-					valueNode.Line = line
-				}
-			}
-		}
+            encodeSkip := false
+            // check if the value is a bool, int or float
+            if b, bok := value.(*bool); bok {
+                encodeSkip = true
+                if *b {
+                    valueNode = utils.CreateBoolNode("true")
+                    valueNode.Line = line
+                } else {
+                    if entry.RenderZero {
+                        valueNode = utils.CreateBoolNode("false")
+                        valueNode.Line = line
+                    }
+                }
+            }
+            if b, bok := value.(*int64); bok {
+                encodeSkip = true
+                if *b > 0 {
+                    valueNode = utils.CreateIntNode(strconv.Itoa(int(*b)))
+                    valueNode.Line = line
+                }
+            }
+            if b, bok := value.(*float64); bok {
+                encodeSkip = true
+                if *b > 0 {
+                    valueNode = utils.CreateFloatNode(strconv.FormatFloat(*b, 'f', -1, 64))
+                    valueNode.Line = line
+                }
+            }
+            if !encodeSkip {
+                var rawNode yaml.Node
+                err := rawNode.Encode(value)
+                if err != nil {
+                    return parent
+                } else {
+                    valueNode = &rawNode
+                    valueNode.Line = line
+                }
+            }
+        }
 
-	}
-	if valueNode == nil {
-		return parent
-	}
-	if l != nil {
-		parent.Content = append(parent.Content, l, valueNode)
-	} else {
-		parent.Content = valueNode.Content
-	}
-	return parent
+    }
+    if valueNode == nil {
+        return parent
+    }
+    if l != nil {
+        parent.Content = append(parent.Content, l, valueNode)
+    } else {
+        parent.Content = valueNode.Content
+    }
+    return parent
 }
 
 func (n *NodeBuilder) extractLowMapKeysWrapped(iu reflect.Value, x string, orderedCollection []*NodeEntry, g int) []*NodeEntry {
-	for _, ky := range iu.MapKeys() {
-		ty := ky.Interface()
-		if ere, eok := ty.(low.HasKeyNode); eok {
-			er := ere.GetKeyNode().Value
-			if er == x {
-				orderedCollection = append(orderedCollection, &NodeEntry{
-					Tag:   x,
-					Key:   x,
-					Line:  ky.Interface().(low.HasKeyNode).GetKeyNode().Line,
-					Value: iu.MapIndex(ky).Interface(),
-				})
-			}
-		} else {
-			orderedCollection = append(orderedCollection, &NodeEntry{
-				Tag:   x,
-				Key:   x,
-				Line:  9999 + g,
-				Value: iu.MapIndex(ky).Interface(),
-			})
-		}
-	}
-	return orderedCollection
+    for _, ky := range iu.MapKeys() {
+        ty := ky.Interface()
+        if ere, eok := ty.(low.HasKeyNode); eok {
+            er := ere.GetKeyNode().Value
+            if er == x {
+                orderedCollection = append(orderedCollection, &NodeEntry{
+                    Tag:   x,
+                    Key:   x,
+                    Line:  ky.Interface().(low.HasKeyNode).GetKeyNode().Line,
+                    Value: iu.MapIndex(ky).Interface(),
+                })
+            }
+        } else {
+            orderedCollection = append(orderedCollection, &NodeEntry{
+                Tag:   x,
+                Key:   x,
+                Line:  9999 + g,
+                Value: iu.MapIndex(ky).Interface(),
+            })
+        }
+    }
+    return orderedCollection
 }
 
 func (n *NodeBuilder) extractLowMapKeys(fg reflect.Value, x string, found bool, orderedCollection []*NodeEntry, m reflect.Value, k reflect.Value) (bool, []*NodeEntry) {
-	for j, ky := range fg.MapKeys() {
-		hu := ky.Interface()
-		if we, wok := hu.(low.HasKeyNode); wok {
-			er := we.GetKeyNode().Value
-			if er == x {
-				found = true
-				orderedCollection = append(orderedCollection, &NodeEntry{
-					Tag:   x,
-					Key:   x,
-					Line:  we.GetKeyNode().Line,
-					Value: m.MapIndex(k).Interface(),
-				})
-			}
-		} else {
-			uu := ky.Interface()
-			if uu == x {
-				// this is a map, without any low level details available
-				found = true
-				orderedCollection = append(orderedCollection, &NodeEntry{
-					Tag:   uu.(string),
-					Key:   uu.(string),
-					Line:  9999 + j,
-					Value: m.MapIndex(k).Interface(),
-				})
-			}
-		}
-	}
-	return found, orderedCollection
+    for j, ky := range fg.MapKeys() {
+        hu := ky.Interface()
+        if we, wok := hu.(low.HasKeyNode); wok {
+            er := we.GetKeyNode().Value
+            if er == x {
+                found = true
+                orderedCollection = append(orderedCollection, &NodeEntry{
+                    Tag:   x,
+                    Key:   x,
+                    Line:  we.GetKeyNode().Line,
+                    Value: m.MapIndex(k).Interface(),
+                })
+            }
+        } else {
+            uu := ky.Interface()
+            if uu == x {
+                // this is a map, without any low level details available
+                found = true
+                orderedCollection = append(orderedCollection, &NodeEntry{
+                    Tag:   uu.(string),
+                    Key:   uu.(string),
+                    Line:  9999 + j,
+                    Value: m.MapIndex(k).Interface(),
+                })
+            }
+        }
+    }
+    return found, orderedCollection
 }
 
 // Renderable is an interface that can be implemented by types that provide a custom MarshaYAML method.
 type Renderable interface {
-	MarshalYAML() (interface{}, error)
+    MarshalYAML() (interface{}, error)
 }
 
 // RenderableInline is an interface that can be implemented by types that provide a custom MarshaYAML method.
 type RenderableInline interface {
-	MarshalYAMLInline() (interface{}, error)
+    MarshalYAMLInline() (interface{}, error)
 }

--- a/datamodel/high/node_builder_test.go
+++ b/datamodel/high/node_builder_test.go
@@ -4,218 +4,218 @@
 package high
 
 import (
-	"github.com/pb33f/libopenapi/datamodel/low"
-	"github.com/pb33f/libopenapi/utils"
-	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
-	"reflect"
-	"strings"
-	"testing"
+    "github.com/pb33f/libopenapi/datamodel/low"
+    "github.com/pb33f/libopenapi/utils"
+    "github.com/stretchr/testify/assert"
+    "gopkg.in/yaml.v3"
+    "reflect"
+    "strings"
+    "testing"
 )
 
 type key struct {
-	Name             string `yaml:"name,omitempty"`
-	ref              bool
-	refStr           string
-	ln               int
-	nilval           bool
-	v                any
-	kn               *yaml.Node
-	low.IsReferenced `yaml:"-"`
+    Name             string `yaml:"name,omitempty"`
+    ref              bool
+    refStr           string
+    ln               int
+    nilval           bool
+    v                any
+    kn               *yaml.Node
+    low.IsReferenced `yaml:"-"`
 }
 
 func (k key) GetKeyNode() *yaml.Node {
-	if k.kn != nil {
-		return k.kn
-	}
-	kn := utils.CreateStringNode("meddy")
-	kn.Line = k.ln
-	return kn
+    if k.kn != nil {
+        return k.kn
+    }
+    kn := utils.CreateStringNode("meddy")
+    kn.Line = k.ln
+    return kn
 }
 
 func (k key) GetValueUntyped() any {
-	return k.v
+    return k.v
 }
 
 func (k key) GetValueNode() *yaml.Node {
-	return k.GetValueNodeUntyped()
+    return k.GetValueNodeUntyped()
 }
 
 func (k key) GetValueNodeUntyped() *yaml.Node {
-	if k.nilval {
-		return nil
-	}
-	kn := utils.CreateStringNode("maddy")
-	kn.Line = k.ln
-	return kn
+    if k.nilval {
+        return nil
+    }
+    kn := utils.CreateStringNode("maddy")
+    kn.Line = k.ln
+    return kn
 }
 
 func (k key) IsReference() bool {
-	return k.ref
+    return k.ref
 }
 
 func (k key) GetReference() string {
-	return k.refStr
+    return k.refStr
 }
 
 func (k key) SetReference(ref string) {
-	k.refStr = ref
+    k.refStr = ref
 }
 
 func (k key) GoLowUntyped() any {
-	return &k
+    return &k
 }
 
 func (k key) MarshalYAML() (interface{}, error) {
-	return utils.CreateStringNode("pizza"), nil
+    return utils.CreateStringNode("pizza"), nil
 }
 
 func (k key) MarshalYAMLInline() (interface{}, error) {
-	return utils.CreateStringNode("pizza-inline!"), nil
+    return utils.CreateStringNode("pizza-inline!"), nil
 }
 
 type plug struct {
-	Name []string `yaml:"name,omitempty"`
+    Name []string `yaml:"name,omitempty"`
 }
 
 type test1 struct {
-	Thrig      map[string]*plug      `yaml:"thrig,omitempty"`
-	Thing      string                `yaml:"thing,omitempty"`
-	Thong      int                   `yaml:"thong,omitempty"`
-	Thrum      int64                 `yaml:"thrum,omitempty"`
-	Thang      float32               `yaml:"thang,omitempty"`
-	Thung      float64               `yaml:"thung,omitempty"`
-	Thyme      bool                  `yaml:"thyme,omitempty"`
-	Thurm      any                   `yaml:"thurm,omitempty"`
-	Thugg      *bool                 `yaml:"thugg,renderZero"`
-	Thurr      *int64                `yaml:"thurr,omitempty"`
-	Thral      *float64              `yaml:"thral,omitempty"`
-	Tharg      []string              `yaml:"tharg,omitempty"`
-	Type       []string              `yaml:"type,omitempty"`
-	Throg      []*key                `yaml:"throg,omitempty"`
-	Thrat      []interface{}         `yaml:"thrat,omitempty"`
-	Thrag      []map[string][]string `yaml:"thrag,omitempty"`
-	Thrug      map[string]string     `yaml:"thrug,omitempty"`
-	Thoom      []map[string]string   `yaml:"thoom,omitempty"`
-	Thomp      map[key]string        `yaml:"thomp,omitempty"`
-	Thump      key                   `yaml:"thump,omitempty"`
-	Thane      key                   `yaml:"thane,omitempty"`
-	Thunk      key                   `yaml:"thunk,omitempty"`
-	Thrim      *key                  `yaml:"thrim,omitempty"`
-	Thril      map[string]*key       `yaml:"thril,omitempty"`
-	Extensions map[string]any        `yaml:"-"`
-	ignoreMe   string                `yaml:"-"`
-	IgnoreMe   string                `yaml:"-"`
+    Thrig      map[string]*plug      `yaml:"thrig,omitempty"`
+    Thing      string                `yaml:"thing,omitempty"`
+    Thong      int                   `yaml:"thong,omitempty"`
+    Thrum      int64                 `yaml:"thrum,omitempty"`
+    Thang      float32               `yaml:"thang,omitempty"`
+    Thung      float64               `yaml:"thung,omitempty"`
+    Thyme      bool                  `yaml:"thyme,omitempty"`
+    Thurm      any                   `yaml:"thurm,omitempty"`
+    Thugg      *bool                 `yaml:"thugg,renderZero"`
+    Thurr      *int64                `yaml:"thurr,omitempty"`
+    Thral      *float64              `yaml:"thral,omitempty"`
+    Tharg      []string              `yaml:"tharg,omitempty"`
+    Type       []string              `yaml:"type,omitempty"`
+    Throg      []*key                `yaml:"throg,omitempty"`
+    Thrat      []interface{}         `yaml:"thrat,omitempty"`
+    Thrag      []map[string][]string `yaml:"thrag,omitempty"`
+    Thrug      map[string]string     `yaml:"thrug,omitempty"`
+    Thoom      []map[string]string   `yaml:"thoom,omitempty"`
+    Thomp      map[key]string        `yaml:"thomp,omitempty"`
+    Thump      key                   `yaml:"thump,omitempty"`
+    Thane      key                   `yaml:"thane,omitempty"`
+    Thunk      key                   `yaml:"thunk,omitempty"`
+    Thrim      *key                  `yaml:"thrim,omitempty"`
+    Thril      map[string]*key       `yaml:"thril,omitempty"`
+    Extensions map[string]any        `yaml:"-"`
+    ignoreMe   string                `yaml:"-"`
+    IgnoreMe   string                `yaml:"-"`
 }
 
 func (te *test1) GetExtensions() map[low.KeyReference[string]]low.ValueReference[any] {
 
-	g := make(map[low.KeyReference[string]]low.ValueReference[any])
+    g := make(map[low.KeyReference[string]]low.ValueReference[any])
 
-	for i := range te.Extensions {
+    for i := range te.Extensions {
 
-		f := reflect.TypeOf(te.Extensions[i])
-		switch f.Kind() {
-		case reflect.String:
-			vn := utils.CreateStringNode(te.Extensions[i].(string))
-			vn.Line = 999999 // weighted to the bottom.
-			g[low.KeyReference[string]{
-				Value:   i,
-				KeyNode: vn,
-			}] = low.ValueReference[any]{
-				ValueNode: vn,
-				Value:     te.Extensions[i].(string),
-			}
-		case reflect.Map:
-			kn := utils.CreateStringNode(i)
-			var vn yaml.Node
-			_ = vn.Decode(te.Extensions[i])
+        f := reflect.TypeOf(te.Extensions[i])
+        switch f.Kind() {
+        case reflect.String:
+            vn := utils.CreateStringNode(te.Extensions[i].(string))
+            vn.Line = 999999 // weighted to the bottom.
+            g[low.KeyReference[string]{
+                Value:   i,
+                KeyNode: vn,
+            }] = low.ValueReference[any]{
+                ValueNode: vn,
+                Value:     te.Extensions[i].(string),
+            }
+        case reflect.Map:
+            kn := utils.CreateStringNode(i)
+            var vn yaml.Node
+            _ = vn.Decode(te.Extensions[i])
 
-			kn.Line = 999999 // weighted to the bottom.
-			g[low.KeyReference[string]{
-				Value:   i,
-				KeyNode: kn,
-			}] = low.ValueReference[any]{
-				ValueNode: &vn,
-				Value:     te.Extensions[i],
-			}
-		}
+            kn.Line = 999999 // weighted to the bottom.
+            g[low.KeyReference[string]{
+                Value:   i,
+                KeyNode: kn,
+            }] = low.ValueReference[any]{
+                ValueNode: &vn,
+                Value:     te.Extensions[i],
+            }
+        }
 
-	}
-	return g
+    }
+    return g
 }
 
 func (te *test1) MarshalYAML() (interface{}, error) {
-	nb := NewNodeBuilder(te, te)
-	return nb.Render(), nil
+    nb := NewNodeBuilder(te, te)
+    return nb.Render(), nil
 }
 
 func (te *test1) GetKeyNode() *yaml.Node {
-	kn := utils.CreateStringNode("meddy")
-	kn.Line = 20
-	return kn
+    kn := utils.CreateStringNode("meddy")
+    kn.Line = 20
+    return kn
 }
 
 func (te *test1) GoesLowUntyped() any {
-	return te
+    return te
 }
 
 func TestNewNodeBuilder(t *testing.T) {
 
-	b := true
-	c := int64(12345)
-	d := 1234.1234
+    b := true
+    c := int64(12345)
+    d := 1234.1234
 
-	t1 := test1{
-		ignoreMe: "I should never be seen!",
-		Thing:    "ding",
-		Thong:    1,
-		Thurm:    nil,
-		Thrum:    1234567,
-		Thang:    2.2,
-		Thung:    3.33333,
-		Thyme:    true,
-		Thugg:    &b,
-		Thurr:    &c,
-		Thral:    &d,
-		Tharg:    []string{"chicken", "nuggets"},
-		Type:     []string{"chicken"},
-		Thoom: []map[string]string{
-			{
-				"maddy": "champion",
-			},
-			{
-				"ember": "naughty",
-			},
-		},
-		Thomp: map[key]string{
-			{ln: 1}: "princess",
-		},
-		Thane: key{ // this is going to be ignored, needs to be a ValueReference
-			ln:     2,
-			ref:    true,
-			refStr: "ripples",
-		},
-		Thrug: map[string]string{
-			"chicken": "nuggets",
-		},
-		Thump: key{Name: "I will be ignored", ln: 3},
-		Thunk: key{ln: 4, nilval: true},
-		Extensions: map[string]any{
-			"x-pizza": "time",
-		},
-	}
+    t1 := test1{
+        ignoreMe: "I should never be seen!",
+        Thing:    "ding",
+        Thong:    1,
+        Thurm:    nil,
+        Thrum:    1234567,
+        Thang:    2.2,
+        Thung:    3.33333,
+        Thyme:    true,
+        Thugg:    &b,
+        Thurr:    &c,
+        Thral:    &d,
+        Tharg:    []string{"chicken", "nuggets"},
+        Type:     []string{"chicken"},
+        Thoom: []map[string]string{
+            {
+                "maddy": "champion",
+            },
+            {
+                "ember": "naughty",
+            },
+        },
+        Thomp: map[key]string{
+            {ln: 1}: "princess",
+        },
+        Thane: key{ // this is going to be ignored, needs to be a ValueReference
+            ln:     2,
+            ref:    true,
+            refStr: "ripples",
+        },
+        Thrug: map[string]string{
+            "chicken": "nuggets",
+        },
+        Thump: key{Name: "I will be ignored", ln: 3},
+        Thunk: key{ln: 4, nilval: true},
+        Extensions: map[string]any{
+            "x-pizza": "time",
+        },
+    }
 
-	nb := NewNodeBuilder(&t1, nil)
-	node := nb.Render()
+    nb := NewNodeBuilder(&t1, nil)
+    node := nb.Render()
 
-	data, _ := yaml.Marshal(node)
+    data, _ := yaml.Marshal(node)
 
-	desired := `thing: ding
-thong: "1"
-thrum: "1234567"
-thang: 2.20
-thung: 3.33333
+    desired := `thing: ding
+thong: 1
+thrum: 1234567
+thang: 2.2
+thung: 3.33
 thyme: true
 thugg: true
 thurr: 12345
@@ -233,755 +233,755 @@ thomp:
     meddy: princess
 x-pizza: time`
 
-	assert.Equal(t, desired, strings.TrimSpace(string(data)))
+    assert.Equal(t, desired, strings.TrimSpace(string(data)))
 
 }
 
 func TestNewNodeBuilder_Type(t *testing.T) {
 
-	t1 := test1{
-		Type: []string{"chicken", "soup"},
-	}
+    t1 := test1{
+        Type: []string{"chicken", "soup"},
+    }
 
-	nb := NewNodeBuilder(&t1, &t1)
-	node := nb.Render()
+    nb := NewNodeBuilder(&t1, &t1)
+    node := nb.Render()
 
-	data, _ := yaml.Marshal(node)
+    data, _ := yaml.Marshal(node)
 
-	desired := `type:
+    desired := `type:
     - chicken
     - soup`
 
-	assert.Equal(t, desired, strings.TrimSpace(string(data)))
+    assert.Equal(t, desired, strings.TrimSpace(string(data)))
 }
 
 func TestNewNodeBuilder_IsReferenced(t *testing.T) {
 
-	t1 := key{
-		Name:   "cotton",
-		ref:    true,
-		refStr: "#/my/heart",
-		ln:     2,
-	}
+    t1 := key{
+        Name:   "cotton",
+        ref:    true,
+        refStr: "#/my/heart",
+        ln:     2,
+    }
 
-	nb := NewNodeBuilder(&t1, &t1)
-	node := nb.Render()
+    nb := NewNodeBuilder(&t1, &t1)
+    node := nb.Render()
 
-	data, _ := yaml.Marshal(node)
+    data, _ := yaml.Marshal(node)
 
-	desired := `$ref: '#/my/heart'`
+    desired := `$ref: '#/my/heart'`
 
-	assert.Equal(t, desired, strings.TrimSpace(string(data)))
+    assert.Equal(t, desired, strings.TrimSpace(string(data)))
 }
 
 func TestNewNodeBuilder_Extensions(t *testing.T) {
 
-	t1 := test1{
-		Thing: "ding",
-		Extensions: map[string]any{
-			"x-pizza": "time",
-			"x-money": "time",
-		},
-		Thong: 1,
-	}
+    t1 := test1{
+        Thing: "ding",
+        Extensions: map[string]any{
+            "x-pizza": "time",
+            "x-money": "time",
+        },
+        Thong: 1,
+    }
 
-	nb := NewNodeBuilder(&t1, &t1)
-	node := nb.Render()
+    nb := NewNodeBuilder(&t1, &t1)
+    node := nb.Render()
 
-	data, _ := yaml.Marshal(node)
-	assert.Len(t, data, 51)
+    data, _ := yaml.Marshal(node)
+    assert.Len(t, data, 49)
 }
 
 func TestNewNodeBuilder_LowValueNode(t *testing.T) {
 
-	t1 := test1{
-		Thing: "ding",
-		Extensions: map[string]any{
-			"x-pizza": "time",
-			"x-money": "time",
-		},
-		Thong: 1,
-	}
+    t1 := test1{
+        Thing: "ding",
+        Extensions: map[string]any{
+            "x-pizza": "time",
+            "x-money": "time",
+        },
+        Thong: 1,
+    }
 
-	nb := NewNodeBuilder(&t1, &t1)
-	node := nb.Render()
+    nb := NewNodeBuilder(&t1, &t1)
+    node := nb.Render()
 
-	data, _ := yaml.Marshal(node)
+    data, _ := yaml.Marshal(node)
 
-	assert.Len(t, data, 51)
+    assert.Len(t, data, 49)
 }
 
 func TestNewNodeBuilder_NoValue(t *testing.T) {
 
-	t1 := test1{
-		Thing: "",
-	}
+    t1 := test1{
+        Thing: "",
+    }
 
-	nodeEnty := NodeEntry{}
-	nb := NewNodeBuilder(&t1, &t1)
-	node := nb.AddYAMLNode(nil, &nodeEnty)
-	assert.Nil(t, node)
+    nodeEnty := NodeEntry{}
+    nb := NewNodeBuilder(&t1, &t1)
+    node := nb.AddYAMLNode(nil, &nodeEnty)
+    assert.Nil(t, node)
 }
 
 func TestNewNodeBuilder_EmptyString(t *testing.T) {
-	t1 := new(test1)
-	nodeEnty := NodeEntry{}
-	nb := NewNodeBuilder(t1, t1)
-	node := nb.AddYAMLNode(nil, &nodeEnty)
-	assert.Nil(t, node)
+    t1 := new(test1)
+    nodeEnty := NodeEntry{}
+    nb := NewNodeBuilder(t1, t1)
+    node := nb.AddYAMLNode(nil, &nodeEnty)
+    assert.Nil(t, node)
 }
 
 func TestNewNodeBuilder_EmptyStringRenderZero(t *testing.T) {
-	t1 := new(test1)
-	nodeEnty := NodeEntry{RenderZero: true, Value: ""}
-	nb := NewNodeBuilder(t1, t1)
-	m := utils.CreateEmptyMapNode()
-	node := nb.AddYAMLNode(m, &nodeEnty)
-	assert.NotNil(t, node)
+    t1 := new(test1)
+    nodeEnty := NodeEntry{RenderZero: true, Value: ""}
+    nb := NewNodeBuilder(t1, t1)
+    m := utils.CreateEmptyMapNode()
+    node := nb.AddYAMLNode(m, &nodeEnty)
+    assert.NotNil(t, node)
 }
 
 func TestNewNodeBuilder_Bool(t *testing.T) {
-	t1 := new(test1)
-	nb := NewNodeBuilder(t1, t1)
-	nodeEnty := NodeEntry{}
-	node := nb.AddYAMLNode(nil, &nodeEnty)
-	assert.Nil(t, node)
+    t1 := new(test1)
+    nb := NewNodeBuilder(t1, t1)
+    nodeEnty := NodeEntry{}
+    node := nb.AddYAMLNode(nil, &nodeEnty)
+    assert.Nil(t, node)
 }
 
 func TestNewNodeBuilder_BoolRenderZero(t *testing.T) {
-	type yui struct {
-		Thrit bool `yaml:"thrit,renderZero"`
-	}
-	t1 := new(yui)
-	t1.Thrit = false
-	nb := NewNodeBuilder(t1, t1)
-	r := nb.Render()
-	assert.NotNil(t, r)
+    type yui struct {
+        Thrit bool `yaml:"thrit,renderZero"`
+    }
+    t1 := new(yui)
+    t1.Thrit = false
+    nb := NewNodeBuilder(t1, t1)
+    r := nb.Render()
+    assert.NotNil(t, r)
 }
 
 func TestNewNodeBuilder_Int(t *testing.T) {
-	t1 := new(test1)
-	nb := NewNodeBuilder(t1, t1)
-	p := utils.CreateEmptyMapNode()
-	nodeEnty := NodeEntry{Tag: "p", Value: 12, Key: "p"}
-	node := nb.AddYAMLNode(p, &nodeEnty)
-	assert.NotNil(t, node)
-	assert.Len(t, node.Content, 2)
-	assert.Equal(t, "12", node.Content[1].Value)
+    t1 := new(test1)
+    nb := NewNodeBuilder(t1, t1)
+    p := utils.CreateEmptyMapNode()
+    nodeEnty := NodeEntry{Tag: "p", Value: 12, Key: "p"}
+    node := nb.AddYAMLNode(p, &nodeEnty)
+    assert.NotNil(t, node)
+    assert.Len(t, node.Content, 2)
+    assert.Equal(t, "12", node.Content[1].Value)
 }
 
 func TestNewNodeBuilder_Int64(t *testing.T) {
-	t1 := new(test1)
-	nb := NewNodeBuilder(t1, t1)
-	p := utils.CreateEmptyMapNode()
-	nodeEnty := NodeEntry{Tag: "p", Value: int64(234556), Key: "p"}
-	node := nb.AddYAMLNode(p, &nodeEnty)
-	assert.NotNil(t, node)
-	assert.Len(t, node.Content, 2)
-	assert.Equal(t, "234556", node.Content[1].Value)
+    t1 := new(test1)
+    nb := NewNodeBuilder(t1, t1)
+    p := utils.CreateEmptyMapNode()
+    nodeEnty := NodeEntry{Tag: "p", Value: int64(234556), Key: "p"}
+    node := nb.AddYAMLNode(p, &nodeEnty)
+    assert.NotNil(t, node)
+    assert.Len(t, node.Content, 2)
+    assert.Equal(t, "234556", node.Content[1].Value)
 }
 
 func TestNewNodeBuilder_Float32(t *testing.T) {
-	t1 := new(test1)
-	nb := NewNodeBuilder(t1, t1)
-	p := utils.CreateEmptyMapNode()
-	nodeEnty := NodeEntry{Tag: "p", Value: float32(1234.23), Key: "p"}
-	node := nb.AddYAMLNode(p, &nodeEnty)
-	assert.NotNil(t, node)
-	assert.Len(t, node.Content, 2)
-	assert.Equal(t, "1234.23", node.Content[1].Value)
+    t1 := new(test1)
+    nb := NewNodeBuilder(t1, t1)
+    p := utils.CreateEmptyMapNode()
+    nodeEnty := NodeEntry{Tag: "p", Value: float32(1234.23), Key: "p"}
+    node := nb.AddYAMLNode(p, &nodeEnty)
+    assert.NotNil(t, node)
+    assert.Len(t, node.Content, 2)
+    assert.Equal(t, "1234.23", node.Content[1].Value)
 }
 
 func TestNewNodeBuilder_Float64(t *testing.T) {
-	t1 := new(test1)
-	nb := NewNodeBuilder(t1, t1)
-	p := utils.CreateEmptyMapNode()
-	nodeEnty := NodeEntry{Tag: "p", Value: 1234.232323, Key: "p"}
-	node := nb.AddYAMLNode(p, &nodeEnty)
-	assert.NotNil(t, node)
-	assert.Len(t, node.Content, 2)
-	assert.Equal(t, "1234.232323", node.Content[1].Value)
+    t1 := new(test1)
+    nb := NewNodeBuilder(t1, t1)
+    p := utils.CreateEmptyMapNode()
+    nodeEnty := NodeEntry{Tag: "p", Value: 1234.232323, Key: "p", StringValue: "1234.232323"}
+    node := nb.AddYAMLNode(p, &nodeEnty)
+    assert.NotNil(t, node)
+    assert.Len(t, node.Content, 2)
+    assert.Equal(t, "1234.232323", node.Content[1].Value)
 }
 
 func TestNewNodeBuilder_EmptyNode(t *testing.T) {
-	t1 := new(test1)
-	nb := NewNodeBuilder(t1, t1)
-	nb.Nodes = nil
-	m := nb.Render()
-	assert.Len(t, m.Content, 0)
+    t1 := new(test1)
+    nb := NewNodeBuilder(t1, t1)
+    nb.Nodes = nil
+    m := nb.Render()
+    assert.Len(t, m.Content, 0)
 
 }
 
 func TestNewNodeBuilder_MapKeyHasValue(t *testing.T) {
 
-	t1 := test1{
-		Thrug: map[string]string{
-			"dump": "trump",
-		},
-	}
+    t1 := test1{
+        Thrug: map[string]string{
+            "dump": "trump",
+        },
+    }
 
-	type test1low struct {
-		Thrug key   `yaml:"thrug"`
-		Thugg *bool `yaml:"thugg"`
-	}
+    type test1low struct {
+        Thrug key   `yaml:"thrug"`
+        Thugg *bool `yaml:"thugg"`
+    }
 
-	t2 := test1low{
-		Thrug: key{
-			v: map[string]string{
-				"dump": "trump",
-			},
-			ln: 2,
-		},
-	}
+    t2 := test1low{
+        Thrug: key{
+            v: map[string]string{
+                "dump": "trump",
+            },
+            ln: 2,
+        },
+    }
 
-	nb := NewNodeBuilder(&t1, &t2)
-	node := nb.Render()
+    nb := NewNodeBuilder(&t1, &t2)
+    node := nb.Render()
 
-	data, _ := yaml.Marshal(node)
+    data, _ := yaml.Marshal(node)
 
-	desired := `thrug:
+    desired := `thrug:
     dump: trump`
 
-	assert.Equal(t, desired, strings.TrimSpace(string(data)))
+    assert.Equal(t, desired, strings.TrimSpace(string(data)))
 }
 
 func TestNewNodeBuilder_MapKeyHasValueThatHasValue(t *testing.T) {
 
-	t1 := test1{
-		Thomp: map[key]string{
-			{v: "who"}: "princess",
-		},
-	}
+    t1 := test1{
+        Thomp: map[key]string{
+            {v: "who"}: "princess",
+        },
+    }
 
-	type test1low struct {
-		Thomp key   `yaml:"thomp"`
-		Thugg *bool `yaml:"thugg"`
-	}
+    type test1low struct {
+        Thomp key   `yaml:"thomp"`
+        Thugg *bool `yaml:"thugg"`
+    }
 
-	t2 := test1low{
-		Thomp: key{
-			v: map[key]string{
-				{
-					v: key{
-						v:  "ice",
-						kn: utils.CreateStringNode("limes"),
-					},
-					kn: utils.CreateStringNode("chimes"),
-					ln: 6}: "princess",
-			},
-			ln: 2,
-		},
-	}
+    t2 := test1low{
+        Thomp: key{
+            v: map[key]string{
+                {
+                    v: key{
+                        v:  "ice",
+                        kn: utils.CreateStringNode("limes"),
+                    },
+                    kn: utils.CreateStringNode("chimes"),
+                    ln: 6}: "princess",
+            },
+            ln: 2,
+        },
+    }
 
-	nb := NewNodeBuilder(&t1, &t2)
-	node := nb.Render()
+    nb := NewNodeBuilder(&t1, &t2)
+    node := nb.Render()
 
-	data, _ := yaml.Marshal(node)
+    data, _ := yaml.Marshal(node)
 
-	desired := `thomp:
+    desired := `thomp:
     meddy: princess`
 
-	assert.Equal(t, desired, strings.TrimSpace(string(data)))
+    assert.Equal(t, desired, strings.TrimSpace(string(data)))
 }
 
 func TestNewNodeBuilder_MapKeyHasValueThatHasValueMatch(t *testing.T) {
 
-	t1 := test1{
-		Thomp: map[key]string{
-			{v: "who"}: "princess",
-		},
-	}
+    t1 := test1{
+        Thomp: map[key]string{
+            {v: "who"}: "princess",
+        },
+    }
 
-	type test1low struct {
-		Thomp low.NodeReference[map[key]string] `yaml:"thomp"`
-		Thugg *bool                             `yaml:"thugg"`
-	}
+    type test1low struct {
+        Thomp low.NodeReference[map[key]string] `yaml:"thomp"`
+        Thugg *bool                             `yaml:"thugg"`
+    }
 
-	g := low.NodeReference[map[key]string]{
-		Value: map[key]string{
-			{v: "my", kn: utils.CreateStringNode("limes")}: "princess",
-		},
-	}
+    g := low.NodeReference[map[key]string]{
+        Value: map[key]string{
+            {v: "my", kn: utils.CreateStringNode("limes")}: "princess",
+        },
+    }
 
-	t2 := test1low{
-		Thomp: g,
-	}
+    t2 := test1low{
+        Thomp: g,
+    }
 
-	nb := NewNodeBuilder(&t1, &t2)
-	node := nb.Render()
+    nb := NewNodeBuilder(&t1, &t2)
+    node := nb.Render()
 
-	data, _ := yaml.Marshal(node)
+    data, _ := yaml.Marshal(node)
 
-	desired := `thomp:
+    desired := `thomp:
     meddy: princess`
 
-	assert.Equal(t, desired, strings.TrimSpace(string(data)))
+    assert.Equal(t, desired, strings.TrimSpace(string(data)))
 }
 
 func TestNewNodeBuilder_MapKeyHasValueThatHasValueMatchKeyNode(t *testing.T) {
 
-	t1 := test1{
-		Thomp: map[key]string{
-			{v: "who"}: "princess",
-		},
-	}
+    t1 := test1{
+        Thomp: map[key]string{
+            {v: "who"}: "princess",
+        },
+    }
 
-	type test1low struct {
-		Thomp low.NodeReference[map[key]string] `yaml:"thomp"`
-		Thugg *bool                             `yaml:"thugg"`
-	}
+    type test1low struct {
+        Thomp low.NodeReference[map[key]string] `yaml:"thomp"`
+        Thugg *bool                             `yaml:"thugg"`
+    }
 
-	g := low.NodeReference[map[key]string]{
-		Value: map[key]string{
-			{v: "my", kn: utils.CreateStringNode("limes")}: "princess",
-		},
-	}
+    g := low.NodeReference[map[key]string]{
+        Value: map[key]string{
+            {v: "my", kn: utils.CreateStringNode("limes")}: "princess",
+        },
+    }
 
-	t2 := test1low{
-		Thomp: g,
-	}
+    t2 := test1low{
+        Thomp: g,
+    }
 
-	nb := NewNodeBuilder(&t1, &t2)
-	node := nb.Render()
+    nb := NewNodeBuilder(&t1, &t2)
+    node := nb.Render()
 
-	data, _ := yaml.Marshal(node)
+    data, _ := yaml.Marshal(node)
 
-	desired := `thomp:
+    desired := `thomp:
     meddy: princess`
 
-	assert.Equal(t, desired, strings.TrimSpace(string(data)))
+    assert.Equal(t, desired, strings.TrimSpace(string(data)))
 }
 
 func TestNewNodeBuilder_MapKeyHasValueThatHasValueMatch_NoWrap(t *testing.T) {
 
-	t1 := test1{
-		Thomp: map[key]string{
-			{v: "who"}: "princess",
-		},
-	}
+    t1 := test1{
+        Thomp: map[key]string{
+            {v: "who"}: "princess",
+        },
+    }
 
-	type test1low struct {
-		Thomp map[key]string `yaml:"thomp"`
-		Thugg *bool          `yaml:"thugg"`
-	}
+    type test1low struct {
+        Thomp map[key]string `yaml:"thomp"`
+        Thugg *bool          `yaml:"thugg"`
+    }
 
-	t2 := test1low{
-		Thomp: map[key]string{
-			{v: "my", kn: utils.CreateStringNode("meddy")}: "princess",
-		},
-	}
+    t2 := test1low{
+        Thomp: map[key]string{
+            {v: "my", kn: utils.CreateStringNode("meddy")}: "princess",
+        },
+    }
 
-	nb := NewNodeBuilder(&t1, &t2)
-	node := nb.Render()
+    nb := NewNodeBuilder(&t1, &t2)
+    node := nb.Render()
 
-	data, _ := yaml.Marshal(node)
+    data, _ := yaml.Marshal(node)
 
-	desired := `thomp:
+    desired := `thomp:
     meddy: princess`
 
-	assert.Equal(t, desired, strings.TrimSpace(string(data)))
+    assert.Equal(t, desired, strings.TrimSpace(string(data)))
 }
 
 func TestNewNodeBuilder_MissingLabel(t *testing.T) {
 
-	t1 := new(test1)
-	nb := NewNodeBuilder(t1, t1)
-	p := utils.CreateEmptyMapNode()
-	nodeEnty := NodeEntry{Value: 1234.232323, Key: "p"}
-	node := nb.AddYAMLNode(p, &nodeEnty)
-	assert.NotNil(t, node)
-	assert.Len(t, node.Content, 0)
+    t1 := new(test1)
+    nb := NewNodeBuilder(t1, t1)
+    p := utils.CreateEmptyMapNode()
+    nodeEnty := NodeEntry{Value: 1234.232323, Key: "p"}
+    node := nb.AddYAMLNode(p, &nodeEnty)
+    assert.NotNil(t, node)
+    assert.Len(t, node.Content, 0)
 }
 
 func TestNewNodeBuilder_ExtensionMap(t *testing.T) {
 
-	t1 := test1{
-		Thing: "ding",
-		Extensions: map[string]any{
-			"x-pizza": map[string]string{
-				"dump": "trump",
-			},
-			"x-money": "time",
-		},
-		Thong: 1,
-	}
+    t1 := test1{
+        Thing: "ding",
+        Extensions: map[string]any{
+            "x-pizza": map[string]string{
+                "dump": "trump",
+            },
+            "x-money": "time",
+        },
+        Thong: 1,
+    }
 
-	nb := NewNodeBuilder(&t1, &t1)
-	node := nb.Render()
+    nb := NewNodeBuilder(&t1, &t1)
+    node := nb.Render()
 
-	data, _ := yaml.Marshal(node)
+    data, _ := yaml.Marshal(node)
 
-	assert.Len(t, data, 62)
+    assert.Len(t, data, 60)
 }
 
 func TestNewNodeBuilder_MapKeyHasValueThatHasValueMismatch(t *testing.T) {
 
-	t1 := test1{
-		Extensions: map[string]any{
-			"x-pizza": map[string]string{
-				"dump": "trump",
-			},
-			"x-cake": map[string]string{
-				"maga": "nomore",
-			},
-		},
-		Thril: map[string]*key{
-			"princess": {v: "who", Name: "beef", ln: 2},
-			"heavy":    {v: "who", Name: "industries", ln: 3},
-		},
-	}
+    t1 := test1{
+        Extensions: map[string]any{
+            "x-pizza": map[string]string{
+                "dump": "trump",
+            },
+            "x-cake": map[string]string{
+                "maga": "nomore",
+            },
+        },
+        Thril: map[string]*key{
+            "princess": {v: "who", Name: "beef", ln: 2},
+            "heavy":    {v: "who", Name: "industries", ln: 3},
+        },
+    }
 
-	nb := NewNodeBuilder(&t1, nil)
-	node := nb.Render()
+    nb := NewNodeBuilder(&t1, nil)
+    node := nb.Render()
 
-	data, _ := yaml.Marshal(node)
+    data, _ := yaml.Marshal(node)
 
-	assert.Len(t, data, 94)
+    assert.Len(t, data, 94)
 }
 
 func TestNewNodeBuilder_SliceRef(t *testing.T) {
 
-	c := key{ref: true, refStr: "#/red/robin/yummmmm", Name: "milky"}
-	ty := []*key{&c}
-	t1 := test1{
-		Throg: ty,
-	}
+    c := key{ref: true, refStr: "#/red/robin/yummmmm", Name: "milky"}
+    ty := []*key{&c}
+    t1 := test1{
+        Throg: ty,
+    }
 
-	nb := NewNodeBuilder(&t1, &t1)
-	node := nb.Render()
+    nb := NewNodeBuilder(&t1, &t1)
+    node := nb.Render()
 
-	data, _ := yaml.Marshal(node)
+    data, _ := yaml.Marshal(node)
 
-	desired := `throg:
+    desired := `throg:
     - $ref: '#/red/robin/yummmmm'`
 
-	assert.Equal(t, desired, strings.TrimSpace(string(data)))
+    assert.Equal(t, desired, strings.TrimSpace(string(data)))
 }
 
 func TestNewNodeBuilder_SliceRef_Inline(t *testing.T) {
 
-	c := key{ref: true, refStr: "#/red/robin/yummmmm", Name: "milky"}
-	ty := []*key{&c}
-	t1 := test1{
-		Throg: ty,
-	}
+    c := key{ref: true, refStr: "#/red/robin/yummmmm", Name: "milky"}
+    ty := []*key{&c}
+    t1 := test1{
+        Throg: ty,
+    }
 
-	nb := NewNodeBuilder(&t1, &t1)
-	nb.Resolve = true
-	node := nb.Render()
+    nb := NewNodeBuilder(&t1, &t1)
+    nb.Resolve = true
+    node := nb.Render()
 
-	data, _ := yaml.Marshal(node)
+    data, _ := yaml.Marshal(node)
 
-	desired := `throg:
+    desired := `throg:
     - pizza-inline!`
 
-	assert.Equal(t, desired, strings.TrimSpace(string(data)))
+    assert.Equal(t, desired, strings.TrimSpace(string(data)))
 }
 
 type testRender struct {
 }
 
 func (t testRender) MarshalYAML() (interface{}, error) {
-	return utils.CreateStringNode("testy!"), nil
+    return utils.CreateStringNode("testy!"), nil
 }
 
 type testRenderRawNode struct {
 }
 
 func (t testRenderRawNode) MarshalYAML() (interface{}, error) {
-	return yaml.Node{Kind: yaml.ScalarNode, Value: "zesty!"}, nil
+    return yaml.Node{Kind: yaml.ScalarNode, Value: "zesty!"}, nil
 }
 
 func TestNewNodeBuilder_SliceRef_Inline_NotCompatible(t *testing.T) {
 
-	ty := []interface{}{testRender{}}
-	t1 := test1{
-		Thrat: ty,
-	}
+    ty := []interface{}{testRender{}}
+    t1 := test1{
+        Thrat: ty,
+    }
 
-	nb := NewNodeBuilder(&t1, &t1)
-	nb.Resolve = true
-	node := nb.Render()
+    nb := NewNodeBuilder(&t1, &t1)
+    nb.Resolve = true
+    node := nb.Render()
 
-	data, _ := yaml.Marshal(node)
+    data, _ := yaml.Marshal(node)
 
-	desired := `thrat:
+    desired := `thrat:
     - testy!`
 
-	assert.Equal(t, desired, strings.TrimSpace(string(data)))
+    assert.Equal(t, desired, strings.TrimSpace(string(data)))
 }
 
 func TestNewNodeBuilder_SliceRef_Inline_NotCompatible_NotPointer(t *testing.T) {
 
-	ty := []interface{}{testRenderRawNode{}}
-	t1 := test1{
-		Thrat: ty,
-	}
+    ty := []interface{}{testRenderRawNode{}}
+    t1 := test1{
+        Thrat: ty,
+    }
 
-	nb := NewNodeBuilder(&t1, &t1)
-	nb.Resolve = true
-	node := nb.Render()
+    nb := NewNodeBuilder(&t1, &t1)
+    nb.Resolve = true
+    node := nb.Render()
 
-	data, _ := yaml.Marshal(node)
+    data, _ := yaml.Marshal(node)
 
-	desired := `thrat:
+    desired := `thrat:
     - zesty!`
 
-	assert.Equal(t, desired, strings.TrimSpace(string(data)))
+    assert.Equal(t, desired, strings.TrimSpace(string(data)))
 }
 
 func TestNewNodeBuilder_PointerRef_Inline_NotCompatible_RawNode(t *testing.T) {
 
-	ty := testRenderRawNode{}
-	t1 := test1{
-		Thurm: &ty,
-	}
+    ty := testRenderRawNode{}
+    t1 := test1{
+        Thurm: &ty,
+    }
 
-	nb := NewNodeBuilder(&t1, &t1)
-	nb.Resolve = true
-	node := nb.Render()
+    nb := NewNodeBuilder(&t1, &t1)
+    nb.Resolve = true
+    node := nb.Render()
 
-	data, _ := yaml.Marshal(node)
+    data, _ := yaml.Marshal(node)
 
-	desired := `thurm: zesty!`
+    desired := `thurm: zesty!`
 
-	assert.Equal(t, desired, strings.TrimSpace(string(data)))
+    assert.Equal(t, desired, strings.TrimSpace(string(data)))
 }
 
 func TestNewNodeBuilder_PointerRef_Inline_NotCompatible(t *testing.T) {
 
-	ty := key{}
-	t1 := test1{
-		Thurm: &ty,
-	}
+    ty := key{}
+    t1 := test1{
+        Thurm: &ty,
+    }
 
-	nb := NewNodeBuilder(&t1, &t1)
-	nb.Resolve = true
-	node := nb.Render()
+    nb := NewNodeBuilder(&t1, &t1)
+    nb.Resolve = true
+    node := nb.Render()
 
-	data, _ := yaml.Marshal(node)
+    data, _ := yaml.Marshal(node)
 
-	desired := `thurm: pizza-inline!`
+    desired := `thurm: pizza-inline!`
 
-	assert.Equal(t, desired, strings.TrimSpace(string(data)))
+    assert.Equal(t, desired, strings.TrimSpace(string(data)))
 }
 
 func TestNewNodeBuilder_SliceNoRef(t *testing.T) {
 
-	c := key{ref: false, Name: "milky"}
-	ty := []*key{&c}
-	t1 := test1{
-		Throg: ty,
-	}
+    c := key{ref: false, Name: "milky"}
+    ty := []*key{&c}
+    t1 := test1{
+        Throg: ty,
+    }
 
-	nb := NewNodeBuilder(&t1, &t1)
-	node := nb.Render()
+    nb := NewNodeBuilder(&t1, &t1)
+    node := nb.Render()
 
-	data, _ := yaml.Marshal(node)
+    data, _ := yaml.Marshal(node)
 
-	desired := `throg:
+    desired := `throg:
     - pizza`
 
-	assert.Equal(t, desired, strings.TrimSpace(string(data)))
+    assert.Equal(t, desired, strings.TrimSpace(string(data)))
 }
 
 func TestNewNodeBuilder_TestStructAny(t *testing.T) {
 
-	t1 := test1{
-		Thurm: low.ValueReference[any]{
-			ValueNode: utils.CreateStringNode("beer"),
-		},
-	}
+    t1 := test1{
+        Thurm: low.ValueReference[any]{
+            ValueNode: utils.CreateStringNode("beer"),
+        },
+    }
 
-	nb := NewNodeBuilder(&t1, &t1)
-	node := nb.Render()
+    nb := NewNodeBuilder(&t1, &t1)
+    node := nb.Render()
 
-	data, _ := yaml.Marshal(node)
+    data, _ := yaml.Marshal(node)
 
-	desired := `thurm: beer`
+    desired := `thurm: beer`
 
-	assert.Equal(t, desired, strings.TrimSpace(string(data)))
+    assert.Equal(t, desired, strings.TrimSpace(string(data)))
 }
 func TestNewNodeBuilder_TestStructString(t *testing.T) {
 
-	t1 := test1{
-		Thurm: low.ValueReference[string]{
-			ValueNode: utils.CreateStringNode("beer"),
-		},
-	}
+    t1 := test1{
+        Thurm: low.ValueReference[string]{
+            ValueNode: utils.CreateStringNode("beer"),
+        },
+    }
 
-	nb := NewNodeBuilder(&t1, &t1)
-	node := nb.Render()
+    nb := NewNodeBuilder(&t1, &t1)
+    node := nb.Render()
 
-	data, _ := yaml.Marshal(node)
+    data, _ := yaml.Marshal(node)
 
-	desired := `thurm: beer`
+    desired := `thurm: beer`
 
-	assert.Equal(t, desired, strings.TrimSpace(string(data)))
+    assert.Equal(t, desired, strings.TrimSpace(string(data)))
 }
 
 func TestNewNodeBuilder_TestStructPointer(t *testing.T) {
 
-	t1 := test1{
-		Thrim: &key{
-			ref:    true,
-			refStr: "#/cash/money",
-			Name:   "pizza",
-		},
-	}
+    t1 := test1{
+        Thrim: &key{
+            ref:    true,
+            refStr: "#/cash/money",
+            Name:   "pizza",
+        },
+    }
 
-	nb := NewNodeBuilder(&t1, &t1)
-	node := nb.Render()
+    nb := NewNodeBuilder(&t1, &t1)
+    node := nb.Render()
 
-	data, _ := yaml.Marshal(node)
+    data, _ := yaml.Marshal(node)
 
-	desired := `thrim:
+    desired := `thrim:
     $ref: '#/cash/money'`
 
-	assert.Equal(t, desired, strings.TrimSpace(string(data)))
+    assert.Equal(t, desired, strings.TrimSpace(string(data)))
 }
 
 func TestNewNodeBuilder_TestStructRef(t *testing.T) {
 
-	fkn := utils.CreateStringNode("pizzaBurgers")
-	fkn.Line = 22
+    fkn := utils.CreateStringNode("pizzaBurgers")
+    fkn.Line = 22
 
-	t1 := test1{
-		Thurm: low.NodeReference[string]{
-			Reference:     "#/cash/money",
-			ReferenceNode: true,
-			KeyNode:       fkn,
-			ValueNode:     fkn,
-		},
-	}
+    t1 := test1{
+        Thurm: low.NodeReference[string]{
+            Reference:     "#/cash/money",
+            ReferenceNode: true,
+            KeyNode:       fkn,
+            ValueNode:     fkn,
+        },
+    }
 
-	nb := NewNodeBuilder(&t1, &t1)
-	node := nb.Render()
+    nb := NewNodeBuilder(&t1, &t1)
+    node := nb.Render()
 
-	data, _ := yaml.Marshal(node)
+    data, _ := yaml.Marshal(node)
 
-	desired := `thurm: pizzaBurgers`
+    desired := `thurm: pizzaBurgers`
 
-	assert.Equal(t, desired, strings.TrimSpace(string(data)))
+    assert.Equal(t, desired, strings.TrimSpace(string(data)))
 }
 
 func TestNewNodeBuilder_TestStructDefaultEncode(t *testing.T) {
 
-	f := 1
-	t1 := test1{
-		Thurm: &f,
-	}
+    f := 1
+    t1 := test1{
+        Thurm: &f,
+    }
 
-	nb := NewNodeBuilder(&t1, &t1)
-	node := nb.Render()
+    nb := NewNodeBuilder(&t1, &t1)
+    node := nb.Render()
 
-	data, _ := yaml.Marshal(node)
+    data, _ := yaml.Marshal(node)
 
-	desired := `thurm: 1`
+    desired := `thurm: 1`
 
-	assert.Equal(t, desired, strings.TrimSpace(string(data)))
+    assert.Equal(t, desired, strings.TrimSpace(string(data)))
 }
 
 func TestNewNodeBuilder_TestSliceMapSliceStruct(t *testing.T) {
 
-	a := []map[string][]string{
-		{"pizza": {"beer", "wine"}},
-	}
+    a := []map[string][]string{
+        {"pizza": {"beer", "wine"}},
+    }
 
-	t1 := test1{
-		Thrag: a,
-	}
+    t1 := test1{
+        Thrag: a,
+    }
 
-	nb := NewNodeBuilder(&t1, &t1)
-	node := nb.Render()
+    nb := NewNodeBuilder(&t1, &t1)
+    node := nb.Render()
 
-	data, _ := yaml.Marshal(node)
+    data, _ := yaml.Marshal(node)
 
-	desired := `thrag:
+    desired := `thrag:
     - pizza:
         - beer
         - wine`
 
-	assert.Equal(t, desired, strings.TrimSpace(string(data)))
+    assert.Equal(t, desired, strings.TrimSpace(string(data)))
 }
 
 func TestNewNodeBuilder_TestRenderZero(t *testing.T) {
 
-	f := false
-	t1 := test1{
-		Thugg: &f,
-	}
+    f := false
+    t1 := test1{
+        Thugg: &f,
+    }
 
-	nb := NewNodeBuilder(&t1, &t1)
-	node := nb.Render()
+    nb := NewNodeBuilder(&t1, &t1)
+    node := nb.Render()
 
-	data, _ := yaml.Marshal(node)
+    data, _ := yaml.Marshal(node)
 
-	desired := `thugg: false`
+    desired := `thugg: false`
 
-	assert.Equal(t, desired, strings.TrimSpace(string(data)))
+    assert.Equal(t, desired, strings.TrimSpace(string(data)))
 }
 
 func TestNewNodeBuilder_TestRenderServerVariableSimulation(t *testing.T) {
 
-	t1 := test1{
-		Thrig: map[string]*plug{
-			"pork": {Name: []string{"gammon", "bacon"}},
-		},
-	}
+    t1 := test1{
+        Thrig: map[string]*plug{
+            "pork": {Name: []string{"gammon", "bacon"}},
+        },
+    }
 
-	nb := NewNodeBuilder(&t1, &t1)
-	node := nb.Render()
+    nb := NewNodeBuilder(&t1, &t1)
+    node := nb.Render()
 
-	data, _ := yaml.Marshal(node)
+    data, _ := yaml.Marshal(node)
 
-	desired := `thrig:
+    desired := `thrig:
     pork:
         name:
             - gammon
             - bacon`
 
-	assert.Equal(t, desired, strings.TrimSpace(string(data)))
+    assert.Equal(t, desired, strings.TrimSpace(string(data)))
 }
 
 func TestNewNodeBuilder_ShouldHaveNotDoneTestsLikeThisOhWell(t *testing.T) {
 
-	m := make(map[low.KeyReference[string]]low.ValueReference[*key])
+    m := make(map[low.KeyReference[string]]low.ValueReference[*key])
 
-	m[low.KeyReference[string]{
-		KeyNode: utils.CreateStringNode("pizza"),
-		Value:   "pizza",
-	}] = low.ValueReference[*key]{
-		ValueNode: utils.CreateStringNode("beer"),
-		Value:     &key{},
-	}
+    m[low.KeyReference[string]{
+        KeyNode: utils.CreateStringNode("pizza"),
+        Value:   "pizza",
+    }] = low.ValueReference[*key]{
+        ValueNode: utils.CreateStringNode("beer"),
+        Value:     &key{},
+    }
 
-	d := make(map[string]*key)
-	d["pizza"] = &key{}
+    d := make(map[string]*key)
+    d["pizza"] = &key{}
 
-	type t1low struct {
-		Thril low.NodeReference[map[low.KeyReference[string]]low.ValueReference[*key]]
-		Thugg *bool `yaml:"thugg"`
-	}
+    type t1low struct {
+        Thril low.NodeReference[map[low.KeyReference[string]]low.ValueReference[*key]]
+        Thugg *bool `yaml:"thugg"`
+    }
 
-	t1 := test1{
-		Thril: d,
-	}
+    t1 := test1{
+        Thril: d,
+    }
 
-	t2 := t1low{
-		Thril: low.NodeReference[map[low.KeyReference[string]]low.ValueReference[*key]]{
-			Value:     m,
-			ValueNode: utils.CreateStringNode("beer"),
-		},
-	}
+    t2 := t1low{
+        Thril: low.NodeReference[map[low.KeyReference[string]]low.ValueReference[*key]]{
+            Value:     m,
+            ValueNode: utils.CreateStringNode("beer"),
+        },
+    }
 
-	nb := NewNodeBuilder(&t1, &t2)
-	node := nb.Render()
+    nb := NewNodeBuilder(&t1, &t2)
+    node := nb.Render()
 
-	data, _ := yaml.Marshal(node)
+    data, _ := yaml.Marshal(node)
 
-	desired := `thril:
+    desired := `thril:
     pizza: pizza`
 
-	assert.Equal(t, desired, strings.TrimSpace(string(data)))
+    assert.Equal(t, desired, strings.TrimSpace(string(data)))
 }

--- a/datamodel/low/base/schema.go
+++ b/datamodel/low/base/schema.go
@@ -1,17 +1,17 @@
 package base
 
 import (
-	"crypto/sha256"
-	"fmt"
-	"reflect"
-	"sort"
-	"strconv"
-	"strings"
+    "crypto/sha256"
+    "fmt"
+    "reflect"
+    "sort"
+    "strconv"
+    "strings"
 
-	"github.com/pb33f/libopenapi/datamodel/low"
-	"github.com/pb33f/libopenapi/index"
-	"github.com/pb33f/libopenapi/utils"
-	"gopkg.in/yaml.v3"
+    "github.com/pb33f/libopenapi/datamodel/low"
+    "github.com/pb33f/libopenapi/index"
+    "github.com/pb33f/libopenapi/utils"
+    "gopkg.in/yaml.v3"
 )
 
 // SchemaDynamicValue is used to hold multiple possible values for a schema property. There are two values, a left
@@ -23,19 +23,19 @@ import (
 // The N value is a bit to make it each to know which value (A or B) is used, this prevents having to
 // if/else on the value to determine which one is set.
 type SchemaDynamicValue[A any, B any] struct {
-	N int // 0 == A, 1 == B
-	A A
-	B B
+    N int // 0 == A, 1 == B
+    A A
+    B B
 }
 
 // IsA will return true if the 'A' or left value is set. (OpenAPI 3)
 func (s SchemaDynamicValue[A, B]) IsA() bool {
-	return s.N == 0
+    return s.N == 0
 }
 
 // IsB will return true if the 'B' or right value is set (OpenAPI 3.1)
 func (s SchemaDynamicValue[A, B]) IsB() bool {
-	return s.N == 1
+    return s.N == 1
 }
 
 // Schema represents a JSON Schema that support Swagger, OpenAPI 3 and OpenAPI 3.1
@@ -48,451 +48,451 @@ func (s SchemaDynamicValue[A, B]) IsB() bool {
 //   - v3 schema: https://swagger.io/specification/#schema-object
 //   - v3.1 schema: https://spec.openapis.org/oas/v3.1.0#schema-object
 type Schema struct {
-	// Reference to the '$schema' dialect setting (3.1 only)
-	SchemaTypeRef low.NodeReference[string]
+    // Reference to the '$schema' dialect setting (3.1 only)
+    SchemaTypeRef low.NodeReference[string]
 
-	// In versions 2 and 3.0, this ExclusiveMaximum can only be a boolean.
-	ExclusiveMaximum low.NodeReference[*SchemaDynamicValue[bool, int64]]
+    // In versions 2 and 3.0, this ExclusiveMaximum can only be a boolean.
+    ExclusiveMaximum low.NodeReference[*SchemaDynamicValue[bool, int64]]
 
-	// In versions 2 and 3.0, this ExclusiveMinimum can only be a boolean.
-	ExclusiveMinimum low.NodeReference[*SchemaDynamicValue[bool, int64]]
+    // In versions 2 and 3.0, this ExclusiveMinimum can only be a boolean.
+    ExclusiveMinimum low.NodeReference[*SchemaDynamicValue[bool, int64]]
 
-	// In versions 2 and 3.0, this Type is a single value, so array will only ever have one value
-	// in version 3.1, Type can be multiple values
-	Type low.NodeReference[SchemaDynamicValue[string, []low.ValueReference[string]]]
+    // In versions 2 and 3.0, this Type is a single value, so array will only ever have one value
+    // in version 3.1, Type can be multiple values
+    Type low.NodeReference[SchemaDynamicValue[string, []low.ValueReference[string]]]
 
-	// Schemas are resolved on demand using a SchemaProxy
-	AllOf low.NodeReference[[]low.ValueReference[*SchemaProxy]]
+    // Schemas are resolved on demand using a SchemaProxy
+    AllOf low.NodeReference[[]low.ValueReference[*SchemaProxy]]
 
-	// Polymorphic Schemas are only available in version 3+
-	OneOf         low.NodeReference[[]low.ValueReference[*SchemaProxy]]
-	AnyOf         low.NodeReference[[]low.ValueReference[*SchemaProxy]]
-	Discriminator low.NodeReference[*Discriminator]
+    // Polymorphic Schemas are only available in version 3+
+    OneOf         low.NodeReference[[]low.ValueReference[*SchemaProxy]]
+    AnyOf         low.NodeReference[[]low.ValueReference[*SchemaProxy]]
+    Discriminator low.NodeReference[*Discriminator]
 
-	// in 3.1 examples can be an array (which is recommended)
-	Examples low.NodeReference[[]low.ValueReference[any]]
-	// in 3.1 PrefixItems provides tuple validation using prefixItems.
-	PrefixItems low.NodeReference[[]low.ValueReference[*SchemaProxy]]
-	// in 3.1 Contains is used by arrays and points to a Schema.
-	Contains    low.NodeReference[*SchemaProxy]
-	MinContains low.NodeReference[int64]
-	MaxContains low.NodeReference[int64]
+    // in 3.1 examples can be an array (which is recommended)
+    Examples low.NodeReference[[]low.ValueReference[any]]
+    // in 3.1 PrefixItems provides tuple validation using prefixItems.
+    PrefixItems low.NodeReference[[]low.ValueReference[*SchemaProxy]]
+    // in 3.1 Contains is used by arrays and points to a Schema.
+    Contains    low.NodeReference[*SchemaProxy]
+    MinContains low.NodeReference[int64]
+    MaxContains low.NodeReference[int64]
 
-	// items can be a schema in 2.0, 3.0 and 3.1 or a bool in 3.1
-	Items low.NodeReference[*SchemaDynamicValue[*SchemaProxy, bool]]
+    // items can be a schema in 2.0, 3.0 and 3.1 or a bool in 3.1
+    Items low.NodeReference[*SchemaDynamicValue[*SchemaProxy, bool]]
 
-	// 3.1 only
-	If                    low.NodeReference[*SchemaProxy]
-	Else                  low.NodeReference[*SchemaProxy]
-	Then                  low.NodeReference[*SchemaProxy]
-	DependentSchemas      low.NodeReference[map[low.KeyReference[string]]low.ValueReference[*SchemaProxy]]
-	PatternProperties     low.NodeReference[map[low.KeyReference[string]]low.ValueReference[*SchemaProxy]]
-	PropertyNames         low.NodeReference[*SchemaProxy]
-	UnevaluatedItems      low.NodeReference[*SchemaProxy]
-	UnevaluatedProperties low.NodeReference[*SchemaProxy]
-	Anchor                low.NodeReference[string]
+    // 3.1 only
+    If                    low.NodeReference[*SchemaProxy]
+    Else                  low.NodeReference[*SchemaProxy]
+    Then                  low.NodeReference[*SchemaProxy]
+    DependentSchemas      low.NodeReference[map[low.KeyReference[string]]low.ValueReference[*SchemaProxy]]
+    PatternProperties     low.NodeReference[map[low.KeyReference[string]]low.ValueReference[*SchemaProxy]]
+    PropertyNames         low.NodeReference[*SchemaProxy]
+    UnevaluatedItems      low.NodeReference[*SchemaProxy]
+    UnevaluatedProperties low.NodeReference[*SchemaProxy]
+    Anchor                low.NodeReference[string]
 
-	// Compatible with all versions
-	Title                low.NodeReference[string]
-	MultipleOf           low.NodeReference[int64]
-	Maximum              low.NodeReference[int64]
-	Minimum              low.NodeReference[int64]
-	MaxLength            low.NodeReference[int64]
-	MinLength            low.NodeReference[int64]
-	Pattern              low.NodeReference[string]
-	Format               low.NodeReference[string]
-	MaxItems             low.NodeReference[int64]
-	MinItems             low.NodeReference[int64]
-	UniqueItems          low.NodeReference[int64]
-	MaxProperties        low.NodeReference[int64]
-	MinProperties        low.NodeReference[int64]
-	Required             low.NodeReference[[]low.ValueReference[string]]
-	Enum                 low.NodeReference[[]low.ValueReference[any]]
-	Not                  low.NodeReference[*SchemaProxy]
-	Properties           low.NodeReference[map[low.KeyReference[string]]low.ValueReference[*SchemaProxy]]
-	AdditionalProperties low.NodeReference[any]
-	Description          low.NodeReference[string]
-	ContentEncoding      low.NodeReference[string]
-	ContentMediaType     low.NodeReference[string]
-	Default              low.NodeReference[any]
-	Nullable             low.NodeReference[bool]
-	ReadOnly             low.NodeReference[bool]
-	WriteOnly            low.NodeReference[bool]
-	XML                  low.NodeReference[*XML]
-	ExternalDocs         low.NodeReference[*ExternalDoc]
-	Example              low.NodeReference[any]
-	Deprecated           low.NodeReference[bool]
-	Extensions           map[low.KeyReference[string]]low.ValueReference[any]
+    // Compatible with all versions
+    Title                low.NodeReference[string]
+    MultipleOf           low.NodeReference[int64]
+    Maximum              low.NodeReference[int64]
+    Minimum              low.NodeReference[int64]
+    MaxLength            low.NodeReference[int64]
+    MinLength            low.NodeReference[int64]
+    Pattern              low.NodeReference[string]
+    Format               low.NodeReference[string]
+    MaxItems             low.NodeReference[int64]
+    MinItems             low.NodeReference[int64]
+    UniqueItems          low.NodeReference[bool]
+    MaxProperties        low.NodeReference[int64]
+    MinProperties        low.NodeReference[int64]
+    Required             low.NodeReference[[]low.ValueReference[string]]
+    Enum                 low.NodeReference[[]low.ValueReference[any]]
+    Not                  low.NodeReference[*SchemaProxy]
+    Properties           low.NodeReference[map[low.KeyReference[string]]low.ValueReference[*SchemaProxy]]
+    AdditionalProperties low.NodeReference[any]
+    Description          low.NodeReference[string]
+    ContentEncoding      low.NodeReference[string]
+    ContentMediaType     low.NodeReference[string]
+    Default              low.NodeReference[any]
+    Nullable             low.NodeReference[bool]
+    ReadOnly             low.NodeReference[bool]
+    WriteOnly            low.NodeReference[bool]
+    XML                  low.NodeReference[*XML]
+    ExternalDocs         low.NodeReference[*ExternalDoc]
+    Example              low.NodeReference[any]
+    Deprecated           low.NodeReference[bool]
+    Extensions           map[low.KeyReference[string]]low.ValueReference[any]
 
-	// Parent Proxy refers back to the low level SchemaProxy that is proxying this schema.
-	ParentProxy *SchemaProxy
-	*low.Reference
+    // Parent Proxy refers back to the low level SchemaProxy that is proxying this schema.
+    ParentProxy *SchemaProxy
+    *low.Reference
 }
 
 // Hash will calculate a SHA256 hash from the values of the schema, This allows equality checking against
 // Schemas defined inside an OpenAPI document. The only way to know if a schema has changed, is to hash it.
 func (s *Schema) Hash() [32]byte {
-	// calculate a hash from every property in the schema.
-	var d []string
-	if !s.SchemaTypeRef.IsEmpty() {
-		d = append(d, fmt.Sprint(s.SchemaTypeRef.Value))
-	}
-	if !s.Title.IsEmpty() {
-		d = append(d, fmt.Sprint(s.Title.Value))
-	}
-	if !s.MultipleOf.IsEmpty() {
-		d = append(d, fmt.Sprint(s.MultipleOf.Value))
-	}
-	if !s.Maximum.IsEmpty() {
-		d = append(d, fmt.Sprint(s.Maximum.Value))
-	}
-	if !s.Minimum.IsEmpty() {
-		d = append(d, fmt.Sprint(s.Minimum.Value))
-	}
-	if !s.MaxLength.IsEmpty() {
-		d = append(d, fmt.Sprint(s.MaxLength.Value))
-	}
-	if !s.MinLength.IsEmpty() {
-		d = append(d, fmt.Sprint(s.MinLength.Value))
-	}
-	if !s.Pattern.IsEmpty() {
-		d = append(d, fmt.Sprint(s.Pattern.Value))
-	}
-	if !s.Format.IsEmpty() {
-		d = append(d, fmt.Sprint(s.Format.Value))
-	}
-	if !s.MaxItems.IsEmpty() {
-		d = append(d, fmt.Sprint(s.MaxItems.Value))
-	}
-	if !s.MinItems.IsEmpty() {
-		d = append(d, fmt.Sprint(s.MinItems.Value))
-	}
-	if !s.UniqueItems.IsEmpty() {
-		d = append(d, fmt.Sprint(s.UniqueItems.Value))
-	}
-	if !s.MaxProperties.IsEmpty() {
-		d = append(d, fmt.Sprint(s.MaxProperties.Value))
-	}
-	if !s.MinProperties.IsEmpty() {
-		d = append(d, fmt.Sprint(s.MinProperties.Value))
-	}
-	if !s.AdditionalProperties.IsEmpty() {
+    // calculate a hash from every property in the schema.
+    var d []string
+    if !s.SchemaTypeRef.IsEmpty() {
+        d = append(d, fmt.Sprint(s.SchemaTypeRef.Value))
+    }
+    if !s.Title.IsEmpty() {
+        d = append(d, fmt.Sprint(s.Title.Value))
+    }
+    if !s.MultipleOf.IsEmpty() {
+        d = append(d, fmt.Sprint(s.MultipleOf.Value))
+    }
+    if !s.Maximum.IsEmpty() {
+        d = append(d, fmt.Sprint(s.Maximum.Value))
+    }
+    if !s.Minimum.IsEmpty() {
+        d = append(d, fmt.Sprint(s.Minimum.Value))
+    }
+    if !s.MaxLength.IsEmpty() {
+        d = append(d, fmt.Sprint(s.MaxLength.Value))
+    }
+    if !s.MinLength.IsEmpty() {
+        d = append(d, fmt.Sprint(s.MinLength.Value))
+    }
+    if !s.Pattern.IsEmpty() {
+        d = append(d, fmt.Sprint(s.Pattern.Value))
+    }
+    if !s.Format.IsEmpty() {
+        d = append(d, fmt.Sprint(s.Format.Value))
+    }
+    if !s.MaxItems.IsEmpty() {
+        d = append(d, fmt.Sprint(s.MaxItems.Value))
+    }
+    if !s.MinItems.IsEmpty() {
+        d = append(d, fmt.Sprint(s.MinItems.Value))
+    }
+    if !s.UniqueItems.IsEmpty() {
+        d = append(d, fmt.Sprint(s.UniqueItems.Value))
+    }
+    if !s.MaxProperties.IsEmpty() {
+        d = append(d, fmt.Sprint(s.MaxProperties.Value))
+    }
+    if !s.MinProperties.IsEmpty() {
+        d = append(d, fmt.Sprint(s.MinProperties.Value))
+    }
+    if !s.AdditionalProperties.IsEmpty() {
 
-		// check type of properties, if we have a low level map, we need to hash the values in a repeatable
-		// order.
-		to := reflect.TypeOf(s.AdditionalProperties.Value)
-		vo := reflect.ValueOf(s.AdditionalProperties.Value)
-		var values []string
-		switch to.Kind() {
-		case reflect.Slice:
-			for i := 0; i < vo.Len(); i++ {
-				vn := vo.Index(i).Interface()
+        // check type of properties, if we have a low level map, we need to hash the values in a repeatable
+        // order.
+        to := reflect.TypeOf(s.AdditionalProperties.Value)
+        vo := reflect.ValueOf(s.AdditionalProperties.Value)
+        var values []string
+        switch to.Kind() {
+        case reflect.Slice:
+            for i := 0; i < vo.Len(); i++ {
+                vn := vo.Index(i).Interface()
 
-				if jh, ok := vn.(low.HasValueUnTyped); ok {
-					vn = jh.GetValueUntyped()
-					fg := reflect.TypeOf(vn)
-					gf := reflect.ValueOf(vn)
+                if jh, ok := vn.(low.HasValueUnTyped); ok {
+                    vn = jh.GetValueUntyped()
+                    fg := reflect.TypeOf(vn)
+                    gf := reflect.ValueOf(vn)
 
-					if fg.Kind() == reflect.Map {
-						for _, ky := range gf.MapKeys() {
-							hu := ky.Interface()
-							values = append(values, fmt.Sprintf("%s:%s", hu, low.GenerateHashString(gf.MapIndex(ky).Interface())))
-						}
-						continue
-					}
-					values = append(values, fmt.Sprintf("%d:%s", i, low.GenerateHashString(vn)))
-				}
-			}
-			sort.Strings(values)
-			d = append(d, strings.Join(values, "||"))
+                    if fg.Kind() == reflect.Map {
+                        for _, ky := range gf.MapKeys() {
+                            hu := ky.Interface()
+                            values = append(values, fmt.Sprintf("%s:%s", hu, low.GenerateHashString(gf.MapIndex(ky).Interface())))
+                        }
+                        continue
+                    }
+                    values = append(values, fmt.Sprintf("%d:%s", i, low.GenerateHashString(vn)))
+                }
+            }
+            sort.Strings(values)
+            d = append(d, strings.Join(values, "||"))
 
-		case reflect.Map:
-			for _, k := range vo.MapKeys() {
-				var x string
-				var l int
-				var v any
-				// extract key
-				if o, ok := k.Interface().(low.HasKeyNode); ok {
-					x = o.GetKeyNode().Value
-					l = o.GetKeyNode().Line
-					v = vo.MapIndex(k).Interface().(low.HasValueNodeUntyped).GetValueNode().Value
-				}
-				values = append(values, fmt.Sprintf("%d:%s:%s", l, x, low.GenerateHashString(v)))
-			}
-			sort.Strings(values)
-			d = append(d, strings.Join(values, "||"))
-		default:
-			d = append(d, low.GenerateHashString(s.AdditionalProperties.Value))
-		}
-	}
-	if !s.Description.IsEmpty() {
-		d = append(d, fmt.Sprint(s.Description.Value))
-	}
-	if !s.ContentEncoding.IsEmpty() {
-		d = append(d, fmt.Sprint(s.ContentEncoding.Value))
-	}
-	if !s.ContentMediaType.IsEmpty() {
-		d = append(d, fmt.Sprint(s.ContentMediaType.Value))
-	}
-	if !s.Default.IsEmpty() {
-		d = append(d, low.GenerateHashString(s.Default.Value))
-	}
-	if !s.Nullable.IsEmpty() {
-		d = append(d, fmt.Sprint(s.Nullable.Value))
-	}
-	if !s.ReadOnly.IsEmpty() {
-		d = append(d, fmt.Sprint(s.ReadOnly.Value))
-	}
-	if !s.WriteOnly.IsEmpty() {
-		d = append(d, fmt.Sprint(s.WriteOnly.Value))
-	}
-	if !s.Deprecated.IsEmpty() {
-		d = append(d, fmt.Sprint(s.Deprecated.Value))
-	}
-	if !s.ExclusiveMaximum.IsEmpty() && s.ExclusiveMaximum.Value.IsA() {
-		d = append(d, fmt.Sprint(s.ExclusiveMaximum.Value.A))
-	}
-	if !s.ExclusiveMaximum.IsEmpty() && s.ExclusiveMaximum.Value.IsB() {
-		d = append(d, fmt.Sprint(s.ExclusiveMaximum.Value.B))
-	}
-	if !s.ExclusiveMinimum.IsEmpty() && s.ExclusiveMinimum.Value.IsA() {
-		d = append(d, fmt.Sprint(s.ExclusiveMinimum.Value.A))
-	}
-	if !s.ExclusiveMinimum.IsEmpty() && s.ExclusiveMinimum.Value.IsB() {
-		d = append(d, fmt.Sprint(s.ExclusiveMinimum.Value.B))
-	}
-	if !s.Type.IsEmpty() && s.Type.Value.IsA() {
-		d = append(d, fmt.Sprint(s.Type.Value.A))
-	}
-	if !s.Type.IsEmpty() && s.Type.Value.IsB() {
-		j := make([]string, len(s.Type.Value.B))
-		for h := range s.Type.Value.B {
-			j[h] = s.Type.Value.B[h].Value
-		}
-		sort.Strings(j)
-		d = append(d, strings.Join(j, "|"))
-	}
+        case reflect.Map:
+            for _, k := range vo.MapKeys() {
+                var x string
+                var l int
+                var v any
+                // extract key
+                if o, ok := k.Interface().(low.HasKeyNode); ok {
+                    x = o.GetKeyNode().Value
+                    l = o.GetKeyNode().Line
+                    v = vo.MapIndex(k).Interface().(low.HasValueNodeUntyped).GetValueNode().Value
+                }
+                values = append(values, fmt.Sprintf("%d:%s:%s", l, x, low.GenerateHashString(v)))
+            }
+            sort.Strings(values)
+            d = append(d, strings.Join(values, "||"))
+        default:
+            d = append(d, low.GenerateHashString(s.AdditionalProperties.Value))
+        }
+    }
+    if !s.Description.IsEmpty() {
+        d = append(d, fmt.Sprint(s.Description.Value))
+    }
+    if !s.ContentEncoding.IsEmpty() {
+        d = append(d, fmt.Sprint(s.ContentEncoding.Value))
+    }
+    if !s.ContentMediaType.IsEmpty() {
+        d = append(d, fmt.Sprint(s.ContentMediaType.Value))
+    }
+    if !s.Default.IsEmpty() {
+        d = append(d, low.GenerateHashString(s.Default.Value))
+    }
+    if !s.Nullable.IsEmpty() {
+        d = append(d, fmt.Sprint(s.Nullable.Value))
+    }
+    if !s.ReadOnly.IsEmpty() {
+        d = append(d, fmt.Sprint(s.ReadOnly.Value))
+    }
+    if !s.WriteOnly.IsEmpty() {
+        d = append(d, fmt.Sprint(s.WriteOnly.Value))
+    }
+    if !s.Deprecated.IsEmpty() {
+        d = append(d, fmt.Sprint(s.Deprecated.Value))
+    }
+    if !s.ExclusiveMaximum.IsEmpty() && s.ExclusiveMaximum.Value.IsA() {
+        d = append(d, fmt.Sprint(s.ExclusiveMaximum.Value.A))
+    }
+    if !s.ExclusiveMaximum.IsEmpty() && s.ExclusiveMaximum.Value.IsB() {
+        d = append(d, fmt.Sprint(s.ExclusiveMaximum.Value.B))
+    }
+    if !s.ExclusiveMinimum.IsEmpty() && s.ExclusiveMinimum.Value.IsA() {
+        d = append(d, fmt.Sprint(s.ExclusiveMinimum.Value.A))
+    }
+    if !s.ExclusiveMinimum.IsEmpty() && s.ExclusiveMinimum.Value.IsB() {
+        d = append(d, fmt.Sprint(s.ExclusiveMinimum.Value.B))
+    }
+    if !s.Type.IsEmpty() && s.Type.Value.IsA() {
+        d = append(d, fmt.Sprint(s.Type.Value.A))
+    }
+    if !s.Type.IsEmpty() && s.Type.Value.IsB() {
+        j := make([]string, len(s.Type.Value.B))
+        for h := range s.Type.Value.B {
+            j[h] = s.Type.Value.B[h].Value
+        }
+        sort.Strings(j)
+        d = append(d, strings.Join(j, "|"))
+    }
 
-	keys := make([]string, len(s.Required.Value))
-	for i := range s.Required.Value {
-		keys[i] = s.Required.Value[i].Value
-	}
-	sort.Strings(keys)
-	d = append(d, keys...)
+    keys := make([]string, len(s.Required.Value))
+    for i := range s.Required.Value {
+        keys[i] = s.Required.Value[i].Value
+    }
+    sort.Strings(keys)
+    d = append(d, keys...)
 
-	keys = make([]string, len(s.Enum.Value))
-	for i := range s.Enum.Value {
-		keys[i] = fmt.Sprint(s.Enum.Value[i].Value)
-	}
-	sort.Strings(keys)
-	d = append(d, keys...)
+    keys = make([]string, len(s.Enum.Value))
+    for i := range s.Enum.Value {
+        keys[i] = fmt.Sprint(s.Enum.Value[i].Value)
+    }
+    sort.Strings(keys)
+    d = append(d, keys...)
 
-	for i := range s.Enum.Value {
-		d = append(d, fmt.Sprint(s.Enum.Value[i].Value))
-	}
-	propKeys := make([]string, len(s.Properties.Value))
-	z := 0
-	for i := range s.Properties.Value {
-		propKeys[z] = i.Value
-		z++
-	}
-	sort.Strings(propKeys)
-	for k := range propKeys {
-		d = append(d, low.GenerateHashString(s.FindProperty(propKeys[k]).Value))
-	}
-	if s.XML.Value != nil {
-		d = append(d, low.GenerateHashString(s.XML.Value))
-	}
-	if s.ExternalDocs.Value != nil {
-		d = append(d, low.GenerateHashString(s.ExternalDocs.Value))
-	}
-	if s.Discriminator.Value != nil {
-		d = append(d, low.GenerateHashString(s.Discriminator.Value))
-	}
+    for i := range s.Enum.Value {
+        d = append(d, fmt.Sprint(s.Enum.Value[i].Value))
+    }
+    propKeys := make([]string, len(s.Properties.Value))
+    z := 0
+    for i := range s.Properties.Value {
+        propKeys[z] = i.Value
+        z++
+    }
+    sort.Strings(propKeys)
+    for k := range propKeys {
+        d = append(d, low.GenerateHashString(s.FindProperty(propKeys[k]).Value))
+    }
+    if s.XML.Value != nil {
+        d = append(d, low.GenerateHashString(s.XML.Value))
+    }
+    if s.ExternalDocs.Value != nil {
+        d = append(d, low.GenerateHashString(s.ExternalDocs.Value))
+    }
+    if s.Discriminator.Value != nil {
+        d = append(d, low.GenerateHashString(s.Discriminator.Value))
+    }
 
-	// hash polymorphic data
-	if len(s.OneOf.Value) > 0 {
-		oneOfKeys := make([]string, len(s.OneOf.Value))
-		oneOfEntities := make(map[string]*SchemaProxy)
-		z = 0
-		for i := range s.OneOf.Value {
-			g := s.OneOf.Value[i].Value
-			r := low.GenerateHashString(g)
-			oneOfEntities[r] = g
-			oneOfKeys[z] = r
-			z++
+    // hash polymorphic data
+    if len(s.OneOf.Value) > 0 {
+        oneOfKeys := make([]string, len(s.OneOf.Value))
+        oneOfEntities := make(map[string]*SchemaProxy)
+        z = 0
+        for i := range s.OneOf.Value {
+            g := s.OneOf.Value[i].Value
+            r := low.GenerateHashString(g)
+            oneOfEntities[r] = g
+            oneOfKeys[z] = r
+            z++
 
-		}
-		sort.Strings(oneOfKeys)
-		for k := range oneOfKeys {
-			d = append(d, low.GenerateHashString(oneOfEntities[oneOfKeys[k]]))
-		}
-	}
+        }
+        sort.Strings(oneOfKeys)
+        for k := range oneOfKeys {
+            d = append(d, low.GenerateHashString(oneOfEntities[oneOfKeys[k]]))
+        }
+    }
 
-	if len(s.AllOf.Value) > 0 {
-		allOfKeys := make([]string, len(s.AllOf.Value))
-		allOfEntities := make(map[string]*SchemaProxy)
-		z = 0
-		for i := range s.AllOf.Value {
-			g := s.AllOf.Value[i].Value
-			r := low.GenerateHashString(g)
-			allOfEntities[r] = g
-			allOfKeys[z] = r
-			z++
+    if len(s.AllOf.Value) > 0 {
+        allOfKeys := make([]string, len(s.AllOf.Value))
+        allOfEntities := make(map[string]*SchemaProxy)
+        z = 0
+        for i := range s.AllOf.Value {
+            g := s.AllOf.Value[i].Value
+            r := low.GenerateHashString(g)
+            allOfEntities[r] = g
+            allOfKeys[z] = r
+            z++
 
-		}
-		sort.Strings(allOfKeys)
-		for k := range allOfKeys {
-			d = append(d, low.GenerateHashString(allOfEntities[allOfKeys[k]]))
-		}
-	}
+        }
+        sort.Strings(allOfKeys)
+        for k := range allOfKeys {
+            d = append(d, low.GenerateHashString(allOfEntities[allOfKeys[k]]))
+        }
+    }
 
-	if len(s.AnyOf.Value) > 0 {
-		anyOfKeys := make([]string, len(s.AnyOf.Value))
-		anyOfEntities := make(map[string]*SchemaProxy)
-		z = 0
-		for i := range s.AnyOf.Value {
-			g := s.AnyOf.Value[i].Value
-			r := low.GenerateHashString(g)
-			anyOfEntities[r] = g
-			anyOfKeys[z] = r
-			z++
+    if len(s.AnyOf.Value) > 0 {
+        anyOfKeys := make([]string, len(s.AnyOf.Value))
+        anyOfEntities := make(map[string]*SchemaProxy)
+        z = 0
+        for i := range s.AnyOf.Value {
+            g := s.AnyOf.Value[i].Value
+            r := low.GenerateHashString(g)
+            anyOfEntities[r] = g
+            anyOfKeys[z] = r
+            z++
 
-		}
-		sort.Strings(anyOfKeys)
-		for k := range anyOfKeys {
-			d = append(d, low.GenerateHashString(anyOfEntities[anyOfKeys[k]]))
-		}
-	}
+        }
+        sort.Strings(anyOfKeys)
+        for k := range anyOfKeys {
+            d = append(d, low.GenerateHashString(anyOfEntities[anyOfKeys[k]]))
+        }
+    }
 
-	if !s.Not.IsEmpty() {
-		d = append(d, low.GenerateHashString(s.Not.Value))
-	}
+    if !s.Not.IsEmpty() {
+        d = append(d, low.GenerateHashString(s.Not.Value))
+    }
 
-	// check if items is a schema or a bool.
-	if !s.Items.IsEmpty() && s.Items.Value.IsA() {
-		d = append(d, low.GenerateHashString(s.Items.Value.A))
-	}
-	if !s.Items.IsEmpty() && s.Items.Value.IsB() {
-		d = append(d, fmt.Sprint(s.Items.Value.B))
-	}
-	// 3.1 only props
-	if !s.If.IsEmpty() {
-		d = append(d, low.GenerateHashString(s.If.Value))
-	}
-	if !s.Else.IsEmpty() {
-		d = append(d, low.GenerateHashString(s.Else.Value))
-	}
-	if !s.Then.IsEmpty() {
-		d = append(d, low.GenerateHashString(s.Then.Value))
-	}
-	if !s.PropertyNames.IsEmpty() {
-		d = append(d, low.GenerateHashString(s.PropertyNames.Value))
-	}
-	if !s.UnevaluatedProperties.IsEmpty() {
-		d = append(d, low.GenerateHashString(s.UnevaluatedProperties.Value))
-	}
-	if !s.UnevaluatedItems.IsEmpty() {
-		d = append(d, low.GenerateHashString(s.UnevaluatedItems.Value))
-	}
-	if !s.Anchor.IsEmpty() {
-		d = append(d, fmt.Sprint(s.Anchor.Value))
-	}
+    // check if items is a schema or a bool.
+    if !s.Items.IsEmpty() && s.Items.Value.IsA() {
+        d = append(d, low.GenerateHashString(s.Items.Value.A))
+    }
+    if !s.Items.IsEmpty() && s.Items.Value.IsB() {
+        d = append(d, fmt.Sprint(s.Items.Value.B))
+    }
+    // 3.1 only props
+    if !s.If.IsEmpty() {
+        d = append(d, low.GenerateHashString(s.If.Value))
+    }
+    if !s.Else.IsEmpty() {
+        d = append(d, low.GenerateHashString(s.Else.Value))
+    }
+    if !s.Then.IsEmpty() {
+        d = append(d, low.GenerateHashString(s.Then.Value))
+    }
+    if !s.PropertyNames.IsEmpty() {
+        d = append(d, low.GenerateHashString(s.PropertyNames.Value))
+    }
+    if !s.UnevaluatedProperties.IsEmpty() {
+        d = append(d, low.GenerateHashString(s.UnevaluatedProperties.Value))
+    }
+    if !s.UnevaluatedItems.IsEmpty() {
+        d = append(d, low.GenerateHashString(s.UnevaluatedItems.Value))
+    }
+    if !s.Anchor.IsEmpty() {
+        d = append(d, fmt.Sprint(s.Anchor.Value))
+    }
 
-	depSchemasKeys := make([]string, len(s.DependentSchemas.Value))
-	z = 0
-	for i := range s.DependentSchemas.Value {
-		depSchemasKeys[z] = i.Value
-		z++
-	}
-	sort.Strings(depSchemasKeys)
-	for k := range depSchemasKeys {
-		d = append(d, low.GenerateHashString(s.FindDependentSchema(depSchemasKeys[k]).Value))
-	}
+    depSchemasKeys := make([]string, len(s.DependentSchemas.Value))
+    z = 0
+    for i := range s.DependentSchemas.Value {
+        depSchemasKeys[z] = i.Value
+        z++
+    }
+    sort.Strings(depSchemasKeys)
+    for k := range depSchemasKeys {
+        d = append(d, low.GenerateHashString(s.FindDependentSchema(depSchemasKeys[k]).Value))
+    }
 
-	patternPropsKeys := make([]string, len(s.PatternProperties.Value))
-	z = 0
-	for i := range s.PatternProperties.Value {
-		patternPropsKeys[z] = i.Value
-		z++
-	}
-	sort.Strings(patternPropsKeys)
-	for k := range patternPropsKeys {
-		d = append(d, low.GenerateHashString(s.FindPatternProperty(patternPropsKeys[k]).Value))
-	}
+    patternPropsKeys := make([]string, len(s.PatternProperties.Value))
+    z = 0
+    for i := range s.PatternProperties.Value {
+        patternPropsKeys[z] = i.Value
+        z++
+    }
+    sort.Strings(patternPropsKeys)
+    for k := range patternPropsKeys {
+        d = append(d, low.GenerateHashString(s.FindPatternProperty(patternPropsKeys[k]).Value))
+    }
 
-	if len(s.PrefixItems.Value) > 0 {
-		itemsKeys := make([]string, len(s.PrefixItems.Value))
-		itemsEntities := make(map[string]*SchemaProxy)
-		z = 0
-		for i := range s.PrefixItems.Value {
-			g := s.PrefixItems.Value[i].Value
-			r := low.GenerateHashString(g)
-			itemsEntities[r] = g
-			itemsKeys[z] = r
-			z++
-		}
-		sort.Strings(itemsKeys)
-		for k := range itemsKeys {
-			d = append(d, low.GenerateHashString(itemsEntities[itemsKeys[k]]))
-		}
-	}
+    if len(s.PrefixItems.Value) > 0 {
+        itemsKeys := make([]string, len(s.PrefixItems.Value))
+        itemsEntities := make(map[string]*SchemaProxy)
+        z = 0
+        for i := range s.PrefixItems.Value {
+            g := s.PrefixItems.Value[i].Value
+            r := low.GenerateHashString(g)
+            itemsEntities[r] = g
+            itemsKeys[z] = r
+            z++
+        }
+        sort.Strings(itemsKeys)
+        for k := range itemsKeys {
+            d = append(d, low.GenerateHashString(itemsEntities[itemsKeys[k]]))
+        }
+    }
 
-	// add extensions to hash
-	keys = make([]string, len(s.Extensions))
-	z = 0
-	for k := range s.Extensions {
-		keys[z] = fmt.Sprintf("%s-%x", k.Value, sha256.Sum256([]byte(fmt.Sprint(s.Extensions[k].Value))))
-		z++
-	}
-	sort.Strings(keys)
-	d = append(d, keys...)
-	if s.Example.Value != nil {
-		d = append(d, low.GenerateHashString(s.Example.Value))
-	}
+    // add extensions to hash
+    keys = make([]string, len(s.Extensions))
+    z = 0
+    for k := range s.Extensions {
+        keys[z] = fmt.Sprintf("%s-%x", k.Value, sha256.Sum256([]byte(fmt.Sprint(s.Extensions[k].Value))))
+        z++
+    }
+    sort.Strings(keys)
+    d = append(d, keys...)
+    if s.Example.Value != nil {
+        d = append(d, low.GenerateHashString(s.Example.Value))
+    }
 
-	// contains
-	if !s.Contains.IsEmpty() {
-		d = append(d, low.GenerateHashString(s.Contains.Value))
-	}
-	if !s.MinContains.IsEmpty() {
-		d = append(d, fmt.Sprint(s.MinContains.Value))
-	}
-	if !s.MaxContains.IsEmpty() {
-		d = append(d, fmt.Sprint(s.MaxContains.Value))
-	}
-	if !s.Examples.IsEmpty() {
-		var xph []string
-		for w := range s.Examples.Value {
-			xph = append(xph, low.GenerateHashString(s.Examples.Value[w].Value))
-		}
-		sort.Strings(xph)
-		d = append(d, strings.Join(xph, "|"))
-	}
-	return sha256.Sum256([]byte(strings.Join(d, "|")))
+    // contains
+    if !s.Contains.IsEmpty() {
+        d = append(d, low.GenerateHashString(s.Contains.Value))
+    }
+    if !s.MinContains.IsEmpty() {
+        d = append(d, fmt.Sprint(s.MinContains.Value))
+    }
+    if !s.MaxContains.IsEmpty() {
+        d = append(d, fmt.Sprint(s.MaxContains.Value))
+    }
+    if !s.Examples.IsEmpty() {
+        var xph []string
+        for w := range s.Examples.Value {
+            xph = append(xph, low.GenerateHashString(s.Examples.Value[w].Value))
+        }
+        sort.Strings(xph)
+        d = append(d, strings.Join(xph, "|"))
+    }
+    return sha256.Sum256([]byte(strings.Join(d, "|")))
 }
 
 // FindProperty will return a ValueReference pointer containing a SchemaProxy pointer
 // from a property key name. if found
 func (s *Schema) FindProperty(name string) *low.ValueReference[*SchemaProxy] {
-	return low.FindItemInMap[*SchemaProxy](name, s.Properties.Value)
+    return low.FindItemInMap[*SchemaProxy](name, s.Properties.Value)
 }
 
 // FindDependentSchema will return a ValueReference pointer containing a SchemaProxy pointer
 // from a dependent schema key name. if found (3.1+ only)
 func (s *Schema) FindDependentSchema(name string) *low.ValueReference[*SchemaProxy] {
-	return low.FindItemInMap[*SchemaProxy](name, s.DependentSchemas.Value)
+    return low.FindItemInMap[*SchemaProxy](name, s.DependentSchemas.Value)
 }
 
 // FindPatternProperty will return a ValueReference pointer containing a SchemaProxy pointer
 // from a pattern property key name. if found (3.1+ only)
 func (s *Schema) FindPatternProperty(name string) *low.ValueReference[*SchemaProxy] {
-	return low.FindItemInMap[*SchemaProxy](name, s.PatternProperties.Value)
+    return low.FindItemInMap[*SchemaProxy](name, s.PatternProperties.Value)
 }
 
 // GetExtensions returns all extensions for Schema
 func (s *Schema) GetExtensions() map[low.KeyReference[string]]low.ValueReference[any] {
-	return s.Extensions
+    return s.Extensions
 }
 
 // Build will perform a number of operations.
@@ -520,756 +520,756 @@ func (s *Schema) GetExtensions() map[low.KeyReference[string]]low.ValueReference
 //   - UnevaluatedProperties
 //   - Anchor
 func (s *Schema) Build(root *yaml.Node, idx *index.SpecIndex) error {
-	s.Reference = new(low.Reference)
-	if h, _, _ := utils.IsNodeRefValue(root); h {
-		ref, err := low.LocateRefNode(root, idx)
-		if ref != nil {
-			root = ref
-			if err != nil {
-				if !idx.AllowCircularReferenceResolving() {
-					return fmt.Errorf("build schema failed: %s", err.Error())
-				}
-			}
-		} else {
-			return fmt.Errorf("build schema failed: reference cannot be found: '%s', line %d, col %d",
-				root.Content[1].Value, root.Content[1].Line, root.Content[1].Column)
-		}
-	}
+    s.Reference = new(low.Reference)
+    if h, _, _ := utils.IsNodeRefValue(root); h {
+        ref, err := low.LocateRefNode(root, idx)
+        if ref != nil {
+            root = ref
+            if err != nil {
+                if !idx.AllowCircularReferenceResolving() {
+                    return fmt.Errorf("build schema failed: %s", err.Error())
+                }
+            }
+        } else {
+            return fmt.Errorf("build schema failed: reference cannot be found: '%s', line %d, col %d",
+                root.Content[1].Value, root.Content[1].Line, root.Content[1].Column)
+        }
+    }
 
-	// Build model using possibly dereferenced root
-	if err := low.BuildModel(root, s); err != nil {
-		return err
-	}
+    // Build model using possibly dereferenced root
+    if err := low.BuildModel(root, s); err != nil {
+        return err
+    }
 
-	s.extractExtensions(root)
+    s.extractExtensions(root)
 
-	// determine schema type, singular (3.0) or multiple (3.1), use a variable value
-	_, typeLabel, typeValue := utils.FindKeyNodeFullTop(TypeLabel, root.Content)
-	if typeValue != nil {
-		if utils.IsNodeStringValue(typeValue) {
-			s.Type = low.NodeReference[SchemaDynamicValue[string, []low.ValueReference[string]]]{
-				KeyNode:   typeLabel,
-				ValueNode: typeValue,
-				Value:     SchemaDynamicValue[string, []low.ValueReference[string]]{N: 0, A: typeValue.Value},
-			}
-		}
-		if utils.IsNodeArray(typeValue) {
+    // determine schema type, singular (3.0) or multiple (3.1), use a variable value
+    _, typeLabel, typeValue := utils.FindKeyNodeFullTop(TypeLabel, root.Content)
+    if typeValue != nil {
+        if utils.IsNodeStringValue(typeValue) {
+            s.Type = low.NodeReference[SchemaDynamicValue[string, []low.ValueReference[string]]]{
+                KeyNode:   typeLabel,
+                ValueNode: typeValue,
+                Value:     SchemaDynamicValue[string, []low.ValueReference[string]]{N: 0, A: typeValue.Value},
+            }
+        }
+        if utils.IsNodeArray(typeValue) {
 
-			var refs []low.ValueReference[string]
-			for r := range typeValue.Content {
-				refs = append(refs, low.ValueReference[string]{
-					Value:     typeValue.Content[r].Value,
-					ValueNode: typeValue.Content[r],
-				})
-			}
-			s.Type = low.NodeReference[SchemaDynamicValue[string, []low.ValueReference[string]]]{
-				KeyNode:   typeLabel,
-				ValueNode: typeValue,
-				Value:     SchemaDynamicValue[string, []low.ValueReference[string]]{N: 1, B: refs},
-			}
-		}
-	}
+            var refs []low.ValueReference[string]
+            for r := range typeValue.Content {
+                refs = append(refs, low.ValueReference[string]{
+                    Value:     typeValue.Content[r].Value,
+                    ValueNode: typeValue.Content[r],
+                })
+            }
+            s.Type = low.NodeReference[SchemaDynamicValue[string, []low.ValueReference[string]]]{
+                KeyNode:   typeLabel,
+                ValueNode: typeValue,
+                Value:     SchemaDynamicValue[string, []low.ValueReference[string]]{N: 1, B: refs},
+            }
+        }
+    }
 
-	// determine exclusive minimum type, bool (3.0) or int (3.1)
-	_, exMinLabel, exMinValue := utils.FindKeyNodeFullTop(ExclusiveMinimumLabel, root.Content)
-	if exMinValue != nil {
-		if utils.IsNodeBoolValue(exMinValue) {
-			val, _ := strconv.ParseBool(exMinValue.Value)
-			s.ExclusiveMinimum = low.NodeReference[*SchemaDynamicValue[bool, int64]]{
-				KeyNode:   exMinLabel,
-				ValueNode: exMinValue,
-				Value:     &SchemaDynamicValue[bool, int64]{N: 0, A: val},
-			}
-		}
-		if utils.IsNodeIntValue(exMinValue) {
-			val, _ := strconv.ParseInt(exMinValue.Value, 10, 64)
-			s.ExclusiveMinimum = low.NodeReference[*SchemaDynamicValue[bool, int64]]{
-				KeyNode:   exMinLabel,
-				ValueNode: exMinValue,
-				Value:     &SchemaDynamicValue[bool, int64]{N: 1, B: val},
-			}
-		}
-	}
+    // determine exclusive minimum type, bool (3.0) or int (3.1)
+    _, exMinLabel, exMinValue := utils.FindKeyNodeFullTop(ExclusiveMinimumLabel, root.Content)
+    if exMinValue != nil {
+        if utils.IsNodeBoolValue(exMinValue) {
+            val, _ := strconv.ParseBool(exMinValue.Value)
+            s.ExclusiveMinimum = low.NodeReference[*SchemaDynamicValue[bool, int64]]{
+                KeyNode:   exMinLabel,
+                ValueNode: exMinValue,
+                Value:     &SchemaDynamicValue[bool, int64]{N: 0, A: val},
+            }
+        }
+        if utils.IsNodeIntValue(exMinValue) {
+            val, _ := strconv.ParseInt(exMinValue.Value, 10, 64)
+            s.ExclusiveMinimum = low.NodeReference[*SchemaDynamicValue[bool, int64]]{
+                KeyNode:   exMinLabel,
+                ValueNode: exMinValue,
+                Value:     &SchemaDynamicValue[bool, int64]{N: 1, B: val},
+            }
+        }
+    }
 
-	// determine exclusive maximum type, bool (3.0) or int (3.1)
-	_, exMaxLabel, exMaxValue := utils.FindKeyNodeFullTop(ExclusiveMaximumLabel, root.Content)
-	if exMaxValue != nil {
-		if utils.IsNodeBoolValue(exMaxValue) {
-			val, _ := strconv.ParseBool(exMaxValue.Value)
-			s.ExclusiveMaximum = low.NodeReference[*SchemaDynamicValue[bool, int64]]{
-				KeyNode:   exMaxLabel,
-				ValueNode: exMaxValue,
-				Value:     &SchemaDynamicValue[bool, int64]{N: 0, A: val},
-			}
-		}
-		if utils.IsNodeIntValue(exMaxValue) {
-			val, _ := strconv.ParseInt(exMaxValue.Value, 10, 64)
-			s.ExclusiveMaximum = low.NodeReference[*SchemaDynamicValue[bool, int64]]{
-				KeyNode:   exMaxLabel,
-				ValueNode: exMaxValue,
-				Value:     &SchemaDynamicValue[bool, int64]{N: 1, B: val},
-			}
-		}
-	}
+    // determine exclusive maximum type, bool (3.0) or int (3.1)
+    _, exMaxLabel, exMaxValue := utils.FindKeyNodeFullTop(ExclusiveMaximumLabel, root.Content)
+    if exMaxValue != nil {
+        if utils.IsNodeBoolValue(exMaxValue) {
+            val, _ := strconv.ParseBool(exMaxValue.Value)
+            s.ExclusiveMaximum = low.NodeReference[*SchemaDynamicValue[bool, int64]]{
+                KeyNode:   exMaxLabel,
+                ValueNode: exMaxValue,
+                Value:     &SchemaDynamicValue[bool, int64]{N: 0, A: val},
+            }
+        }
+        if utils.IsNodeIntValue(exMaxValue) {
+            val, _ := strconv.ParseInt(exMaxValue.Value, 10, 64)
+            s.ExclusiveMaximum = low.NodeReference[*SchemaDynamicValue[bool, int64]]{
+                KeyNode:   exMaxLabel,
+                ValueNode: exMaxValue,
+                Value:     &SchemaDynamicValue[bool, int64]{N: 1, B: val},
+            }
+        }
+    }
 
-	// handle schema reference type if set. (3.1)
-	_, schemaRefLabel, schemaRefNode := utils.FindKeyNodeFullTop(SchemaTypeLabel, root.Content)
-	if schemaRefNode != nil {
-		s.SchemaTypeRef = low.NodeReference[string]{
-			Value: schemaRefNode.Value, KeyNode: schemaRefLabel, ValueNode: schemaRefLabel,
-		}
-	}
+    // handle schema reference type if set. (3.1)
+    _, schemaRefLabel, schemaRefNode := utils.FindKeyNodeFullTop(SchemaTypeLabel, root.Content)
+    if schemaRefNode != nil {
+        s.SchemaTypeRef = low.NodeReference[string]{
+            Value: schemaRefNode.Value, KeyNode: schemaRefLabel, ValueNode: schemaRefLabel,
+        }
+    }
 
-	// handle anchor if set. (3.1)
-	_, anchorLabel, anchorNode := utils.FindKeyNodeFullTop(AnchorLabel, root.Content)
-	if anchorNode != nil {
-		s.Anchor = low.NodeReference[string]{
-			Value: anchorNode.Value, KeyNode: anchorLabel, ValueNode: anchorLabel,
-		}
-	}
+    // handle anchor if set. (3.1)
+    _, anchorLabel, anchorNode := utils.FindKeyNodeFullTop(AnchorLabel, root.Content)
+    if anchorNode != nil {
+        s.Anchor = low.NodeReference[string]{
+            Value: anchorNode.Value, KeyNode: anchorLabel, ValueNode: anchorLabel,
+        }
+    }
 
-	// handle example if set. (3.0)
-	_, expLabel, expNode := utils.FindKeyNodeFull(ExampleLabel, root.Content)
-	if expNode != nil {
-		s.Example = low.NodeReference[any]{Value: ExtractExampleValue(expNode), KeyNode: expLabel, ValueNode: expNode}
-	}
+    // handle example if set. (3.0)
+    _, expLabel, expNode := utils.FindKeyNodeFull(ExampleLabel, root.Content)
+    if expNode != nil {
+        s.Example = low.NodeReference[any]{Value: ExtractExampleValue(expNode), KeyNode: expLabel, ValueNode: expNode}
+    }
 
-	// handle examples if set.(3.1)
-	_, expArrLabel, expArrNode := utils.FindKeyNodeFullTop(ExamplesLabel, root.Content)
-	if expArrNode != nil {
-		if utils.IsNodeArray(expArrNode) {
-			var examples []low.ValueReference[any]
-			for i := range expArrNode.Content {
-				examples = append(examples, low.ValueReference[any]{Value: ExtractExampleValue(expArrNode.Content[i]), ValueNode: expArrNode.Content[i]})
-			}
-			s.Examples = low.NodeReference[[]low.ValueReference[any]]{
-				Value:     examples,
-				ValueNode: expArrNode,
-				KeyNode:   expArrLabel,
-			}
-		}
-	}
+    // handle examples if set.(3.1)
+    _, expArrLabel, expArrNode := utils.FindKeyNodeFullTop(ExamplesLabel, root.Content)
+    if expArrNode != nil {
+        if utils.IsNodeArray(expArrNode) {
+            var examples []low.ValueReference[any]
+            for i := range expArrNode.Content {
+                examples = append(examples, low.ValueReference[any]{Value: ExtractExampleValue(expArrNode.Content[i]), ValueNode: expArrNode.Content[i]})
+            }
+            s.Examples = low.NodeReference[[]low.ValueReference[any]]{
+                Value:     examples,
+                ValueNode: expArrNode,
+                KeyNode:   expArrLabel,
+            }
+        }
+    }
 
-	_, addPLabel, addPNode := utils.FindKeyNodeFullTop(AdditionalPropertiesLabel, root.Content)
-	if addPNode != nil {
-		if utils.IsNodeMap(addPNode) || utils.IsNodeArray(addPNode) {
-			// check if this is a reference, or an inline schema.
-			isRef, _, _ := utils.IsNodeRefValue(addPNode)
-			var sp *SchemaProxy
-			// now check if this object has a 'type' if so, it's a schema, if not... it's a random
-			// object, and we should treat it as a raw map.
-			if _, v := utils.FindKeyNodeTop(TypeLabel, addPNode.Content); v != nil {
-				sp = &SchemaProxy{
-					kn:  addPLabel,
-					vn:  addPNode,
-					idx: idx,
-				}
-			}
-			if isRef {
-				_, vn := utils.FindKeyNodeTop("$ref", addPNode.Content)
-				sp = &SchemaProxy{
-					kn:              addPLabel,
-					vn:              addPNode,
-					idx:             idx,
-					isReference:     true,
-					referenceLookup: vn.Value,
-				}
-			}
+    _, addPLabel, addPNode := utils.FindKeyNodeFullTop(AdditionalPropertiesLabel, root.Content)
+    if addPNode != nil {
+        if utils.IsNodeMap(addPNode) || utils.IsNodeArray(addPNode) {
+            // check if this is a reference, or an inline schema.
+            isRef, _, _ := utils.IsNodeRefValue(addPNode)
+            var sp *SchemaProxy
+            // now check if this object has a 'type' if so, it's a schema, if not... it's a random
+            // object, and we should treat it as a raw map.
+            if _, v := utils.FindKeyNodeTop(TypeLabel, addPNode.Content); v != nil {
+                sp = &SchemaProxy{
+                    kn:  addPLabel,
+                    vn:  addPNode,
+                    idx: idx,
+                }
+            }
+            if isRef {
+                _, vn := utils.FindKeyNodeTop("$ref", addPNode.Content)
+                sp = &SchemaProxy{
+                    kn:              addPLabel,
+                    vn:              addPNode,
+                    idx:             idx,
+                    isReference:     true,
+                    referenceLookup: vn.Value,
+                }
+            }
 
-			// if this is a reference, or a schema, we're done.
-			if sp != nil {
-				s.AdditionalProperties = low.NodeReference[any]{Value: sp, KeyNode: addPLabel, ValueNode: addPNode}
-			} else {
+            // if this is a reference, or a schema, we're done.
+            if sp != nil {
+                s.AdditionalProperties = low.NodeReference[any]{Value: sp, KeyNode: addPLabel, ValueNode: addPNode}
+            } else {
 
-				// if this is a map, collect all the keys and values.
-				if utils.IsNodeMap(addPNode) {
+                // if this is a map, collect all the keys and values.
+                if utils.IsNodeMap(addPNode) {
 
-					addProps := make(map[low.KeyReference[string]]low.ValueReference[any])
-					var label string
-					for g := range addPNode.Content {
-						if g%2 == 0 {
-							label = addPNode.Content[g].Value
-							continue
-						} else {
-							addProps[low.KeyReference[string]{Value: label, KeyNode: addPNode.Content[g-1]}] =
-								low.ValueReference[any]{Value: addPNode.Content[g].Value, ValueNode: addPNode.Content[g]}
-						}
-					}
-					s.AdditionalProperties = low.NodeReference[any]{Value: addProps, KeyNode: addPLabel, ValueNode: addPNode}
-				}
+                    addProps := make(map[low.KeyReference[string]]low.ValueReference[any])
+                    var label string
+                    for g := range addPNode.Content {
+                        if g%2 == 0 {
+                            label = addPNode.Content[g].Value
+                            continue
+                        } else {
+                            addProps[low.KeyReference[string]{Value: label, KeyNode: addPNode.Content[g-1]}] =
+                                low.ValueReference[any]{Value: addPNode.Content[g].Value, ValueNode: addPNode.Content[g]}
+                        }
+                    }
+                    s.AdditionalProperties = low.NodeReference[any]{Value: addProps, KeyNode: addPLabel, ValueNode: addPNode}
+                }
 
-				// if the node is an array, extract everything into a trackable structure
-				if utils.IsNodeArray(addPNode) {
-					var addProps []low.ValueReference[any]
+                // if the node is an array, extract everything into a trackable structure
+                if utils.IsNodeArray(addPNode) {
+                    var addProps []low.ValueReference[any]
 
-					// if this is an array or maps, encode the map items correctly.
-					for i := range addPNode.Content {
-						if utils.IsNodeMap(addPNode.Content[i]) {
-							var prop map[string]any
-							addPNode.Content[i].Decode(&prop)
-							addProps = append(addProps,
-								low.ValueReference[any]{Value: prop, ValueNode: addPNode.Content[i]})
-						} else {
-							addProps = append(addProps,
-								low.ValueReference[any]{Value: addPNode.Content[i].Value, ValueNode: addPNode.Content[i]})
-						}
-					}
+                    // if this is an array or maps, encode the map items correctly.
+                    for i := range addPNode.Content {
+                        if utils.IsNodeMap(addPNode.Content[i]) {
+                            var prop map[string]any
+                            addPNode.Content[i].Decode(&prop)
+                            addProps = append(addProps,
+                                low.ValueReference[any]{Value: prop, ValueNode: addPNode.Content[i]})
+                        } else {
+                            addProps = append(addProps,
+                                low.ValueReference[any]{Value: addPNode.Content[i].Value, ValueNode: addPNode.Content[i]})
+                        }
+                    }
 
-					s.AdditionalProperties =
-						low.NodeReference[any]{Value: addProps, KeyNode: addPLabel, ValueNode: addPNode}
-				}
-			}
-		}
-		if utils.IsNodeBoolValue(addPNode) {
-			b, _ := strconv.ParseBool(addPNode.Value)
-			s.AdditionalProperties = low.NodeReference[any]{Value: b, KeyNode: addPLabel, ValueNode: addPNode}
-		}
-	}
+                    s.AdditionalProperties =
+                        low.NodeReference[any]{Value: addProps, KeyNode: addPLabel, ValueNode: addPNode}
+                }
+            }
+        }
+        if utils.IsNodeBoolValue(addPNode) {
+            b, _ := strconv.ParseBool(addPNode.Value)
+            s.AdditionalProperties = low.NodeReference[any]{Value: b, KeyNode: addPLabel, ValueNode: addPNode}
+        }
+    }
 
-	// handle discriminator if set.
-	_, discLabel, discNode := utils.FindKeyNodeFullTop(DiscriminatorLabel, root.Content)
-	if discNode != nil {
-		var discriminator Discriminator
-		_ = low.BuildModel(discNode, &discriminator)
-		s.Discriminator = low.NodeReference[*Discriminator]{Value: &discriminator, KeyNode: discLabel, ValueNode: discNode}
-	}
+    // handle discriminator if set.
+    _, discLabel, discNode := utils.FindKeyNodeFullTop(DiscriminatorLabel, root.Content)
+    if discNode != nil {
+        var discriminator Discriminator
+        _ = low.BuildModel(discNode, &discriminator)
+        s.Discriminator = low.NodeReference[*Discriminator]{Value: &discriminator, KeyNode: discLabel, ValueNode: discNode}
+    }
 
-	// handle externalDocs if set.
-	_, extDocLabel, extDocNode := utils.FindKeyNodeFullTop(ExternalDocsLabel, root.Content)
-	if extDocNode != nil {
-		var exDoc ExternalDoc
-		_ = low.BuildModel(extDocNode, &exDoc)
-		_ = exDoc.Build(extDocNode, idx) // throws no errors, can't check for one.
-		s.ExternalDocs = low.NodeReference[*ExternalDoc]{Value: &exDoc, KeyNode: extDocLabel, ValueNode: extDocNode}
-	}
+    // handle externalDocs if set.
+    _, extDocLabel, extDocNode := utils.FindKeyNodeFullTop(ExternalDocsLabel, root.Content)
+    if extDocNode != nil {
+        var exDoc ExternalDoc
+        _ = low.BuildModel(extDocNode, &exDoc)
+        _ = exDoc.Build(extDocNode, idx) // throws no errors, can't check for one.
+        s.ExternalDocs = low.NodeReference[*ExternalDoc]{Value: &exDoc, KeyNode: extDocLabel, ValueNode: extDocNode}
+    }
 
-	// handle xml if set.
-	_, xmlLabel, xmlNode := utils.FindKeyNodeFullTop(XMLLabel, root.Content)
-	if xmlNode != nil {
-		var xml XML
-		_ = low.BuildModel(xmlNode, &xml)
-		// extract extensions if set.
-		_ = xml.Build(xmlNode, idx) // returns no errors, can't check for one.
-		s.XML = low.NodeReference[*XML]{Value: &xml, KeyNode: xmlLabel, ValueNode: xmlNode}
-	}
+    // handle xml if set.
+    _, xmlLabel, xmlNode := utils.FindKeyNodeFullTop(XMLLabel, root.Content)
+    if xmlNode != nil {
+        var xml XML
+        _ = low.BuildModel(xmlNode, &xml)
+        // extract extensions if set.
+        _ = xml.Build(xmlNode, idx) // returns no errors, can't check for one.
+        s.XML = low.NodeReference[*XML]{Value: &xml, KeyNode: xmlLabel, ValueNode: xmlNode}
+    }
 
-	// handle properties
-	props, err := buildPropertyMap(root, idx, PropertiesLabel)
-	if err != nil {
-		return err
-	}
-	if props != nil {
-		s.Properties = *props
-	}
+    // handle properties
+    props, err := buildPropertyMap(root, idx, PropertiesLabel)
+    if err != nil {
+        return err
+    }
+    if props != nil {
+        s.Properties = *props
+    }
 
-	// handle dependent schemas
-	props, err = buildPropertyMap(root, idx, DependentSchemasLabel)
-	if err != nil {
-		return err
-	}
-	if props != nil {
-		s.DependentSchemas = *props
-	}
+    // handle dependent schemas
+    props, err = buildPropertyMap(root, idx, DependentSchemasLabel)
+    if err != nil {
+        return err
+    }
+    if props != nil {
+        s.DependentSchemas = *props
+    }
 
-	// handle pattern properties
-	props, err = buildPropertyMap(root, idx, PatternPropertiesLabel)
-	if err != nil {
-		return err
-	}
-	if props != nil {
-		s.PatternProperties = *props
-	}
+    // handle pattern properties
+    props, err = buildPropertyMap(root, idx, PatternPropertiesLabel)
+    if err != nil {
+        return err
+    }
+    if props != nil {
+        s.PatternProperties = *props
+    }
 
-	// check items type for schema or bool (3.1 only)
-	itemsIsBool := false
-	itemsBoolValue := false
-	_, itemsLabel, itemsValue := utils.FindKeyNodeFullTop(ItemsLabel, root.Content)
-	if itemsValue != nil {
-		if utils.IsNodeBoolValue(itemsValue) {
-			itemsIsBool = true
-			itemsBoolValue, _ = strconv.ParseBool(itemsValue.Value)
-		}
-	}
-	if itemsIsBool {
-		s.Items = low.NodeReference[*SchemaDynamicValue[*SchemaProxy, bool]]{
-			Value: &SchemaDynamicValue[*SchemaProxy, bool]{
-				B: itemsBoolValue,
-				N: 1,
-			},
-			KeyNode:   itemsLabel,
-			ValueNode: itemsValue,
-		}
-	}
+    // check items type for schema or bool (3.1 only)
+    itemsIsBool := false
+    itemsBoolValue := false
+    _, itemsLabel, itemsValue := utils.FindKeyNodeFullTop(ItemsLabel, root.Content)
+    if itemsValue != nil {
+        if utils.IsNodeBoolValue(itemsValue) {
+            itemsIsBool = true
+            itemsBoolValue, _ = strconv.ParseBool(itemsValue.Value)
+        }
+    }
+    if itemsIsBool {
+        s.Items = low.NodeReference[*SchemaDynamicValue[*SchemaProxy, bool]]{
+            Value: &SchemaDynamicValue[*SchemaProxy, bool]{
+                B: itemsBoolValue,
+                N: 1,
+            },
+            KeyNode:   itemsLabel,
+            ValueNode: itemsValue,
+        }
+    }
 
-	var allOf, anyOf, oneOf, prefixItems []low.ValueReference[*SchemaProxy]
-	var items, not, contains, sif, selse, sthen, propertyNames, unevalItems, unevalProperties low.ValueReference[*SchemaProxy]
+    var allOf, anyOf, oneOf, prefixItems []low.ValueReference[*SchemaProxy]
+    var items, not, contains, sif, selse, sthen, propertyNames, unevalItems, unevalProperties low.ValueReference[*SchemaProxy]
 
-	_, allOfLabel, allOfValue := utils.FindKeyNodeFullTop(AllOfLabel, root.Content)
-	_, anyOfLabel, anyOfValue := utils.FindKeyNodeFullTop(AnyOfLabel, root.Content)
-	_, oneOfLabel, oneOfValue := utils.FindKeyNodeFullTop(OneOfLabel, root.Content)
-	_, notLabel, notValue := utils.FindKeyNodeFullTop(NotLabel, root.Content)
-	_, prefixItemsLabel, prefixItemsValue := utils.FindKeyNodeFullTop(PrefixItemsLabel, root.Content)
-	_, containsLabel, containsValue := utils.FindKeyNodeFullTop(ContainsLabel, root.Content)
-	_, sifLabel, sifValue := utils.FindKeyNodeFullTop(IfLabel, root.Content)
-	_, selseLabel, selseValue := utils.FindKeyNodeFullTop(ElseLabel, root.Content)
-	_, sthenLabel, sthenValue := utils.FindKeyNodeFullTop(ThenLabel, root.Content)
-	_, propNamesLabel, propNamesValue := utils.FindKeyNodeFullTop(PropertyNamesLabel, root.Content)
+    _, allOfLabel, allOfValue := utils.FindKeyNodeFullTop(AllOfLabel, root.Content)
+    _, anyOfLabel, anyOfValue := utils.FindKeyNodeFullTop(AnyOfLabel, root.Content)
+    _, oneOfLabel, oneOfValue := utils.FindKeyNodeFullTop(OneOfLabel, root.Content)
+    _, notLabel, notValue := utils.FindKeyNodeFullTop(NotLabel, root.Content)
+    _, prefixItemsLabel, prefixItemsValue := utils.FindKeyNodeFullTop(PrefixItemsLabel, root.Content)
+    _, containsLabel, containsValue := utils.FindKeyNodeFullTop(ContainsLabel, root.Content)
+    _, sifLabel, sifValue := utils.FindKeyNodeFullTop(IfLabel, root.Content)
+    _, selseLabel, selseValue := utils.FindKeyNodeFullTop(ElseLabel, root.Content)
+    _, sthenLabel, sthenValue := utils.FindKeyNodeFullTop(ThenLabel, root.Content)
+    _, propNamesLabel, propNamesValue := utils.FindKeyNodeFullTop(PropertyNamesLabel, root.Content)
 
-	_, unevalItemsLabel, unevalItemsValue := utils.FindKeyNodeFullTop(UnevaluatedItemsLabel, root.Content)
-	_, unevalPropsLabel, unevalPropsValue := utils.FindKeyNodeFullTop(UnevaluatedPropertiesLabel, root.Content)
+    _, unevalItemsLabel, unevalItemsValue := utils.FindKeyNodeFullTop(UnevaluatedItemsLabel, root.Content)
+    _, unevalPropsLabel, unevalPropsValue := utils.FindKeyNodeFullTop(UnevaluatedPropertiesLabel, root.Content)
 
-	errorChan := make(chan error)
-	allOfChan := make(chan schemaProxyBuildResult)
-	anyOfChan := make(chan schemaProxyBuildResult)
-	oneOfChan := make(chan schemaProxyBuildResult)
-	itemsChan := make(chan schemaProxyBuildResult)
-	prefixItemsChan := make(chan schemaProxyBuildResult)
-	notChan := make(chan schemaProxyBuildResult)
-	containsChan := make(chan schemaProxyBuildResult)
-	ifChan := make(chan schemaProxyBuildResult)
-	elseChan := make(chan schemaProxyBuildResult)
-	thenChan := make(chan schemaProxyBuildResult)
-	propNamesChan := make(chan schemaProxyBuildResult)
-	unevalItemsChan := make(chan schemaProxyBuildResult)
-	unevalPropsChan := make(chan schemaProxyBuildResult)
+    errorChan := make(chan error)
+    allOfChan := make(chan schemaProxyBuildResult)
+    anyOfChan := make(chan schemaProxyBuildResult)
+    oneOfChan := make(chan schemaProxyBuildResult)
+    itemsChan := make(chan schemaProxyBuildResult)
+    prefixItemsChan := make(chan schemaProxyBuildResult)
+    notChan := make(chan schemaProxyBuildResult)
+    containsChan := make(chan schemaProxyBuildResult)
+    ifChan := make(chan schemaProxyBuildResult)
+    elseChan := make(chan schemaProxyBuildResult)
+    thenChan := make(chan schemaProxyBuildResult)
+    propNamesChan := make(chan schemaProxyBuildResult)
+    unevalItemsChan := make(chan schemaProxyBuildResult)
+    unevalPropsChan := make(chan schemaProxyBuildResult)
 
-	totalBuilds := countSubSchemaItems(allOfValue) +
-		countSubSchemaItems(anyOfValue) +
-		countSubSchemaItems(oneOfValue) +
-		countSubSchemaItems(prefixItemsValue)
+    totalBuilds := countSubSchemaItems(allOfValue) +
+        countSubSchemaItems(anyOfValue) +
+        countSubSchemaItems(oneOfValue) +
+        countSubSchemaItems(prefixItemsValue)
 
-	if allOfValue != nil {
-		go buildSchema(allOfChan, allOfLabel, allOfValue, errorChan, idx)
-	}
-	if anyOfValue != nil {
-		go buildSchema(anyOfChan, anyOfLabel, anyOfValue, errorChan, idx)
-	}
-	if oneOfValue != nil {
-		go buildSchema(oneOfChan, oneOfLabel, oneOfValue, errorChan, idx)
-	}
-	if prefixItemsValue != nil {
-		go buildSchema(prefixItemsChan, prefixItemsLabel, prefixItemsValue, errorChan, idx)
-	}
-	if notValue != nil {
-		totalBuilds++
-		go buildSchema(notChan, notLabel, notValue, errorChan, idx)
-	}
-	if containsValue != nil {
-		totalBuilds++
-		go buildSchema(containsChan, containsLabel, containsValue, errorChan, idx)
-	}
-	if !itemsIsBool && itemsValue != nil {
-		totalBuilds++
-		go buildSchema(itemsChan, itemsLabel, itemsValue, errorChan, idx)
-	}
-	if sifValue != nil {
-		totalBuilds++
-		go buildSchema(ifChan, sifLabel, sifValue, errorChan, idx)
-	}
-	if selseValue != nil {
-		totalBuilds++
-		go buildSchema(elseChan, selseLabel, selseValue, errorChan, idx)
-	}
-	if sthenValue != nil {
-		totalBuilds++
-		go buildSchema(thenChan, sthenLabel, sthenValue, errorChan, idx)
-	}
-	if propNamesValue != nil {
-		totalBuilds++
-		go buildSchema(propNamesChan, propNamesLabel, propNamesValue, errorChan, idx)
-	}
-	if unevalItemsValue != nil {
-		totalBuilds++
-		go buildSchema(unevalItemsChan, unevalItemsLabel, unevalItemsValue, errorChan, idx)
-	}
-	if unevalPropsValue != nil {
-		totalBuilds++
-		go buildSchema(unevalPropsChan, unevalPropsLabel, unevalPropsValue, errorChan, idx)
-	}
+    if allOfValue != nil {
+        go buildSchema(allOfChan, allOfLabel, allOfValue, errorChan, idx)
+    }
+    if anyOfValue != nil {
+        go buildSchema(anyOfChan, anyOfLabel, anyOfValue, errorChan, idx)
+    }
+    if oneOfValue != nil {
+        go buildSchema(oneOfChan, oneOfLabel, oneOfValue, errorChan, idx)
+    }
+    if prefixItemsValue != nil {
+        go buildSchema(prefixItemsChan, prefixItemsLabel, prefixItemsValue, errorChan, idx)
+    }
+    if notValue != nil {
+        totalBuilds++
+        go buildSchema(notChan, notLabel, notValue, errorChan, idx)
+    }
+    if containsValue != nil {
+        totalBuilds++
+        go buildSchema(containsChan, containsLabel, containsValue, errorChan, idx)
+    }
+    if !itemsIsBool && itemsValue != nil {
+        totalBuilds++
+        go buildSchema(itemsChan, itemsLabel, itemsValue, errorChan, idx)
+    }
+    if sifValue != nil {
+        totalBuilds++
+        go buildSchema(ifChan, sifLabel, sifValue, errorChan, idx)
+    }
+    if selseValue != nil {
+        totalBuilds++
+        go buildSchema(elseChan, selseLabel, selseValue, errorChan, idx)
+    }
+    if sthenValue != nil {
+        totalBuilds++
+        go buildSchema(thenChan, sthenLabel, sthenValue, errorChan, idx)
+    }
+    if propNamesValue != nil {
+        totalBuilds++
+        go buildSchema(propNamesChan, propNamesLabel, propNamesValue, errorChan, idx)
+    }
+    if unevalItemsValue != nil {
+        totalBuilds++
+        go buildSchema(unevalItemsChan, unevalItemsLabel, unevalItemsValue, errorChan, idx)
+    }
+    if unevalPropsValue != nil {
+        totalBuilds++
+        go buildSchema(unevalPropsChan, unevalPropsLabel, unevalPropsValue, errorChan, idx)
+    }
 
-	completeCount := 0
-	for completeCount < totalBuilds {
-		select {
-		case e := <-errorChan:
-			return e
-		case r := <-allOfChan:
-			completeCount++
-			allOf = append(allOf, r.v)
-		case r := <-anyOfChan:
-			completeCount++
-			anyOf = append(anyOf, r.v)
-		case r := <-oneOfChan:
-			completeCount++
-			oneOf = append(oneOf, r.v)
-		case r := <-itemsChan:
-			completeCount++
-			items = r.v
-		case r := <-prefixItemsChan:
-			completeCount++
-			prefixItems = append(prefixItems, r.v)
-		case r := <-notChan:
-			completeCount++
-			not = r.v
-		case r := <-containsChan:
-			completeCount++
-			contains = r.v
-		case r := <-ifChan:
-			completeCount++
-			sif = r.v
-		case r := <-elseChan:
-			completeCount++
-			selse = r.v
-		case r := <-thenChan:
-			completeCount++
-			sthen = r.v
-		case r := <-propNamesChan:
-			completeCount++
-			propertyNames = r.v
-		case r := <-unevalItemsChan:
-			completeCount++
-			unevalItems = r.v
-		case r := <-unevalPropsChan:
-			completeCount++
-			unevalProperties = r.v
-		}
-	}
+    completeCount := 0
+    for completeCount < totalBuilds {
+        select {
+        case e := <-errorChan:
+            return e
+        case r := <-allOfChan:
+            completeCount++
+            allOf = append(allOf, r.v)
+        case r := <-anyOfChan:
+            completeCount++
+            anyOf = append(anyOf, r.v)
+        case r := <-oneOfChan:
+            completeCount++
+            oneOf = append(oneOf, r.v)
+        case r := <-itemsChan:
+            completeCount++
+            items = r.v
+        case r := <-prefixItemsChan:
+            completeCount++
+            prefixItems = append(prefixItems, r.v)
+        case r := <-notChan:
+            completeCount++
+            not = r.v
+        case r := <-containsChan:
+            completeCount++
+            contains = r.v
+        case r := <-ifChan:
+            completeCount++
+            sif = r.v
+        case r := <-elseChan:
+            completeCount++
+            selse = r.v
+        case r := <-thenChan:
+            completeCount++
+            sthen = r.v
+        case r := <-propNamesChan:
+            completeCount++
+            propertyNames = r.v
+        case r := <-unevalItemsChan:
+            completeCount++
+            unevalItems = r.v
+        case r := <-unevalPropsChan:
+            completeCount++
+            unevalProperties = r.v
+        }
+    }
 
-	if len(anyOf) > 0 {
-		s.AnyOf = low.NodeReference[[]low.ValueReference[*SchemaProxy]]{
-			Value:     anyOf,
-			KeyNode:   anyOfLabel,
-			ValueNode: anyOfValue,
-		}
-	}
-	if len(oneOf) > 0 {
-		s.OneOf = low.NodeReference[[]low.ValueReference[*SchemaProxy]]{
-			Value:     oneOf,
-			KeyNode:   oneOfLabel,
-			ValueNode: oneOfValue,
-		}
-	}
-	if len(allOf) > 0 {
-		s.AllOf = low.NodeReference[[]low.ValueReference[*SchemaProxy]]{
-			Value:     allOf,
-			KeyNode:   allOfLabel,
-			ValueNode: allOfValue,
-		}
-	}
-	if !not.IsEmpty() {
-		s.Not = low.NodeReference[*SchemaProxy]{
-			Value:     not.Value,
-			KeyNode:   notLabel,
-			ValueNode: notValue,
-		}
-	}
-	if !itemsIsBool && !items.IsEmpty() {
-		s.Items = low.NodeReference[*SchemaDynamicValue[*SchemaProxy, bool]]{
-			Value: &SchemaDynamicValue[*SchemaProxy, bool]{
-				A: items.Value,
-			},
-			KeyNode:   itemsLabel,
-			ValueNode: itemsValue,
-		}
-	}
-	if len(prefixItems) > 0 {
-		s.PrefixItems = low.NodeReference[[]low.ValueReference[*SchemaProxy]]{
-			Value:     prefixItems,
-			KeyNode:   prefixItemsLabel,
-			ValueNode: prefixItemsValue,
-		}
-	}
-	if !contains.IsEmpty() {
-		s.Contains = low.NodeReference[*SchemaProxy]{
-			Value:     contains.Value,
-			KeyNode:   containsLabel,
-			ValueNode: containsValue,
-		}
-	}
-	if !sif.IsEmpty() {
-		s.If = low.NodeReference[*SchemaProxy]{
-			Value:     sif.Value,
-			KeyNode:   sifLabel,
-			ValueNode: sifValue,
-		}
-	}
-	if !selse.IsEmpty() {
-		s.Else = low.NodeReference[*SchemaProxy]{
-			Value:     selse.Value,
-			KeyNode:   selseLabel,
-			ValueNode: selseValue,
-		}
-	}
-	if !sthen.IsEmpty() {
-		s.Then = low.NodeReference[*SchemaProxy]{
-			Value:     sthen.Value,
-			KeyNode:   sthenLabel,
-			ValueNode: sthenValue,
-		}
-	}
-	if !propertyNames.IsEmpty() {
-		s.PropertyNames = low.NodeReference[*SchemaProxy]{
-			Value:     propertyNames.Value,
-			KeyNode:   propNamesLabel,
-			ValueNode: propNamesValue,
-		}
-	}
-	if !unevalItems.IsEmpty() {
-		s.UnevaluatedItems = low.NodeReference[*SchemaProxy]{
-			Value:     unevalItems.Value,
-			KeyNode:   unevalItemsLabel,
-			ValueNode: unevalItemsValue,
-		}
-	}
-	if !unevalProperties.IsEmpty() {
-		s.UnevaluatedProperties = low.NodeReference[*SchemaProxy]{
-			Value:     unevalProperties.Value,
-			KeyNode:   unevalPropsLabel,
-			ValueNode: unevalPropsValue,
-		}
-	}
-	return nil
+    if len(anyOf) > 0 {
+        s.AnyOf = low.NodeReference[[]low.ValueReference[*SchemaProxy]]{
+            Value:     anyOf,
+            KeyNode:   anyOfLabel,
+            ValueNode: anyOfValue,
+        }
+    }
+    if len(oneOf) > 0 {
+        s.OneOf = low.NodeReference[[]low.ValueReference[*SchemaProxy]]{
+            Value:     oneOf,
+            KeyNode:   oneOfLabel,
+            ValueNode: oneOfValue,
+        }
+    }
+    if len(allOf) > 0 {
+        s.AllOf = low.NodeReference[[]low.ValueReference[*SchemaProxy]]{
+            Value:     allOf,
+            KeyNode:   allOfLabel,
+            ValueNode: allOfValue,
+        }
+    }
+    if !not.IsEmpty() {
+        s.Not = low.NodeReference[*SchemaProxy]{
+            Value:     not.Value,
+            KeyNode:   notLabel,
+            ValueNode: notValue,
+        }
+    }
+    if !itemsIsBool && !items.IsEmpty() {
+        s.Items = low.NodeReference[*SchemaDynamicValue[*SchemaProxy, bool]]{
+            Value: &SchemaDynamicValue[*SchemaProxy, bool]{
+                A: items.Value,
+            },
+            KeyNode:   itemsLabel,
+            ValueNode: itemsValue,
+        }
+    }
+    if len(prefixItems) > 0 {
+        s.PrefixItems = low.NodeReference[[]low.ValueReference[*SchemaProxy]]{
+            Value:     prefixItems,
+            KeyNode:   prefixItemsLabel,
+            ValueNode: prefixItemsValue,
+        }
+    }
+    if !contains.IsEmpty() {
+        s.Contains = low.NodeReference[*SchemaProxy]{
+            Value:     contains.Value,
+            KeyNode:   containsLabel,
+            ValueNode: containsValue,
+        }
+    }
+    if !sif.IsEmpty() {
+        s.If = low.NodeReference[*SchemaProxy]{
+            Value:     sif.Value,
+            KeyNode:   sifLabel,
+            ValueNode: sifValue,
+        }
+    }
+    if !selse.IsEmpty() {
+        s.Else = low.NodeReference[*SchemaProxy]{
+            Value:     selse.Value,
+            KeyNode:   selseLabel,
+            ValueNode: selseValue,
+        }
+    }
+    if !sthen.IsEmpty() {
+        s.Then = low.NodeReference[*SchemaProxy]{
+            Value:     sthen.Value,
+            KeyNode:   sthenLabel,
+            ValueNode: sthenValue,
+        }
+    }
+    if !propertyNames.IsEmpty() {
+        s.PropertyNames = low.NodeReference[*SchemaProxy]{
+            Value:     propertyNames.Value,
+            KeyNode:   propNamesLabel,
+            ValueNode: propNamesValue,
+        }
+    }
+    if !unevalItems.IsEmpty() {
+        s.UnevaluatedItems = low.NodeReference[*SchemaProxy]{
+            Value:     unevalItems.Value,
+            KeyNode:   unevalItemsLabel,
+            ValueNode: unevalItemsValue,
+        }
+    }
+    if !unevalProperties.IsEmpty() {
+        s.UnevaluatedProperties = low.NodeReference[*SchemaProxy]{
+            Value:     unevalProperties.Value,
+            KeyNode:   unevalPropsLabel,
+            ValueNode: unevalPropsValue,
+        }
+    }
+    return nil
 }
 
 func buildPropertyMap(root *yaml.Node, idx *index.SpecIndex, label string) (*low.NodeReference[map[low.KeyReference[string]]low.ValueReference[*SchemaProxy]], error) {
-	// for property, build in a new thread!
-	bChan := make(chan schemaProxyBuildResult)
+    // for property, build in a new thread!
+    bChan := make(chan schemaProxyBuildResult)
 
-	buildProperty := func(label *yaml.Node, value *yaml.Node, c chan schemaProxyBuildResult, isRef bool,
-		refString string,
-	) {
-		c <- schemaProxyBuildResult{
-			k: low.KeyReference[string]{
-				KeyNode: label,
-				Value:   label.Value,
-			},
-			v: low.ValueReference[*SchemaProxy]{
-				Value:     &SchemaProxy{kn: label, vn: value, idx: idx, isReference: isRef, referenceLookup: refString},
-				ValueNode: value,
-			},
-		}
-	}
+    buildProperty := func(label *yaml.Node, value *yaml.Node, c chan schemaProxyBuildResult, isRef bool,
+        refString string,
+    ) {
+        c <- schemaProxyBuildResult{
+            k: low.KeyReference[string]{
+                KeyNode: label,
+                Value:   label.Value,
+            },
+            v: low.ValueReference[*SchemaProxy]{
+                Value:     &SchemaProxy{kn: label, vn: value, idx: idx, isReference: isRef, referenceLookup: refString},
+                ValueNode: value,
+            },
+        }
+    }
 
-	_, propLabel, propsNode := utils.FindKeyNodeFullTop(label, root.Content)
-	if propsNode != nil {
-		propertyMap := make(map[low.KeyReference[string]]low.ValueReference[*SchemaProxy])
-		var currentProp *yaml.Node
-		totalProps := 0
-		for i, prop := range propsNode.Content {
-			if i%2 == 0 {
-				currentProp = prop
-				continue
-			}
+    _, propLabel, propsNode := utils.FindKeyNodeFullTop(label, root.Content)
+    if propsNode != nil {
+        propertyMap := make(map[low.KeyReference[string]]low.ValueReference[*SchemaProxy])
+        var currentProp *yaml.Node
+        totalProps := 0
+        for i, prop := range propsNode.Content {
+            if i%2 == 0 {
+                currentProp = prop
+                continue
+            }
 
-			// check our prop isn't reference
-			isRef := false
-			refString := ""
-			if h, _, l := utils.IsNodeRefValue(prop); h {
-				ref, _ := low.LocateRefNode(prop, idx)
-				if ref != nil {
-					isRef = true
-					prop = ref
-					refString = l
-				} else {
-					return nil, fmt.Errorf("schema properties build failed: cannot find reference %s, line %d, col %d",
-						prop.Content[1].Value, prop.Content[1].Line, prop.Content[1].Column)
-				}
-			}
-			totalProps++
-			go buildProperty(currentProp, prop, bChan, isRef, refString)
-		}
-		completedProps := 0
-		for completedProps < totalProps {
-			select {
-			case res := <-bChan:
-				completedProps++
-				propertyMap[res.k] = res.v
-			}
-		}
-		return &low.NodeReference[map[low.KeyReference[string]]low.ValueReference[*SchemaProxy]]{
-			Value:     propertyMap,
-			KeyNode:   propLabel,
-			ValueNode: propsNode,
-		}, nil
-	}
-	return nil, nil
+            // check our prop isn't reference
+            isRef := false
+            refString := ""
+            if h, _, l := utils.IsNodeRefValue(prop); h {
+                ref, _ := low.LocateRefNode(prop, idx)
+                if ref != nil {
+                    isRef = true
+                    prop = ref
+                    refString = l
+                } else {
+                    return nil, fmt.Errorf("schema properties build failed: cannot find reference %s, line %d, col %d",
+                        prop.Content[1].Value, prop.Content[1].Line, prop.Content[1].Column)
+                }
+            }
+            totalProps++
+            go buildProperty(currentProp, prop, bChan, isRef, refString)
+        }
+        completedProps := 0
+        for completedProps < totalProps {
+            select {
+            case res := <-bChan:
+                completedProps++
+                propertyMap[res.k] = res.v
+            }
+        }
+        return &low.NodeReference[map[low.KeyReference[string]]low.ValueReference[*SchemaProxy]]{
+            Value:     propertyMap,
+            KeyNode:   propLabel,
+            ValueNode: propsNode,
+        }, nil
+    }
+    return nil, nil
 }
 
 // count the number of sub-schemas in a node.
 func countSubSchemaItems(node *yaml.Node) int {
-	if utils.IsNodeMap(node) {
-		return 1
-	}
-	if utils.IsNodeArray(node) {
-		return len(node.Content)
-	}
-	return 0
+    if utils.IsNodeMap(node) {
+        return 1
+    }
+    if utils.IsNodeArray(node) {
+        return len(node.Content)
+    }
+    return 0
 }
 
 // schema build result container used for async building.
 type schemaProxyBuildResult struct {
-	k low.KeyReference[string]
-	v low.ValueReference[*SchemaProxy]
+    k low.KeyReference[string]
+    v low.ValueReference[*SchemaProxy]
 }
 
 // extract extensions from schema
 func (s *Schema) extractExtensions(root *yaml.Node) {
-	s.Extensions = low.ExtractExtensions(root)
+    s.Extensions = low.ExtractExtensions(root)
 }
 
 // build out a child schema for parent schema.
 func buildSchema(schemas chan schemaProxyBuildResult, labelNode, valueNode *yaml.Node, errors chan error, idx *index.SpecIndex) {
-	if valueNode != nil {
-		type buildResult struct {
-			res *low.ValueReference[*SchemaProxy]
-			idx int
-		}
+    if valueNode != nil {
+        type buildResult struct {
+            res *low.ValueReference[*SchemaProxy]
+            idx int
+        }
 
-		syncChan := make(chan buildResult)
+        syncChan := make(chan buildResult)
 
-		// build out a SchemaProxy for every sub-schema.
-		build := func(kn *yaml.Node, vn *yaml.Node, schemaIdx int, c chan buildResult,
-			isRef bool, refLocation string,
-		) {
-			// a proxy design works best here. polymorphism, pretty much guarantees that a sub-schema can
-			// take on circular references through polymorphism. Like the resolver, if we try and follow these
-			// journey's through hyperspace, we will end up creating endless amounts of threads, spinning off
-			// chasing down circles, that in turn spin up endless threads.
-			// In order to combat this, we need a schema proxy that will only resolve the schema when asked, and then
-			// it will only do it one level at a time.
-			sp := new(SchemaProxy)
-			sp.kn = kn
-			sp.vn = vn
-			sp.idx = idx
-			if isRef {
-				sp.referenceLookup = refLocation
-				sp.isReference = true
-			}
-			res := &low.ValueReference[*SchemaProxy]{
-				Value:     sp,
-				ValueNode: vn,
-			}
-			c <- buildResult{
-				res: res,
-				idx: schemaIdx,
-			}
-		}
+        // build out a SchemaProxy for every sub-schema.
+        build := func(kn *yaml.Node, vn *yaml.Node, schemaIdx int, c chan buildResult,
+            isRef bool, refLocation string,
+        ) {
+            // a proxy design works best here. polymorphism, pretty much guarantees that a sub-schema can
+            // take on circular references through polymorphism. Like the resolver, if we try and follow these
+            // journey's through hyperspace, we will end up creating endless amounts of threads, spinning off
+            // chasing down circles, that in turn spin up endless threads.
+            // In order to combat this, we need a schema proxy that will only resolve the schema when asked, and then
+            // it will only do it one level at a time.
+            sp := new(SchemaProxy)
+            sp.kn = kn
+            sp.vn = vn
+            sp.idx = idx
+            if isRef {
+                sp.referenceLookup = refLocation
+                sp.isReference = true
+            }
+            res := &low.ValueReference[*SchemaProxy]{
+                Value:     sp,
+                ValueNode: vn,
+            }
+            c <- buildResult{
+                res: res,
+                idx: schemaIdx,
+            }
+        }
 
-		isRef := false
-		refLocation := ""
-		if utils.IsNodeMap(valueNode) {
-			h := false
-			if h, _, refLocation = utils.IsNodeRefValue(valueNode); h {
-				isRef = true
-				ref, _ := low.LocateRefNode(valueNode, idx)
-				if ref != nil {
-					valueNode = ref
-				} else {
-					errors <- fmt.Errorf("build schema failed: reference cannot be found: %s, line %d, col %d",
-						valueNode.Content[1].Value, valueNode.Content[1].Line, valueNode.Content[1].Column)
-				}
-			}
+        isRef := false
+        refLocation := ""
+        if utils.IsNodeMap(valueNode) {
+            h := false
+            if h, _, refLocation = utils.IsNodeRefValue(valueNode); h {
+                isRef = true
+                ref, _ := low.LocateRefNode(valueNode, idx)
+                if ref != nil {
+                    valueNode = ref
+                } else {
+                    errors <- fmt.Errorf("build schema failed: reference cannot be found: %s, line %d, col %d",
+                        valueNode.Content[1].Value, valueNode.Content[1].Line, valueNode.Content[1].Column)
+                }
+            }
 
-			// this only runs once, however to keep things consistent, it makes sense to use the same async method
-			// that arrays will use.
-			go build(labelNode, valueNode, -1, syncChan, isRef, refLocation)
-			select {
-			case r := <-syncChan:
-				schemas <- schemaProxyBuildResult{
-					k: low.KeyReference[string]{
-						KeyNode: labelNode,
-						Value:   labelNode.Value,
-					},
-					v: *r.res,
-				}
-			}
-		}
-		if utils.IsNodeArray(valueNode) {
-			refBuilds := 0
-			results := make([]*low.ValueReference[*SchemaProxy], len(valueNode.Content))
+            // this only runs once, however to keep things consistent, it makes sense to use the same async method
+            // that arrays will use.
+            go build(labelNode, valueNode, -1, syncChan, isRef, refLocation)
+            select {
+            case r := <-syncChan:
+                schemas <- schemaProxyBuildResult{
+                    k: low.KeyReference[string]{
+                        KeyNode: labelNode,
+                        Value:   labelNode.Value,
+                    },
+                    v: *r.res,
+                }
+            }
+        }
+        if utils.IsNodeArray(valueNode) {
+            refBuilds := 0
+            results := make([]*low.ValueReference[*SchemaProxy], len(valueNode.Content))
 
-			for i, vn := range valueNode.Content {
-				isRef = false
-				h := false
-				if h, _, refLocation = utils.IsNodeRefValue(vn); h {
-					isRef = true
-					ref, _ := low.LocateRefNode(vn, idx)
-					if ref != nil {
-						vn = ref
-					} else {
-						err := fmt.Errorf("build schema failed: reference cannot be found: %s, line %d, col %d",
-							vn.Content[1].Value, vn.Content[1].Line, vn.Content[1].Column)
-						errors <- err
-						return
-					}
-				}
-				refBuilds++
-				go build(vn, vn, i, syncChan, isRef, refLocation)
-			}
+            for i, vn := range valueNode.Content {
+                isRef = false
+                h := false
+                if h, _, refLocation = utils.IsNodeRefValue(vn); h {
+                    isRef = true
+                    ref, _ := low.LocateRefNode(vn, idx)
+                    if ref != nil {
+                        vn = ref
+                    } else {
+                        err := fmt.Errorf("build schema failed: reference cannot be found: %s, line %d, col %d",
+                            vn.Content[1].Value, vn.Content[1].Line, vn.Content[1].Column)
+                        errors <- err
+                        return
+                    }
+                }
+                refBuilds++
+                go build(vn, vn, i, syncChan, isRef, refLocation)
+            }
 
-			completedBuilds := 0
-			for completedBuilds < refBuilds {
-				select {
-				case res := <-syncChan:
-					completedBuilds++
-					results[res.idx] = res.res
-				}
-			}
+            completedBuilds := 0
+            for completedBuilds < refBuilds {
+                select {
+                case res := <-syncChan:
+                    completedBuilds++
+                    results[res.idx] = res.res
+                }
+            }
 
-			for _, r := range results {
-				schemas <- schemaProxyBuildResult{
-					k: low.KeyReference[string]{
-						KeyNode: labelNode,
-						Value:   labelNode.Value,
-					},
-					v: *r,
-				}
-			}
-		}
-	}
+            for _, r := range results {
+                schemas <- schemaProxyBuildResult{
+                    k: low.KeyReference[string]{
+                        KeyNode: labelNode,
+                        Value:   labelNode.Value,
+                    },
+                    v: *r,
+                }
+            }
+        }
+    }
 }
 
 // ExtractSchema will return a pointer to a NodeReference that contains a *SchemaProxy if successful. The function
 // will specifically look for a key node named 'schema' and extract the value mapped to that key. If the operation
 // fails then no NodeReference is returned and an error is returned instead.
 func ExtractSchema(root *yaml.Node, idx *index.SpecIndex) (*low.NodeReference[*SchemaProxy], error) {
-	var schLabel, schNode *yaml.Node
-	errStr := "schema build failed: reference '%s' cannot be found at line %d, col %d"
+    var schLabel, schNode *yaml.Node
+    errStr := "schema build failed: reference '%s' cannot be found at line %d, col %d"
 
-	isRef := false
-	refLocation := ""
-	if rf, rl, _ := utils.IsNodeRefValue(root); rf {
-		// locate reference in index.
-		isRef = true
-		ref, _ := low.LocateRefNode(root, idx)
-		if ref != nil {
-			schNode = ref
-			schLabel = rl
-		} else {
-			return nil, fmt.Errorf(errStr,
-				root.Content[1].Value, root.Content[1].Line, root.Content[1].Column)
-		}
-	} else {
-		_, schLabel, schNode = utils.FindKeyNodeFull(SchemaLabel, root.Content)
-		if schNode != nil {
-			h := false
-			if h, _, refLocation = utils.IsNodeRefValue(schNode); h {
-				isRef = true
-				ref, _ := low.LocateRefNode(schNode, idx)
-				if ref != nil {
-					schNode = ref
-				} else {
-					return nil, fmt.Errorf(errStr,
-						schNode.Content[1].Value, schNode.Content[1].Line, schNode.Content[1].Column)
-				}
-			}
-		}
-	}
+    isRef := false
+    refLocation := ""
+    if rf, rl, _ := utils.IsNodeRefValue(root); rf {
+        // locate reference in index.
+        isRef = true
+        ref, _ := low.LocateRefNode(root, idx)
+        if ref != nil {
+            schNode = ref
+            schLabel = rl
+        } else {
+            return nil, fmt.Errorf(errStr,
+                root.Content[1].Value, root.Content[1].Line, root.Content[1].Column)
+        }
+    } else {
+        _, schLabel, schNode = utils.FindKeyNodeFull(SchemaLabel, root.Content)
+        if schNode != nil {
+            h := false
+            if h, _, refLocation = utils.IsNodeRefValue(schNode); h {
+                isRef = true
+                ref, _ := low.LocateRefNode(schNode, idx)
+                if ref != nil {
+                    schNode = ref
+                } else {
+                    return nil, fmt.Errorf(errStr,
+                        schNode.Content[1].Value, schNode.Content[1].Line, schNode.Content[1].Column)
+                }
+            }
+        }
+    }
 
-	if schNode != nil {
-		// check if schema has already been built.
-		schema := &SchemaProxy{kn: schLabel, vn: schNode, idx: idx, isReference: isRef, referenceLookup: refLocation}
-		return &low.NodeReference[*SchemaProxy]{Value: schema, KeyNode: schLabel, ValueNode: schNode, ReferenceNode: isRef,
-			Reference: refLocation}, nil
-	}
-	return nil, nil
+    if schNode != nil {
+        // check if schema has already been built.
+        schema := &SchemaProxy{kn: schLabel, vn: schNode, idx: idx, isReference: isRef, referenceLookup: refLocation}
+        return &low.NodeReference[*SchemaProxy]{Value: schema, KeyNode: schLabel, ValueNode: schNode, ReferenceNode: isRef,
+            Reference: refLocation}, nil
+    }
+    return nil, nil
 }

--- a/datamodel/low/base/schema_test.go
+++ b/datamodel/low/base/schema_test.go
@@ -1,18 +1,18 @@
 package base
 
 import (
-	"testing"
+    "testing"
 
-	"github.com/pb33f/libopenapi/datamodel/low"
-	"github.com/pb33f/libopenapi/index"
-	"github.com/pb33f/libopenapi/resolver"
-	"github.com/pb33f/libopenapi/utils"
-	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
+    "github.com/pb33f/libopenapi/datamodel/low"
+    "github.com/pb33f/libopenapi/index"
+    "github.com/pb33f/libopenapi/resolver"
+    "github.com/pb33f/libopenapi/utils"
+    "github.com/stretchr/testify/assert"
+    "gopkg.in/yaml.v3"
 )
 
 func test_get_schema_blob() string {
-	return `type: object
+    return `type: object
 description: something object
 if:
   type: string
@@ -151,249 +151,250 @@ contains:
   type: int
 maxContains: 10
 minContains: 1
+uniqueItems: true
 $anchor: anchor`
 }
 
 func Test_Schema(t *testing.T) {
-	testSpec := test_get_schema_blob()
+    testSpec := test_get_schema_blob()
 
-	var rootNode yaml.Node
-	mErr := yaml.Unmarshal([]byte(testSpec), &rootNode)
-	assert.NoError(t, mErr)
+    var rootNode yaml.Node
+    mErr := yaml.Unmarshal([]byte(testSpec), &rootNode)
+    assert.NoError(t, mErr)
 
-	sch := Schema{}
-	mbErr := low.BuildModel(rootNode.Content[0], &sch)
-	assert.NoError(t, mbErr)
+    sch := Schema{}
+    mbErr := low.BuildModel(rootNode.Content[0], &sch)
+    assert.NoError(t, mbErr)
 
-	schErr := sch.Build(rootNode.Content[0], nil)
-	assert.NoError(t, schErr)
-	assert.Equal(t, "something object", sch.Description.Value)
-	assert.True(t, sch.AdditionalProperties.Value.(bool))
+    schErr := sch.Build(rootNode.Content[0], nil)
+    assert.NoError(t, schErr)
+    assert.Equal(t, "something object", sch.Description.Value)
+    assert.True(t, sch.AdditionalProperties.Value.(bool))
 
-	assert.Len(t, sch.Properties.Value, 2)
-	v := sch.FindProperty("somethingB")
+    assert.Len(t, sch.Properties.Value, 2)
+    v := sch.FindProperty("somethingB")
 
-	assert.Equal(t, "https://pb33f.io", v.Value.Schema().ExternalDocs.Value.URL.Value)
-	assert.Equal(t, "the best docs", v.Value.Schema().ExternalDocs.Value.Description.Value)
+    assert.Equal(t, "https://pb33f.io", v.Value.Schema().ExternalDocs.Value.URL.Value)
+    assert.Equal(t, "the best docs", v.Value.Schema().ExternalDocs.Value.Description.Value)
 
-	assert.True(t, v.Value.Schema().ExclusiveMinimum.Value.A)
-	assert.True(t, v.Value.Schema().ExclusiveMaximum.Value.A)
+    assert.True(t, v.Value.Schema().ExclusiveMinimum.Value.A)
+    assert.True(t, v.Value.Schema().ExclusiveMaximum.Value.A)
 
-	j := v.Value.Schema().FindProperty("somethingBProp").Value.Schema()
-	k := v.Value.Schema().FindProperty("somethingBProp").Value
+    j := v.Value.Schema().FindProperty("somethingBProp").Value.Schema()
+    k := v.Value.Schema().FindProperty("somethingBProp").Value
 
-	assert.Equal(t, k, j.ParentProxy)
+    assert.Equal(t, k, j.ParentProxy)
 
-	assert.NotNil(t, j)
-	assert.NotNil(t, j.XML.Value)
-	assert.Equal(t, "an xml thing", j.XML.Value.Name.Value)
-	assert.Equal(t, "an xml namespace", j.XML.Value.Namespace.Value)
-	assert.Equal(t, "a prefix", j.XML.Value.Prefix.Value)
-	assert.Equal(t, true, j.XML.Value.Attribute.Value)
-	assert.Len(t, j.XML.Value.Extensions, 1)
-	assert.Len(t, j.XML.Value.GetExtensions(), 1)
+    assert.NotNil(t, j)
+    assert.NotNil(t, j.XML.Value)
+    assert.Equal(t, "an xml thing", j.XML.Value.Name.Value)
+    assert.Equal(t, "an xml namespace", j.XML.Value.Namespace.Value)
+    assert.Equal(t, "a prefix", j.XML.Value.Prefix.Value)
+    assert.Equal(t, true, j.XML.Value.Attribute.Value)
+    assert.Len(t, j.XML.Value.Extensions, 1)
+    assert.Len(t, j.XML.Value.GetExtensions(), 1)
 
-	assert.NotNil(t, v.Value.Schema().AdditionalProperties.Value)
+    assert.NotNil(t, v.Value.Schema().AdditionalProperties.Value)
 
-	var addProps map[string]interface{}
-	v.Value.Schema().AdditionalProperties.ValueNode.Decode(&addProps)
-	assert.Equal(t, "yes", addProps["why"])
-	assert.Equal(t, true, addProps["thatIs"])
+    var addProps map[string]interface{}
+    v.Value.Schema().AdditionalProperties.ValueNode.Decode(&addProps)
+    assert.Equal(t, "yes", addProps["why"])
+    assert.Equal(t, true, addProps["thatIs"])
 
-	// check polymorphic values allOf
-	f := sch.AllOf.Value[0].Value.Schema()
-	assert.Equal(t, "an allof thing", f.Description.Value)
-	assert.Len(t, f.Properties.Value, 2)
+    // check polymorphic values allOf
+    f := sch.AllOf.Value[0].Value.Schema()
+    assert.Equal(t, "an allof thing", f.Description.Value)
+    assert.Len(t, f.Properties.Value, 2)
 
-	v = f.FindProperty("allOfA")
-	assert.NotNil(t, v)
+    v = f.FindProperty("allOfA")
+    assert.NotNil(t, v)
 
-	io := v.Value.Schema()
+    io := v.Value.Schema()
 
-	assert.Equal(t, "allOfA description", io.Description.Value)
-	assert.Equal(t, "allOfAExp", io.Example.Value)
+    assert.Equal(t, "allOfA description", io.Description.Value)
+    assert.Equal(t, "allOfAExp", io.Example.Value)
 
-	qw := f.FindProperty("allOfB").Value.Schema()
-	assert.NotNil(t, v)
-	assert.Equal(t, "allOfB description", qw.Description.Value)
-	assert.Equal(t, "allOfBExp", qw.Example.Value)
+    qw := f.FindProperty("allOfB").Value.Schema()
+    assert.NotNil(t, v)
+    assert.Equal(t, "allOfB description", qw.Description.Value)
+    assert.Equal(t, "allOfBExp", qw.Example.Value)
 
-	// check polymorphic values anyOf
-	assert.Equal(t, "an anyOf thing", sch.AnyOf.Value[0].Value.Schema().Description.Value)
-	assert.Len(t, sch.AnyOf.Value[0].Value.Schema().Properties.Value, 2)
+    // check polymorphic values anyOf
+    assert.Equal(t, "an anyOf thing", sch.AnyOf.Value[0].Value.Schema().Description.Value)
+    assert.Len(t, sch.AnyOf.Value[0].Value.Schema().Properties.Value, 2)
 
-	v = sch.AnyOf.Value[0].Value.Schema().FindProperty("anyOfA")
-	assert.NotNil(t, v)
-	assert.Equal(t, "anyOfA description", v.Value.Schema().Description.Value)
-	assert.Equal(t, "anyOfAExp", v.Value.Schema().Example.Value)
+    v = sch.AnyOf.Value[0].Value.Schema().FindProperty("anyOfA")
+    assert.NotNil(t, v)
+    assert.Equal(t, "anyOfA description", v.Value.Schema().Description.Value)
+    assert.Equal(t, "anyOfAExp", v.Value.Schema().Example.Value)
 
-	v = sch.AnyOf.Value[0].Value.Schema().FindProperty("anyOfB")
-	assert.NotNil(t, v)
-	assert.Equal(t, "anyOfB description", v.Value.Schema().Description.Value)
-	assert.Equal(t, "anyOfBExp", v.Value.Schema().Example.Value)
+    v = sch.AnyOf.Value[0].Value.Schema().FindProperty("anyOfB")
+    assert.NotNil(t, v)
+    assert.Equal(t, "anyOfB description", v.Value.Schema().Description.Value)
+    assert.Equal(t, "anyOfBExp", v.Value.Schema().Example.Value)
 
-	// check polymorphic values oneOf
-	assert.Equal(t, "a oneof thing", sch.OneOf.Value[0].Value.Schema().Description.Value)
-	assert.Len(t, sch.OneOf.Value[0].Value.Schema().Properties.Value, 2)
+    // check polymorphic values oneOf
+    assert.Equal(t, "a oneof thing", sch.OneOf.Value[0].Value.Schema().Description.Value)
+    assert.Len(t, sch.OneOf.Value[0].Value.Schema().Properties.Value, 2)
 
-	v = sch.OneOf.Value[0].Value.Schema().FindProperty("oneOfA")
-	assert.NotNil(t, v)
-	assert.Equal(t, "oneOfA description", v.Value.Schema().Description.Value)
-	assert.Equal(t, "oneOfAExp", v.Value.Schema().Example.Value)
+    v = sch.OneOf.Value[0].Value.Schema().FindProperty("oneOfA")
+    assert.NotNil(t, v)
+    assert.Equal(t, "oneOfA description", v.Value.Schema().Description.Value)
+    assert.Equal(t, "oneOfAExp", v.Value.Schema().Example.Value)
 
-	v = sch.OneOf.Value[0].Value.Schema().FindProperty("oneOfB")
-	assert.NotNil(t, v)
-	assert.Equal(t, "oneOfB description", v.Value.Schema().Description.Value)
-	assert.Equal(t, "oneOfBExp", v.Value.Schema().Example.Value)
+    v = sch.OneOf.Value[0].Value.Schema().FindProperty("oneOfB")
+    assert.NotNil(t, v)
+    assert.Equal(t, "oneOfB description", v.Value.Schema().Description.Value)
+    assert.Equal(t, "oneOfBExp", v.Value.Schema().Example.Value)
 
-	// check values NOT
-	assert.Equal(t, "a not thing", sch.Not.Value.Schema().Description.Value)
-	assert.Len(t, sch.Not.Value.Schema().Properties.Value, 2)
+    // check values NOT
+    assert.Equal(t, "a not thing", sch.Not.Value.Schema().Description.Value)
+    assert.Len(t, sch.Not.Value.Schema().Properties.Value, 2)
 
-	v = sch.Not.Value.Schema().FindProperty("notA")
-	assert.NotNil(t, v)
-	assert.Equal(t, "notA description", v.Value.Schema().Description.Value)
-	assert.Equal(t, "notAExp", v.Value.Schema().Example.Value)
+    v = sch.Not.Value.Schema().FindProperty("notA")
+    assert.NotNil(t, v)
+    assert.Equal(t, "notA description", v.Value.Schema().Description.Value)
+    assert.Equal(t, "notAExp", v.Value.Schema().Example.Value)
 
-	v = sch.Not.Value.Schema().FindProperty("notB")
-	assert.NotNil(t, v)
-	assert.Equal(t, "notB description", v.Value.Schema().Description.Value)
-	assert.Equal(t, "notBExp", v.Value.Schema().Example.Value)
+    v = sch.Not.Value.Schema().FindProperty("notB")
+    assert.NotNil(t, v)
+    assert.Equal(t, "notB description", v.Value.Schema().Description.Value)
+    assert.Equal(t, "notBExp", v.Value.Schema().Example.Value)
 
-	// check values Items
-	assert.Equal(t, "an items thing", sch.Items.Value.A.Schema().Description.Value)
-	assert.Len(t, sch.Items.Value.A.Schema().Properties.Value, 2)
+    // check values Items
+    assert.Equal(t, "an items thing", sch.Items.Value.A.Schema().Description.Value)
+    assert.Len(t, sch.Items.Value.A.Schema().Properties.Value, 2)
 
-	v = sch.Items.Value.A.Schema().FindProperty("itemsA")
-	assert.NotNil(t, v)
-	assert.Equal(t, "itemsA description", v.Value.Schema().Description.Value)
-	assert.Equal(t, "itemsAExp", v.Value.Schema().Example.Value)
+    v = sch.Items.Value.A.Schema().FindProperty("itemsA")
+    assert.NotNil(t, v)
+    assert.Equal(t, "itemsA description", v.Value.Schema().Description.Value)
+    assert.Equal(t, "itemsAExp", v.Value.Schema().Example.Value)
 
-	v = sch.Items.Value.A.Schema().FindProperty("itemsB")
-	assert.NotNil(t, v)
-	assert.Equal(t, "itemsB description", v.Value.Schema().Description.Value)
-	assert.Equal(t, "itemsBExp", v.Value.Schema().Example.Value)
+    v = sch.Items.Value.A.Schema().FindProperty("itemsB")
+    assert.NotNil(t, v)
+    assert.Equal(t, "itemsB description", v.Value.Schema().Description.Value)
+    assert.Equal(t, "itemsBExp", v.Value.Schema().Example.Value)
 
-	// check values PrefixItems
-	assert.Equal(t, "an items thing", sch.PrefixItems.Value[0].Value.Schema().Description.Value)
-	assert.Len(t, sch.PrefixItems.Value[0].Value.Schema().Properties.Value, 2)
+    // check values PrefixItems
+    assert.Equal(t, "an items thing", sch.PrefixItems.Value[0].Value.Schema().Description.Value)
+    assert.Len(t, sch.PrefixItems.Value[0].Value.Schema().Properties.Value, 2)
 
-	v = sch.PrefixItems.Value[0].Value.Schema().FindProperty("itemsA")
-	assert.NotNil(t, v)
-	assert.Equal(t, "itemsA description", v.Value.Schema().Description.Value)
-	assert.Equal(t, "itemsAExp", v.Value.Schema().Example.Value)
+    v = sch.PrefixItems.Value[0].Value.Schema().FindProperty("itemsA")
+    assert.NotNil(t, v)
+    assert.Equal(t, "itemsA description", v.Value.Schema().Description.Value)
+    assert.Equal(t, "itemsAExp", v.Value.Schema().Example.Value)
 
-	v = sch.PrefixItems.Value[0].Value.Schema().FindProperty("itemsB")
-	assert.NotNil(t, v)
-	assert.Equal(t, "itemsB description", v.Value.Schema().Description.Value)
-	assert.Equal(t, "itemsBExp", v.Value.Schema().Example.Value)
+    v = sch.PrefixItems.Value[0].Value.Schema().FindProperty("itemsB")
+    assert.NotNil(t, v)
+    assert.Equal(t, "itemsB description", v.Value.Schema().Description.Value)
+    assert.Equal(t, "itemsBExp", v.Value.Schema().Example.Value)
 
-	// check discriminator
-	assert.NotNil(t, sch.Discriminator.Value)
-	assert.Equal(t, "athing", sch.Discriminator.Value.PropertyName.Value)
-	assert.Len(t, sch.Discriminator.Value.Mapping.Value, 2)
-	mv := sch.Discriminator.Value.FindMappingValue("log")
-	assert.Equal(t, "cat", mv.Value)
-	mv = sch.Discriminator.Value.FindMappingValue("pizza")
-	assert.Equal(t, "party", mv.Value)
+    // check discriminator
+    assert.NotNil(t, sch.Discriminator.Value)
+    assert.Equal(t, "athing", sch.Discriminator.Value.PropertyName.Value)
+    assert.Len(t, sch.Discriminator.Value.Mapping.Value, 2)
+    mv := sch.Discriminator.Value.FindMappingValue("log")
+    assert.Equal(t, "cat", mv.Value)
+    mv = sch.Discriminator.Value.FindMappingValue("pizza")
+    assert.Equal(t, "party", mv.Value)
 
-	// check 3.1 properties.
-	assert.Equal(t, "int", sch.Contains.Value.Schema().Type.Value.A)
-	assert.Equal(t, int64(1), sch.MinContains.Value)
-	assert.Equal(t, int64(10), sch.MaxContains.Value)
-	assert.Equal(t, "string", sch.If.Value.Schema().Type.Value.A)
-	assert.Equal(t, "integer", sch.Else.Value.Schema().Type.Value.A)
-	assert.Equal(t, "boolean", sch.Then.Value.Schema().Type.Value.A)
-	assert.Equal(t, "string", sch.FindDependentSchema("schemaOne").Value.Schema().Type.Value.A)
-	assert.Equal(t, "string", sch.FindPatternProperty("patternOne").Value.Schema().Type.Value.A)
-	assert.Equal(t, "string", sch.PropertyNames.Value.Schema().Type.Value.A)
-	assert.Equal(t, "boolean", sch.UnevaluatedItems.Value.Schema().Type.Value.A)
-	assert.Equal(t, "integer", sch.UnevaluatedProperties.Value.Schema().Type.Value.A)
-	assert.Equal(t, "anchor", sch.Anchor.Value)
+    // check 3.1 properties.
+    assert.Equal(t, "int", sch.Contains.Value.Schema().Type.Value.A)
+    assert.Equal(t, int64(1), sch.MinContains.Value)
+    assert.Equal(t, int64(10), sch.MaxContains.Value)
+    assert.Equal(t, "string", sch.If.Value.Schema().Type.Value.A)
+    assert.Equal(t, "integer", sch.Else.Value.Schema().Type.Value.A)
+    assert.Equal(t, "boolean", sch.Then.Value.Schema().Type.Value.A)
+    assert.Equal(t, "string", sch.FindDependentSchema("schemaOne").Value.Schema().Type.Value.A)
+    assert.Equal(t, "string", sch.FindPatternProperty("patternOne").Value.Schema().Type.Value.A)
+    assert.Equal(t, "string", sch.PropertyNames.Value.Schema().Type.Value.A)
+    assert.Equal(t, "boolean", sch.UnevaluatedItems.Value.Schema().Type.Value.A)
+    assert.Equal(t, "integer", sch.UnevaluatedProperties.Value.Schema().Type.Value.A)
+    assert.Equal(t, "anchor", sch.Anchor.Value)
 }
 
 func TestSchemaAllOfSequenceOrder(t *testing.T) {
-	testSpec := test_get_allOf_schema_blob()
+    testSpec := test_get_allOf_schema_blob()
 
-	var rootNode yaml.Node
-	mErr := yaml.Unmarshal([]byte(testSpec), &rootNode)
-	assert.NoError(t, mErr)
+    var rootNode yaml.Node
+    mErr := yaml.Unmarshal([]byte(testSpec), &rootNode)
+    assert.NoError(t, mErr)
 
-	// test data is a map with one node
-	mapContent := rootNode.Content[0].Content
+    // test data is a map with one node
+    mapContent := rootNode.Content[0].Content
 
-	_, vn := utils.FindKeyNodeTop(AllOfLabel, mapContent)
-	assert.True(t, utils.IsNodeArray(vn))
+    _, vn := utils.FindKeyNodeTop(AllOfLabel, mapContent)
+    assert.True(t, utils.IsNodeArray(vn))
 
-	want := []string{}
+    want := []string{}
 
-	// Go over every element in AllOf and grab description
-	// Odd: object
-	// Event: description
-	for i := range vn.Content {
-		assert.True(t, utils.IsNodeMap(vn.Content[i]))
-		_, vn := utils.FindKeyNodeTop("description", vn.Content[i].Content)
-		assert.True(t, utils.IsNodeStringValue(vn))
-		want = append(want, vn.Value)
-	}
+    // Go over every element in AllOf and grab description
+    // Odd: object
+    // Event: description
+    for i := range vn.Content {
+        assert.True(t, utils.IsNodeMap(vn.Content[i]))
+        _, vn := utils.FindKeyNodeTop("description", vn.Content[i].Content)
+        assert.True(t, utils.IsNodeStringValue(vn))
+        want = append(want, vn.Value)
+    }
 
-	sch := Schema{}
-	mbErr := low.BuildModel(rootNode.Content[0], &sch)
-	assert.NoError(t, mbErr)
+    sch := Schema{}
+    mbErr := low.BuildModel(rootNode.Content[0], &sch)
+    assert.NoError(t, mbErr)
 
-	schErr := sch.Build(rootNode.Content[0], nil)
-	assert.NoError(t, schErr)
-	assert.Equal(t, "allOf sequence check", sch.Description.Value)
+    schErr := sch.Build(rootNode.Content[0], nil)
+    assert.NoError(t, schErr)
+    assert.Equal(t, "allOf sequence check", sch.Description.Value)
 
-	got := []string{}
-	for i := range sch.AllOf.Value {
-		v := sch.AllOf.Value[i]
-		got = append(got, v.Value.Schema().Description.Value)
-	}
+    got := []string{}
+    for i := range sch.AllOf.Value {
+        v := sch.AllOf.Value[i]
+        got = append(got, v.Value.Schema().Description.Value)
+    }
 
-	assert.Equal(t, want, got)
+    assert.Equal(t, want, got)
 }
 
 func TestSchema_Hash(t *testing.T) {
-	// create two versions
-	testSpec := test_get_schema_blob()
-	var sc1n yaml.Node
-	_ = yaml.Unmarshal([]byte(testSpec), &sc1n)
-	sch1 := Schema{}
-	_ = low.BuildModel(&sc1n, &sch1)
-	_ = sch1.Build(sc1n.Content[0], nil)
+    // create two versions
+    testSpec := test_get_schema_blob()
+    var sc1n yaml.Node
+    _ = yaml.Unmarshal([]byte(testSpec), &sc1n)
+    sch1 := Schema{}
+    _ = low.BuildModel(&sc1n, &sch1)
+    _ = sch1.Build(sc1n.Content[0], nil)
 
-	var sc2n yaml.Node
-	_ = yaml.Unmarshal([]byte(testSpec), &sc2n)
-	sch2 := Schema{}
-	_ = low.BuildModel(&sc2n, &sch2)
-	_ = sch2.Build(sc2n.Content[0], nil)
+    var sc2n yaml.Node
+    _ = yaml.Unmarshal([]byte(testSpec), &sc2n)
+    sch2 := Schema{}
+    _ = low.BuildModel(&sc2n, &sch2)
+    _ = sch2.Build(sc2n.Content[0], nil)
 
-	assert.Equal(t, sch1.Hash(), sch2.Hash())
+    assert.Equal(t, sch1.Hash(), sch2.Hash())
 }
 
 func BenchmarkSchema_Hash(b *testing.B) {
-	// create two versions
-	testSpec := test_get_schema_blob()
-	var sc1n yaml.Node
-	_ = yaml.Unmarshal([]byte(testSpec), &sc1n)
-	sch1 := Schema{}
-	_ = low.BuildModel(&sc1n, &sch1)
-	_ = sch1.Build(sc1n.Content[0], nil)
+    // create two versions
+    testSpec := test_get_schema_blob()
+    var sc1n yaml.Node
+    _ = yaml.Unmarshal([]byte(testSpec), &sc1n)
+    sch1 := Schema{}
+    _ = low.BuildModel(&sc1n, &sch1)
+    _ = sch1.Build(sc1n.Content[0], nil)
 
-	var sc2n yaml.Node
-	_ = yaml.Unmarshal([]byte(testSpec), &sc2n)
-	sch2 := Schema{}
-	_ = low.BuildModel(&sc2n, &sch2)
-	_ = sch2.Build(sc2n.Content[0], nil)
+    var sc2n yaml.Node
+    _ = yaml.Unmarshal([]byte(testSpec), &sc2n)
+    sch2 := Schema{}
+    _ = low.BuildModel(&sc2n, &sch2)
+    _ = sch2.Build(sc2n.Content[0], nil)
 
-	for i := 0; i < b.N; i++ {
-		assert.Equal(b, sch1.Hash(), sch2.Hash())
-	}
+    for i := 0; i < b.N; i++ {
+        assert.Equal(b, sch1.Hash(), sch2.Hash())
+    }
 }
 
 func Test_Schema_31(t *testing.T) {
-	testSpec := `$schema: https://something
+    testSpec := `$schema: https://something
 type:
   - object
   - null
@@ -406,136 +407,136 @@ items: true
 examples:
   - testing`
 
-	var rootNode yaml.Node
-	mErr := yaml.Unmarshal([]byte(testSpec), &rootNode)
-	assert.NoError(t, mErr)
+    var rootNode yaml.Node
+    mErr := yaml.Unmarshal([]byte(testSpec), &rootNode)
+    assert.NoError(t, mErr)
 
-	sch := Schema{}
-	mbErr := low.BuildModel(rootNode.Content[0], &sch)
-	assert.NoError(t, mbErr)
+    sch := Schema{}
+    mbErr := low.BuildModel(rootNode.Content[0], &sch)
+    assert.NoError(t, mbErr)
 
-	schErr := sch.Build(rootNode.Content[0], nil)
-	assert.NoError(t, schErr)
-	assert.Equal(t, "something object", sch.Description.Value)
-	assert.Len(t, sch.Type.Value.B, 2)
-	assert.True(t, sch.Type.Value.IsB())
-	assert.Equal(t, "object", sch.Type.Value.B[0].Value)
-	assert.True(t, sch.ExclusiveMinimum.Value.IsB())
-	assert.False(t, sch.ExclusiveMinimum.Value.IsA())
-	assert.True(t, sch.ExclusiveMaximum.Value.IsB())
-	assert.Equal(t, int64(12), sch.ExclusiveMinimum.Value.B)
-	assert.Equal(t, int64(13), sch.ExclusiveMaximum.Value.B)
-	assert.Len(t, sch.Examples.Value, 1)
-	assert.Equal(t, "testing", sch.Examples.Value[0].Value)
-	assert.Equal(t, "fish64", sch.ContentEncoding.Value)
-	assert.Equal(t, "fish/paste", sch.ContentMediaType.Value)
-	assert.True(t, sch.Items.Value.IsB())
-	assert.True(t, sch.Items.Value.B)
+    schErr := sch.Build(rootNode.Content[0], nil)
+    assert.NoError(t, schErr)
+    assert.Equal(t, "something object", sch.Description.Value)
+    assert.Len(t, sch.Type.Value.B, 2)
+    assert.True(t, sch.Type.Value.IsB())
+    assert.Equal(t, "object", sch.Type.Value.B[0].Value)
+    assert.True(t, sch.ExclusiveMinimum.Value.IsB())
+    assert.False(t, sch.ExclusiveMinimum.Value.IsA())
+    assert.True(t, sch.ExclusiveMaximum.Value.IsB())
+    assert.Equal(t, int64(12), sch.ExclusiveMinimum.Value.B)
+    assert.Equal(t, int64(13), sch.ExclusiveMaximum.Value.B)
+    assert.Len(t, sch.Examples.Value, 1)
+    assert.Equal(t, "testing", sch.Examples.Value[0].Value)
+    assert.Equal(t, "fish64", sch.ContentEncoding.Value)
+    assert.Equal(t, "fish/paste", sch.ContentMediaType.Value)
+    assert.True(t, sch.Items.Value.IsB())
+    assert.True(t, sch.Items.Value.B)
 }
 
 func TestSchema_Build_PropsLookup(t *testing.T) {
-	yml := `components:
+    yml := `components:
   schemas:
     Something:
       description: this is something
       type: string`
 
-	var iNode yaml.Node
-	mErr := yaml.Unmarshal([]byte(yml), &iNode)
-	assert.NoError(t, mErr)
-	idx := index.NewSpecIndex(&iNode)
+    var iNode yaml.Node
+    mErr := yaml.Unmarshal([]byte(yml), &iNode)
+    assert.NoError(t, mErr)
+    idx := index.NewSpecIndex(&iNode)
 
-	yml = `type: object
+    yml = `type: object
 properties:
   aValue:
     $ref: '#/components/schemas/Something'`
 
-	var idxNode yaml.Node
-	_ = yaml.Unmarshal([]byte(yml), &idxNode)
+    var idxNode yaml.Node
+    _ = yaml.Unmarshal([]byte(yml), &idxNode)
 
-	var n Schema
-	err := n.Build(idxNode.Content[0], idx)
-	assert.NoError(t, err)
-	assert.Equal(t, "this is something", n.FindProperty("aValue").Value.Schema().Description.Value)
+    var n Schema
+    err := n.Build(idxNode.Content[0], idx)
+    assert.NoError(t, err)
+    assert.Equal(t, "this is something", n.FindProperty("aValue").Value.Schema().Description.Value)
 }
 
 func TestSchema_Build_PropsLookup_Fail(t *testing.T) {
-	yml := `components:
+    yml := `components:
   schemas:
     Something:
       description: this is something
       type: string`
 
-	var iNode yaml.Node
-	mErr := yaml.Unmarshal([]byte(yml), &iNode)
-	assert.NoError(t, mErr)
-	idx := index.NewSpecIndex(&iNode)
+    var iNode yaml.Node
+    mErr := yaml.Unmarshal([]byte(yml), &iNode)
+    assert.NoError(t, mErr)
+    idx := index.NewSpecIndex(&iNode)
 
-	yml = `type: object
+    yml = `type: object
 properties:
   aValue:
     $ref: '#/bork'`
 
-	var idxNode yaml.Node
-	_ = yaml.Unmarshal([]byte(yml), &idxNode)
+    var idxNode yaml.Node
+    _ = yaml.Unmarshal([]byte(yml), &idxNode)
 
-	var n Schema
-	err := n.Build(idxNode.Content[0], idx)
-	assert.Error(t, err)
+    var n Schema
+    err := n.Build(idxNode.Content[0], idx)
+    assert.Error(t, err)
 }
 
 func TestSchema_Build_DependentSchemas_Fail(t *testing.T) {
-	yml := `components:
+    yml := `components:
   schemas:
     Something:
       description: this is something
       type: string`
 
-	var iNode yaml.Node
-	mErr := yaml.Unmarshal([]byte(yml), &iNode)
-	assert.NoError(t, mErr)
-	idx := index.NewSpecIndex(&iNode)
+    var iNode yaml.Node
+    mErr := yaml.Unmarshal([]byte(yml), &iNode)
+    assert.NoError(t, mErr)
+    idx := index.NewSpecIndex(&iNode)
 
-	yml = `type: object
+    yml = `type: object
 dependentSchemas:
   aValue:
     $ref: '#/bork'`
 
-	var idxNode yaml.Node
-	_ = yaml.Unmarshal([]byte(yml), &idxNode)
+    var idxNode yaml.Node
+    _ = yaml.Unmarshal([]byte(yml), &idxNode)
 
-	var n Schema
-	err := n.Build(idxNode.Content[0], idx)
-	assert.Error(t, err)
+    var n Schema
+    err := n.Build(idxNode.Content[0], idx)
+    assert.Error(t, err)
 }
 
 func TestSchema_Build_PatternProperties_Fail(t *testing.T) {
-	yml := `components:
+    yml := `components:
   schemas:
     Something:
       description: this is something
       type: string`
 
-	var iNode yaml.Node
-	mErr := yaml.Unmarshal([]byte(yml), &iNode)
-	assert.NoError(t, mErr)
-	idx := index.NewSpecIndex(&iNode)
+    var iNode yaml.Node
+    mErr := yaml.Unmarshal([]byte(yml), &iNode)
+    assert.NoError(t, mErr)
+    idx := index.NewSpecIndex(&iNode)
 
-	yml = `type: object
+    yml = `type: object
 patternProperties:
   aValue:
     $ref: '#/bork'`
 
-	var idxNode yaml.Node
-	_ = yaml.Unmarshal([]byte(yml), &idxNode)
+    var idxNode yaml.Node
+    _ = yaml.Unmarshal([]byte(yml), &idxNode)
 
-	var n Schema
-	err := n.Build(idxNode.Content[0], idx)
-	assert.Error(t, err)
+    var n Schema
+    err := n.Build(idxNode.Content[0], idx)
+    assert.Error(t, err)
 }
 
 func Test_Schema_Polymorphism_Array_Ref(t *testing.T) {
-	yml := `components:
+    yml := `components:
   schemas:
     Something:
       type: object
@@ -546,12 +547,12 @@ func Test_Schema_Polymorphism_Array_Ref(t *testing.T) {
           description: a property
           example: anything`
 
-	var iNode yaml.Node
-	mErr := yaml.Unmarshal([]byte(yml), &iNode)
-	assert.NoError(t, mErr)
-	idx := index.NewSpecIndex(&iNode)
+    var iNode yaml.Node
+    mErr := yaml.Unmarshal([]byte(yml), &iNode)
+    assert.NoError(t, mErr)
+    idx := index.NewSpecIndex(&iNode)
 
-	yml = `type: object
+    yml = `type: object
 allOf:
   - $ref: '#/components/schemas/Something'
 oneOf:
@@ -563,26 +564,26 @@ not:
 items:
   - $ref: '#/components/schemas/Something'`
 
-	var sch Schema
-	var idxNode yaml.Node
-	_ = yaml.Unmarshal([]byte(yml), &idxNode)
+    var sch Schema
+    var idxNode yaml.Node
+    _ = yaml.Unmarshal([]byte(yml), &idxNode)
 
-	err := low.BuildModel(&idxNode, &sch)
-	assert.NoError(t, err)
+    err := low.BuildModel(&idxNode, &sch)
+    assert.NoError(t, err)
 
-	schErr := sch.Build(idxNode.Content[0], idx)
-	assert.NoError(t, schErr)
+    schErr := sch.Build(idxNode.Content[0], idx)
+    assert.NoError(t, schErr)
 
-	desc := "poly thing"
-	assert.Equal(t, desc, sch.OneOf.Value[0].Value.Schema().Description.Value)
-	assert.Equal(t, desc, sch.AnyOf.Value[0].Value.Schema().Description.Value)
-	assert.Equal(t, desc, sch.AllOf.Value[0].Value.Schema().Description.Value)
-	assert.Equal(t, desc, sch.Not.Value.Schema().Description.Value)
-	assert.Equal(t, desc, sch.Items.Value.A.Schema().Description.Value)
+    desc := "poly thing"
+    assert.Equal(t, desc, sch.OneOf.Value[0].Value.Schema().Description.Value)
+    assert.Equal(t, desc, sch.AnyOf.Value[0].Value.Schema().Description.Value)
+    assert.Equal(t, desc, sch.AllOf.Value[0].Value.Schema().Description.Value)
+    assert.Equal(t, desc, sch.Not.Value.Schema().Description.Value)
+    assert.Equal(t, desc, sch.Items.Value.A.Schema().Description.Value)
 }
 
 func Test_Schema_Polymorphism_Array_Ref_Fail(t *testing.T) {
-	yml := `components:
+    yml := `components:
   schemas:
     Something:
       type: object
@@ -593,12 +594,12 @@ func Test_Schema_Polymorphism_Array_Ref_Fail(t *testing.T) {
           description: a property
           example: anything`
 
-	var iNode yaml.Node
-	mErr := yaml.Unmarshal([]byte(yml), &iNode)
-	assert.NoError(t, mErr)
-	idx := index.NewSpecIndex(&iNode)
+    var iNode yaml.Node
+    mErr := yaml.Unmarshal([]byte(yml), &iNode)
+    assert.NoError(t, mErr)
+    idx := index.NewSpecIndex(&iNode)
 
-	yml = `type: object
+    yml = `type: object
 allOf:
   - $ref: '#/components/schemas/Missing'
 oneOf:
@@ -610,19 +611,19 @@ not:
 items:
   - $ref: '#/components/schemas/Something'`
 
-	var sch Schema
-	var idxNode yaml.Node
-	_ = yaml.Unmarshal([]byte(yml), &idxNode)
+    var sch Schema
+    var idxNode yaml.Node
+    _ = yaml.Unmarshal([]byte(yml), &idxNode)
 
-	err := low.BuildModel(&idxNode, &sch)
-	assert.NoError(t, err)
+    err := low.BuildModel(&idxNode, &sch)
+    assert.NoError(t, err)
 
-	schErr := sch.Build(idxNode.Content[0], idx)
-	assert.Error(t, schErr)
+    schErr := sch.Build(idxNode.Content[0], idx)
+    assert.Error(t, schErr)
 }
 
 func Test_Schema_Polymorphism_Map_Ref(t *testing.T) {
-	yml := `components:
+    yml := `components:
   schemas:
     Something:
       type: object
@@ -633,12 +634,12 @@ func Test_Schema_Polymorphism_Map_Ref(t *testing.T) {
           description: a property
           example: anything`
 
-	var iNode yaml.Node
-	mErr := yaml.Unmarshal([]byte(yml), &iNode)
-	assert.NoError(t, mErr)
-	idx := index.NewSpecIndex(&iNode)
+    var iNode yaml.Node
+    mErr := yaml.Unmarshal([]byte(yml), &iNode)
+    assert.NoError(t, mErr)
+    idx := index.NewSpecIndex(&iNode)
 
-	yml = `type: object
+    yml = `type: object
 allOf:
   $ref: '#/components/schemas/Something'
 oneOf:
@@ -650,26 +651,26 @@ not:
 items:
   $ref: '#/components/schemas/Something'`
 
-	var sch Schema
-	var idxNode yaml.Node
-	_ = yaml.Unmarshal([]byte(yml), &idxNode)
+    var sch Schema
+    var idxNode yaml.Node
+    _ = yaml.Unmarshal([]byte(yml), &idxNode)
 
-	err := low.BuildModel(&idxNode, &sch)
-	assert.NoError(t, err)
+    err := low.BuildModel(&idxNode, &sch)
+    assert.NoError(t, err)
 
-	schErr := sch.Build(idxNode.Content[0], idx)
-	assert.NoError(t, schErr)
+    schErr := sch.Build(idxNode.Content[0], idx)
+    assert.NoError(t, schErr)
 
-	desc := "poly thing"
-	assert.Equal(t, desc, sch.OneOf.Value[0].Value.Schema().Description.Value)
-	assert.Equal(t, desc, sch.AnyOf.Value[0].Value.Schema().Description.Value)
-	assert.Equal(t, desc, sch.AllOf.Value[0].Value.Schema().Description.Value)
-	assert.Equal(t, desc, sch.Not.Value.Schema().Description.Value)
-	assert.Equal(t, desc, sch.Items.Value.A.Schema().Description.Value)
+    desc := "poly thing"
+    assert.Equal(t, desc, sch.OneOf.Value[0].Value.Schema().Description.Value)
+    assert.Equal(t, desc, sch.AnyOf.Value[0].Value.Schema().Description.Value)
+    assert.Equal(t, desc, sch.AllOf.Value[0].Value.Schema().Description.Value)
+    assert.Equal(t, desc, sch.Not.Value.Schema().Description.Value)
+    assert.Equal(t, desc, sch.Items.Value.A.Schema().Description.Value)
 }
 
 func Test_Schema_Polymorphism_Map_Ref_Fail(t *testing.T) {
-	yml := `components:
+    yml := `components:
   schemas:
     Something:
       type: object
@@ -680,12 +681,12 @@ func Test_Schema_Polymorphism_Map_Ref_Fail(t *testing.T) {
           description: a property
           example: anything`
 
-	var iNode yaml.Node
-	mErr := yaml.Unmarshal([]byte(yml), &iNode)
-	assert.NoError(t, mErr)
-	idx := index.NewSpecIndex(&iNode)
+    var iNode yaml.Node
+    mErr := yaml.Unmarshal([]byte(yml), &iNode)
+    assert.NoError(t, mErr)
+    idx := index.NewSpecIndex(&iNode)
 
-	yml = `type: object
+    yml = `type: object
 allOf:
   $ref: '#/components/schemas/Missing'
 oneOf:
@@ -697,342 +698,342 @@ not:
 items:
   $ref: '#/components/schemas/Something'`
 
-	var sch Schema
-	var idxNode yaml.Node
-	_ = yaml.Unmarshal([]byte(yml), &idxNode)
+    var sch Schema
+    var idxNode yaml.Node
+    _ = yaml.Unmarshal([]byte(yml), &idxNode)
 
-	err := low.BuildModel(&idxNode, &sch)
-	assert.NoError(t, err)
+    err := low.BuildModel(&idxNode, &sch)
+    assert.NoError(t, err)
 
-	schErr := sch.Build(idxNode.Content[0], idx)
-	assert.Error(t, schErr)
+    schErr := sch.Build(idxNode.Content[0], idx)
+    assert.Error(t, schErr)
 }
 
 func Test_Schema_Polymorphism_BorkParent(t *testing.T) {
-	yml := `components:
+    yml := `components:
   schemas:
     Something:
       $ref: #borko`
 
-	var iNode yaml.Node
-	mErr := yaml.Unmarshal([]byte(yml), &iNode)
-	assert.NoError(t, mErr)
-	idx := index.NewSpecIndex(&iNode)
+    var iNode yaml.Node
+    mErr := yaml.Unmarshal([]byte(yml), &iNode)
+    assert.NoError(t, mErr)
+    idx := index.NewSpecIndex(&iNode)
 
-	yml = `type: object
+    yml = `type: object
 allOf:
   $ref: '#/components/schemas/Something'`
 
-	var sch Schema
-	var idxNode yaml.Node
-	_ = yaml.Unmarshal([]byte(yml), &idxNode)
+    var sch Schema
+    var idxNode yaml.Node
+    _ = yaml.Unmarshal([]byte(yml), &idxNode)
 
-	err := low.BuildModel(&idxNode, &sch)
-	assert.NoError(t, err)
+    err := low.BuildModel(&idxNode, &sch)
+    assert.NoError(t, err)
 
-	schErr := sch.Build(idxNode.Content[0], idx)
-	assert.Error(t, schErr)
+    schErr := sch.Build(idxNode.Content[0], idx)
+    assert.Error(t, schErr)
 }
 
 func Test_Schema_Polymorphism_BorkChild(t *testing.T) {
-	yml := `components:
+    yml := `components:
   schemas:
     Something:
       $ref: #borko`
 
-	var iNode yaml.Node
-	mErr := yaml.Unmarshal([]byte(yml), &iNode)
-	assert.NoError(t, mErr)
-	idx := index.NewSpecIndex(&iNode)
+    var iNode yaml.Node
+    mErr := yaml.Unmarshal([]byte(yml), &iNode)
+    assert.NoError(t, mErr)
+    idx := index.NewSpecIndex(&iNode)
 
-	yml = `type: object
+    yml = `type: object
 allOf:
   $ref: #borko`
 
-	var sch Schema
-	var idxNode yaml.Node
-	_ = yaml.Unmarshal([]byte(yml), &idxNode)
+    var sch Schema
+    var idxNode yaml.Node
+    _ = yaml.Unmarshal([]byte(yml), &idxNode)
 
-	err := low.BuildModel(&idxNode, &sch)
-	assert.NoError(t, err)
+    err := low.BuildModel(&idxNode, &sch)
+    assert.NoError(t, err)
 
-	schErr := sch.Build(idxNode.Content[0], idx)
-	assert.Error(t, schErr)
+    schErr := sch.Build(idxNode.Content[0], idx)
+    assert.Error(t, schErr)
 }
 
 func Test_Schema_Polymorphism_BorkChild_Array(t *testing.T) {
-	yml := `components:
+    yml := `components:
   schemas:
     Something:
       $ref: #borko`
 
-	var iNode yaml.Node
-	mErr := yaml.Unmarshal([]byte(yml), &iNode)
-	assert.NoError(t, mErr)
-	idx := index.NewSpecIndex(&iNode)
+    var iNode yaml.Node
+    mErr := yaml.Unmarshal([]byte(yml), &iNode)
+    assert.NoError(t, mErr)
+    idx := index.NewSpecIndex(&iNode)
 
-	yml = `type: object
+    yml = `type: object
 allOf:
   - type: object
     allOf:
       - $ref: #bork'`
 
-	var sch Schema
-	var idxNode yaml.Node
-	_ = yaml.Unmarshal([]byte(yml), &idxNode)
+    var sch Schema
+    var idxNode yaml.Node
+    _ = yaml.Unmarshal([]byte(yml), &idxNode)
 
-	err := low.BuildModel(&idxNode, &sch)
-	assert.NoError(t, err)
+    err := low.BuildModel(&idxNode, &sch)
+    assert.NoError(t, err)
 
-	schErr := sch.Build(idxNode.Content[0], idx)
-	assert.NoError(t, schErr)
-	assert.Nil(t, sch.AllOf.Value[0].Value.Schema()) // child can't be resolved, so this will be nil.
-	assert.Error(t, sch.AllOf.Value[0].Value.GetBuildError())
+    schErr := sch.Build(idxNode.Content[0], idx)
+    assert.NoError(t, schErr)
+    assert.Nil(t, sch.AllOf.Value[0].Value.Schema()) // child can't be resolved, so this will be nil.
+    assert.Error(t, sch.AllOf.Value[0].Value.GetBuildError())
 }
 
 func Test_Schema_Polymorphism_RefMadness(t *testing.T) {
-	yml := `components:
+    yml := `components:
   schemas:
     Something:
       $ref: '#/components/schemas/Else'
     Else:
       description: madness`
 
-	var iNode yaml.Node
-	mErr := yaml.Unmarshal([]byte(yml), &iNode)
-	assert.NoError(t, mErr)
-	idx := index.NewSpecIndex(&iNode)
+    var iNode yaml.Node
+    mErr := yaml.Unmarshal([]byte(yml), &iNode)
+    assert.NoError(t, mErr)
+    idx := index.NewSpecIndex(&iNode)
 
-	yml = `type: object
+    yml = `type: object
 allOf:
   $ref: '#/components/schemas/Something'`
 
-	var sch Schema
-	var idxNode yaml.Node
-	_ = yaml.Unmarshal([]byte(yml), &idxNode)
+    var sch Schema
+    var idxNode yaml.Node
+    _ = yaml.Unmarshal([]byte(yml), &idxNode)
 
-	err := low.BuildModel(&idxNode, &sch)
-	assert.NoError(t, err)
+    err := low.BuildModel(&idxNode, &sch)
+    assert.NoError(t, err)
 
-	schErr := sch.Build(idxNode.Content[0], idx)
-	assert.NoError(t, schErr)
+    schErr := sch.Build(idxNode.Content[0], idx)
+    assert.NoError(t, schErr)
 
-	desc := "madness"
-	assert.Equal(t, desc, sch.AllOf.Value[0].Value.Schema().Description.Value)
+    desc := "madness"
+    assert.Equal(t, desc, sch.AllOf.Value[0].Value.Schema().Description.Value)
 }
 
 func Test_Schema_Polymorphism_RefMadnessBork(t *testing.T) {
-	yml := `components:
+    yml := `components:
   schemas:
     Something:
       $ref: '#/components/schemas/Else'
     Else:
       $ref: #borko`
 
-	var iNode yaml.Node
-	mErr := yaml.Unmarshal([]byte(yml), &iNode)
-	assert.NoError(t, mErr)
-	idx := index.NewSpecIndex(&iNode)
+    var iNode yaml.Node
+    mErr := yaml.Unmarshal([]byte(yml), &iNode)
+    assert.NoError(t, mErr)
+    idx := index.NewSpecIndex(&iNode)
 
-	yml = `type: object
+    yml = `type: object
 allOf:
   $ref: '#/components/schemas/Something'`
 
-	var sch Schema
-	var idxNode yaml.Node
-	_ = yaml.Unmarshal([]byte(yml), &idxNode)
+    var sch Schema
+    var idxNode yaml.Node
+    _ = yaml.Unmarshal([]byte(yml), &idxNode)
 
-	err := low.BuildModel(&idxNode, &sch)
-	assert.NoError(t, err)
+    err := low.BuildModel(&idxNode, &sch)
+    assert.NoError(t, err)
 
-	err = sch.Build(idxNode.Content[0], idx)
-	assert.Error(t, err)
+    err = sch.Build(idxNode.Content[0], idx)
+    assert.Error(t, err)
 }
 
 func Test_Schema_Polymorphism_RefMadnessIllegal(t *testing.T) {
-	// this does not work, but it won't error out.
+    // this does not work, but it won't error out.
 
-	yml := `components:
+    yml := `components:
   schemas:
     Something:
       $ref: '#/components/schemas/Else'
     Else:
       description: hey!`
 
-	var iNode yaml.Node
-	mErr := yaml.Unmarshal([]byte(yml), &iNode)
-	assert.NoError(t, mErr)
-	idx := index.NewSpecIndex(&iNode)
+    var iNode yaml.Node
+    mErr := yaml.Unmarshal([]byte(yml), &iNode)
+    assert.NoError(t, mErr)
+    idx := index.NewSpecIndex(&iNode)
 
-	yml = `$ref: '#/components/schemas/Something'`
+    yml = `$ref: '#/components/schemas/Something'`
 
-	var sch Schema
-	var idxNode yaml.Node
-	_ = yaml.Unmarshal([]byte(yml), &idxNode)
+    var sch Schema
+    var idxNode yaml.Node
+    _ = yaml.Unmarshal([]byte(yml), &idxNode)
 
-	err := low.BuildModel(&idxNode, &sch)
-	assert.NoError(t, err)
+    err := low.BuildModel(&idxNode, &sch)
+    assert.NoError(t, err)
 
-	schErr := sch.Build(idxNode.Content[0], idx)
-	assert.NoError(t, schErr)
+    schErr := sch.Build(idxNode.Content[0], idx)
+    assert.NoError(t, schErr)
 }
 
 func Test_Schema_RefMadnessIllegal_Circular(t *testing.T) {
-	// this does not work, but it won't error out.
+    // this does not work, but it won't error out.
 
-	yml := `components:
+    yml := `components:
   schemas:
     Something:
       $ref: '#/components/schemas/Else'
     Else:
       $ref: '#/components/schemas/Something'`
 
-	var iNode yaml.Node
-	mErr := yaml.Unmarshal([]byte(yml), &iNode)
-	assert.NoError(t, mErr)
-	idx := index.NewSpecIndex(&iNode)
+    var iNode yaml.Node
+    mErr := yaml.Unmarshal([]byte(yml), &iNode)
+    assert.NoError(t, mErr)
+    idx := index.NewSpecIndex(&iNode)
 
-	yml = `$ref: '#/components/schemas/Something'`
+    yml = `$ref: '#/components/schemas/Something'`
 
-	var sch Schema
-	var idxNode yaml.Node
-	_ = yaml.Unmarshal([]byte(yml), &idxNode)
+    var sch Schema
+    var idxNode yaml.Node
+    _ = yaml.Unmarshal([]byte(yml), &idxNode)
 
-	resolve := resolver.NewResolver(idx)
-	errs := resolve.CheckForCircularReferences()
-	assert.Len(t, errs, 1)
+    resolve := resolver.NewResolver(idx)
+    errs := resolve.CheckForCircularReferences()
+    assert.Len(t, errs, 1)
 
-	err := low.BuildModel(&idxNode, &sch)
-	assert.NoError(t, err)
+    err := low.BuildModel(&idxNode, &sch)
+    assert.NoError(t, err)
 
-	schErr := sch.Build(idxNode.Content[0], idx)
-	assert.Error(t, schErr)
+    schErr := sch.Build(idxNode.Content[0], idx)
+    assert.Error(t, schErr)
 }
 
 func Test_Schema_RefMadnessIllegal_Nonexist(t *testing.T) {
-	// this does not work, but it won't error out.
+    // this does not work, but it won't error out.
 
-	yml := `components:
+    yml := `components:
   schemas:
     Something:
       $ref: '#/components/schemas/Else'
     Else:
       $ref: '#/components/schemas/Something'`
 
-	var iNode yaml.Node
-	mErr := yaml.Unmarshal([]byte(yml), &iNode)
-	assert.NoError(t, mErr)
-	idx := index.NewSpecIndex(&iNode)
+    var iNode yaml.Node
+    mErr := yaml.Unmarshal([]byte(yml), &iNode)
+    assert.NoError(t, mErr)
+    idx := index.NewSpecIndex(&iNode)
 
-	yml = `$ref: #BORKLE`
+    yml = `$ref: #BORKLE`
 
-	var sch Schema
-	var idxNode yaml.Node
-	_ = yaml.Unmarshal([]byte(yml), &idxNode)
+    var sch Schema
+    var idxNode yaml.Node
+    _ = yaml.Unmarshal([]byte(yml), &idxNode)
 
-	resolve := resolver.NewResolver(idx)
-	errs := resolve.CheckForCircularReferences()
-	assert.Len(t, errs, 1)
+    resolve := resolver.NewResolver(idx)
+    errs := resolve.CheckForCircularReferences()
+    assert.Len(t, errs, 1)
 
-	err := low.BuildModel(&idxNode, &sch)
-	assert.NoError(t, err)
+    err := low.BuildModel(&idxNode, &sch)
+    assert.NoError(t, err)
 
-	schErr := sch.Build(idxNode.Content[0], idx)
-	assert.Error(t, schErr)
+    schErr := sch.Build(idxNode.Content[0], idx)
+    assert.Error(t, schErr)
 }
 
 func TestExtractSchema(t *testing.T) {
-	yml := `components:
+    yml := `components:
   schemas:
     Something:
       description: this is something
       type: string`
 
-	var iNode yaml.Node
-	mErr := yaml.Unmarshal([]byte(yml), &iNode)
-	assert.NoError(t, mErr)
-	idx := index.NewSpecIndex(&iNode)
+    var iNode yaml.Node
+    mErr := yaml.Unmarshal([]byte(yml), &iNode)
+    assert.NoError(t, mErr)
+    idx := index.NewSpecIndex(&iNode)
 
-	yml = `schema: 
+    yml = `schema: 
   type: object
   properties:
     aValue:
       $ref: '#/components/schemas/Something'`
 
-	var idxNode yaml.Node
-	_ = yaml.Unmarshal([]byte(yml), &idxNode)
+    var idxNode yaml.Node
+    _ = yaml.Unmarshal([]byte(yml), &idxNode)
 
-	res, err := ExtractSchema(idxNode.Content[0], idx)
-	assert.NoError(t, err)
-	assert.NotNil(t, res.Value)
-	aValue := res.Value.Schema().FindProperty("aValue")
-	assert.Equal(t, "this is something", aValue.Value.Schema().Description.Value)
+    res, err := ExtractSchema(idxNode.Content[0], idx)
+    assert.NoError(t, err)
+    assert.NotNil(t, res.Value)
+    aValue := res.Value.Schema().FindProperty("aValue")
+    assert.Equal(t, "this is something", aValue.Value.Schema().Description.Value)
 }
 
 func TestExtractSchema_DefaultPrimitive(t *testing.T) {
-	yml := `
+    yml := `
 schema: 
   type: object
   default: 5`
 
-	var idxNode yaml.Node
-	_ = yaml.Unmarshal([]byte(yml), &idxNode)
+    var idxNode yaml.Node
+    _ = yaml.Unmarshal([]byte(yml), &idxNode)
 
-	res, err := ExtractSchema(idxNode.Content[0], nil)
-	assert.NoError(t, err)
-	assert.NotNil(t, res.Value)
-	sch := res.Value.Schema()
-	assert.Equal(t, 5, sch.Default.Value)
+    res, err := ExtractSchema(idxNode.Content[0], nil)
+    assert.NoError(t, err)
+    assert.NotNil(t, res.Value)
+    sch := res.Value.Schema()
+    assert.Equal(t, 5, sch.Default.Value)
 }
 
 func TestExtractSchema_Ref(t *testing.T) {
-	yml := `components:
+    yml := `components:
   schemas:
     Something:
       description: this is something
       type: string`
 
-	var iNode yaml.Node
-	mErr := yaml.Unmarshal([]byte(yml), &iNode)
-	assert.NoError(t, mErr)
-	idx := index.NewSpecIndex(&iNode)
+    var iNode yaml.Node
+    mErr := yaml.Unmarshal([]byte(yml), &iNode)
+    assert.NoError(t, mErr)
+    idx := index.NewSpecIndex(&iNode)
 
-	yml = `schema: 
+    yml = `schema: 
   $ref: '#/components/schemas/Something'`
 
-	var idxNode yaml.Node
-	_ = yaml.Unmarshal([]byte(yml), &idxNode)
+    var idxNode yaml.Node
+    _ = yaml.Unmarshal([]byte(yml), &idxNode)
 
-	res, err := ExtractSchema(idxNode.Content[0], idx)
-	assert.NoError(t, err)
-	assert.NotNil(t, res.Value)
-	assert.Equal(t, "this is something", res.Value.Schema().Description.Value)
+    res, err := ExtractSchema(idxNode.Content[0], idx)
+    assert.NoError(t, err)
+    assert.NotNil(t, res.Value)
+    assert.Equal(t, "this is something", res.Value.Schema().Description.Value)
 }
 
 func TestExtractSchema_Ref_Fail(t *testing.T) {
-	yml := `components:
+    yml := `components:
   schemas:
     Something:
       description: this is something
       type: string`
 
-	var iNode yaml.Node
-	mErr := yaml.Unmarshal([]byte(yml), &iNode)
-	assert.NoError(t, mErr)
-	idx := index.NewSpecIndex(&iNode)
+    var iNode yaml.Node
+    mErr := yaml.Unmarshal([]byte(yml), &iNode)
+    assert.NoError(t, mErr)
+    idx := index.NewSpecIndex(&iNode)
 
-	yml = `schema: 
+    yml = `schema: 
   $ref: '#/components/schemas/Missing'`
 
-	var idxNode yaml.Node
-	_ = yaml.Unmarshal([]byte(yml), &idxNode)
+    var idxNode yaml.Node
+    _ = yaml.Unmarshal([]byte(yml), &idxNode)
 
-	_, err := ExtractSchema(idxNode.Content[0], idx)
-	assert.Error(t, err)
+    _, err := ExtractSchema(idxNode.Content[0], idx)
+    assert.Error(t, err)
 }
 
 func TestExtractSchema_CheckChildPropCircular(t *testing.T) {
-	yml := `components:
+    yml := `components:
   schemas:
     Something:
       properties:
@@ -1048,163 +1049,163 @@ func TestExtractSchema_CheckChildPropCircular(t *testing.T) {
         - something
 `
 
-	var iNode yaml.Node
-	mErr := yaml.Unmarshal([]byte(yml), &iNode)
-	assert.NoError(t, mErr)
-	idx := index.NewSpecIndex(&iNode)
+    var iNode yaml.Node
+    mErr := yaml.Unmarshal([]byte(yml), &iNode)
+    assert.NoError(t, mErr)
+    idx := index.NewSpecIndex(&iNode)
 
-	yml = `$ref: '#/components/schemas/Something'`
+    yml = `$ref: '#/components/schemas/Something'`
 
-	resolve := resolver.NewResolver(idx)
-	errs := resolve.CheckForCircularReferences()
-	assert.Len(t, errs, 1)
+    resolve := resolver.NewResolver(idx)
+    errs := resolve.CheckForCircularReferences()
+    assert.Len(t, errs, 1)
 
-	var idxNode yaml.Node
-	_ = yaml.Unmarshal([]byte(yml), &idxNode)
+    var idxNode yaml.Node
+    _ = yaml.Unmarshal([]byte(yml), &idxNode)
 
-	res, err := ExtractSchema(idxNode.Content[0], idx)
-	assert.NoError(t, err)
-	assert.NotNil(t, res.Value)
+    res, err := ExtractSchema(idxNode.Content[0], idx)
+    assert.NoError(t, err)
+    assert.NotNil(t, res.Value)
 
-	props := res.Value.Schema().FindProperty("nothing")
-	assert.NotNil(t, props)
+    props := res.Value.Schema().FindProperty("nothing")
+    assert.NotNil(t, props)
 }
 
 func TestExtractSchema_RefRoot(t *testing.T) {
-	yml := `components:
+    yml := `components:
   schemas:
     Something:
       description: this is something
       type: string`
 
-	var iNode yaml.Node
-	mErr := yaml.Unmarshal([]byte(yml), &iNode)
-	assert.NoError(t, mErr)
-	idx := index.NewSpecIndex(&iNode)
+    var iNode yaml.Node
+    mErr := yaml.Unmarshal([]byte(yml), &iNode)
+    assert.NoError(t, mErr)
+    idx := index.NewSpecIndex(&iNode)
 
-	yml = `$ref: '#/components/schemas/Something'`
+    yml = `$ref: '#/components/schemas/Something'`
 
-	var idxNode yaml.Node
-	_ = yaml.Unmarshal([]byte(yml), &idxNode)
+    var idxNode yaml.Node
+    _ = yaml.Unmarshal([]byte(yml), &idxNode)
 
-	res, err := ExtractSchema(idxNode.Content[0], idx)
-	assert.NoError(t, err)
-	assert.NotNil(t, res.Value)
-	assert.Equal(t, "this is something", res.Value.Schema().Description.Value)
+    res, err := ExtractSchema(idxNode.Content[0], idx)
+    assert.NoError(t, err)
+    assert.NotNil(t, res.Value)
+    assert.Equal(t, "this is something", res.Value.Schema().Description.Value)
 }
 
 func TestExtractSchema_RefRoot_Fail(t *testing.T) {
-	yml := `components:
+    yml := `components:
   schemas:
     Something:
       description: this is something
       type: string`
 
-	var iNode yaml.Node
-	mErr := yaml.Unmarshal([]byte(yml), &iNode)
-	assert.NoError(t, mErr)
-	idx := index.NewSpecIndex(&iNode)
+    var iNode yaml.Node
+    mErr := yaml.Unmarshal([]byte(yml), &iNode)
+    assert.NoError(t, mErr)
+    idx := index.NewSpecIndex(&iNode)
 
-	yml = `$ref: '#/components/schemas/Missing'`
+    yml = `$ref: '#/components/schemas/Missing'`
 
-	var idxNode yaml.Node
-	_ = yaml.Unmarshal([]byte(yml), &idxNode)
+    var idxNode yaml.Node
+    _ = yaml.Unmarshal([]byte(yml), &idxNode)
 
-	_, err := ExtractSchema(idxNode.Content[0], idx)
-	assert.Error(t, err)
+    _, err := ExtractSchema(idxNode.Content[0], idx)
+    assert.Error(t, err)
 }
 
 func TestExtractSchema_RefRoot_Child_Fail(t *testing.T) {
-	yml := `components:
+    yml := `components:
   schemas:
     Something:
       $ref: #bork`
 
-	var iNode yaml.Node
-	mErr := yaml.Unmarshal([]byte(yml), &iNode)
-	assert.NoError(t, mErr)
-	idx := index.NewSpecIndex(&iNode)
+    var iNode yaml.Node
+    mErr := yaml.Unmarshal([]byte(yml), &iNode)
+    assert.NoError(t, mErr)
+    idx := index.NewSpecIndex(&iNode)
 
-	yml = `$ref: '#/components/schemas/Something'`
+    yml = `$ref: '#/components/schemas/Something'`
 
-	var idxNode yaml.Node
-	_ = yaml.Unmarshal([]byte(yml), &idxNode)
+    var idxNode yaml.Node
+    _ = yaml.Unmarshal([]byte(yml), &idxNode)
 
-	_, err := ExtractSchema(idxNode.Content[0], idx)
-	assert.Error(t, err)
+    _, err := ExtractSchema(idxNode.Content[0], idx)
+    assert.Error(t, err)
 }
 
 func TestExtractSchema_AdditionalPropertiesAsSchema(t *testing.T) {
-	yml := `components:
+    yml := `components:
   schemas:
     Something:
       additionalProperties:
         type: string`
 
-	var iNode yaml.Node
-	mErr := yaml.Unmarshal([]byte(yml), &iNode)
-	assert.NoError(t, mErr)
-	idx := index.NewSpecIndex(&iNode)
+    var iNode yaml.Node
+    mErr := yaml.Unmarshal([]byte(yml), &iNode)
+    assert.NoError(t, mErr)
+    idx := index.NewSpecIndex(&iNode)
 
-	yml = `$ref: '#/components/schemas/Something'`
+    yml = `$ref: '#/components/schemas/Something'`
 
-	var idxNode yaml.Node
-	_ = yaml.Unmarshal([]byte(yml), &idxNode)
+    var idxNode yaml.Node
+    _ = yaml.Unmarshal([]byte(yml), &idxNode)
 
-	res, err := ExtractSchema(idxNode.Content[0], idx)
+    res, err := ExtractSchema(idxNode.Content[0], idx)
 
-	assert.NotNil(t, res.Value.Schema().AdditionalProperties.Value.(*SchemaProxy).Schema())
-	assert.Nil(t, err)
+    assert.NotNil(t, res.Value.Schema().AdditionalProperties.Value.(*SchemaProxy).Schema())
+    assert.Nil(t, err)
 
 }
 
 func TestExtractSchema_AdditionalPropertiesAsSchemaSlice(t *testing.T) {
-	yml := `components:
+    yml := `components:
   schemas:
     Something:
       additionalProperties:
         - nice: rice`
 
-	var iNode yaml.Node
-	mErr := yaml.Unmarshal([]byte(yml), &iNode)
-	assert.NoError(t, mErr)
-	idx := index.NewSpecIndex(&iNode)
+    var iNode yaml.Node
+    mErr := yaml.Unmarshal([]byte(yml), &iNode)
+    assert.NoError(t, mErr)
+    idx := index.NewSpecIndex(&iNode)
 
-	yml = `$ref: '#/components/schemas/Something'`
+    yml = `$ref: '#/components/schemas/Something'`
 
-	var idxNode yaml.Node
-	_ = yaml.Unmarshal([]byte(yml), &idxNode)
+    var idxNode yaml.Node
+    _ = yaml.Unmarshal([]byte(yml), &idxNode)
 
-	res, err := ExtractSchema(idxNode.Content[0], idx)
+    res, err := ExtractSchema(idxNode.Content[0], idx)
 
-	assert.NotNil(t, res.Value.Schema().AdditionalProperties.Value.([]low.ValueReference[interface{}]))
-	assert.Nil(t, err)
+    assert.NotNil(t, res.Value.Schema().AdditionalProperties.Value.([]low.ValueReference[interface{}]))
+    assert.Nil(t, err)
 
 }
 
 func TestExtractSchema_DoNothing(t *testing.T) {
-	yml := `components:
+    yml := `components:
   schemas:
     Something:
       $ref: #bork`
 
-	var iNode yaml.Node
-	mErr := yaml.Unmarshal([]byte(yml), &iNode)
-	assert.NoError(t, mErr)
-	idx := index.NewSpecIndex(&iNode)
+    var iNode yaml.Node
+    mErr := yaml.Unmarshal([]byte(yml), &iNode)
+    assert.NoError(t, mErr)
+    idx := index.NewSpecIndex(&iNode)
 
-	yml = `please: do nothing.`
+    yml = `please: do nothing.`
 
-	var idxNode yaml.Node
-	_ = yaml.Unmarshal([]byte(yml), &idxNode)
+    var idxNode yaml.Node
+    _ = yaml.Unmarshal([]byte(yml), &idxNode)
 
-	res, err := ExtractSchema(idxNode.Content[0], idx)
-	assert.Nil(t, res)
-	assert.Nil(t, err)
+    res, err := ExtractSchema(idxNode.Content[0], idx)
+    assert.Nil(t, res)
+    assert.Nil(t, err)
 }
 
 func TestExtractSchema_AdditionalProperties_Ref(t *testing.T) {
-	yml := `components:
+    yml := `components:
   schemas:
     Nothing:
       type: int
@@ -1213,26 +1214,26 @@ func TestExtractSchema_AdditionalProperties_Ref(t *testing.T) {
         cake:
           $ref: '#/components/schemas/Nothing'`
 
-	var iNode yaml.Node
-	mErr := yaml.Unmarshal([]byte(yml), &iNode)
-	assert.NoError(t, mErr)
-	idx := index.NewSpecIndex(&iNode)
+    var iNode yaml.Node
+    mErr := yaml.Unmarshal([]byte(yml), &iNode)
+    assert.NoError(t, mErr)
+    idx := index.NewSpecIndex(&iNode)
 
-	yml = `schema:
+    yml = `schema:
   type: int
   additionalProperties:
     $ref: '#/components/schemas/Something'`
 
-	var idxNode yaml.Node
-	_ = yaml.Unmarshal([]byte(yml), &idxNode)
+    var idxNode yaml.Node
+    _ = yaml.Unmarshal([]byte(yml), &idxNode)
 
-	res, err := ExtractSchema(idxNode.Content[0], idx)
-	assert.NotNil(t, res.Value.Schema().AdditionalProperties.Value.(*SchemaProxy).Schema())
-	assert.Nil(t, err)
+    res, err := ExtractSchema(idxNode.Content[0], idx)
+    assert.NotNil(t, res.Value.Schema().AdditionalProperties.Value.(*SchemaProxy).Schema())
+    assert.Nil(t, err)
 }
 
 func TestExtractSchema_OneOfRef(t *testing.T) {
-	yml := `components:
+    yml := `components:
   schemas:
     Error:
       type: object
@@ -1329,25 +1330,25 @@ func TestExtractSchema_OneOfRef(t *testing.T) {
       oneOf:
         - $ref: '#/components/schemas/Drink'`
 
-	var iNode yaml.Node
-	mErr := yaml.Unmarshal([]byte(yml), &iNode)
-	assert.NoError(t, mErr)
-	idx := index.NewSpecIndex(&iNode)
+    var iNode yaml.Node
+    mErr := yaml.Unmarshal([]byte(yml), &iNode)
+    assert.NoError(t, mErr)
+    idx := index.NewSpecIndex(&iNode)
 
-	yml = `schema:
+    yml = `schema:
   $ref: '#/components/schemas/SomePayload'`
 
-	var idxNode yaml.Node
-	_ = yaml.Unmarshal([]byte(yml), &idxNode)
+    var idxNode yaml.Node
+    _ = yaml.Unmarshal([]byte(yml), &idxNode)
 
-	res, err := ExtractSchema(idxNode.Content[0], idx)
-	assert.NoError(t, err)
-	assert.Equal(t, "a frosty cold beverage can be coke or sprite",
-		res.Value.Schema().OneOf.Value[0].Value.Schema().Description.Value)
+    res, err := ExtractSchema(idxNode.Content[0], idx)
+    assert.NoError(t, err)
+    assert.Equal(t, "a frosty cold beverage can be coke or sprite",
+        res.Value.Schema().OneOf.Value[0].Value.Schema().Description.Value)
 }
 
 func TestSchema_Hash_Equal(t *testing.T) {
-	left := `schema:
+    left := `schema:
   $schema: https://athing.com
   multipleOf: 1
   maximum: 10
@@ -1388,7 +1389,7 @@ func TestSchema_Hash_Equal(t *testing.T) {
       title: a proxy property
       type: string`
 
-	right := `schema:
+    right := `schema:
   $schema: https://athing.com
   multipleOf: 1
   maximum: 10
@@ -1429,74 +1430,74 @@ func TestSchema_Hash_Equal(t *testing.T) {
       title: a proxy property
       type: string`
 
-	var lNode, rNode yaml.Node
-	_ = yaml.Unmarshal([]byte(left), &lNode)
-	_ = yaml.Unmarshal([]byte(right), &rNode)
+    var lNode, rNode yaml.Node
+    _ = yaml.Unmarshal([]byte(left), &lNode)
+    _ = yaml.Unmarshal([]byte(right), &rNode)
 
-	lDoc, _ := ExtractSchema(lNode.Content[0], nil)
-	rDoc, _ := ExtractSchema(rNode.Content[0], nil)
+    lDoc, _ := ExtractSchema(lNode.Content[0], nil)
+    rDoc, _ := ExtractSchema(rNode.Content[0], nil)
 
-	assert.NotNil(t, lDoc)
-	assert.NotNil(t, rDoc)
+    assert.NotNil(t, lDoc)
+    assert.NotNil(t, rDoc)
 
-	lHash := lDoc.Value.Schema().Hash()
-	rHash := rDoc.Value.Schema().Hash()
+    lHash := lDoc.Value.Schema().Hash()
+    rHash := rDoc.Value.Schema().Hash()
 
-	assert.Equal(t, lHash, rHash)
+    assert.Equal(t, lHash, rHash)
 }
 
 func TestSchema_Hash_AdditionalPropsSlice(t *testing.T) {
-	left := `schema:
+    left := `schema:
   additionalProperties:
     - type: string`
 
-	right := `schema:
+    right := `schema:
   additionalProperties:
     - type: string`
 
-	var lNode, rNode yaml.Node
-	_ = yaml.Unmarshal([]byte(left), &lNode)
-	_ = yaml.Unmarshal([]byte(right), &rNode)
+    var lNode, rNode yaml.Node
+    _ = yaml.Unmarshal([]byte(left), &lNode)
+    _ = yaml.Unmarshal([]byte(right), &rNode)
 
-	lDoc, _ := ExtractSchema(lNode.Content[0], nil)
-	rDoc, _ := ExtractSchema(rNode.Content[0], nil)
+    lDoc, _ := ExtractSchema(lNode.Content[0], nil)
+    rDoc, _ := ExtractSchema(rNode.Content[0], nil)
 
-	assert.NotNil(t, lDoc)
-	assert.NotNil(t, rDoc)
+    assert.NotNil(t, lDoc)
+    assert.NotNil(t, rDoc)
 
-	lHash := lDoc.Value.Schema().Hash()
-	rHash := rDoc.Value.Schema().Hash()
+    lHash := lDoc.Value.Schema().Hash()
+    rHash := rDoc.Value.Schema().Hash()
 
-	assert.Equal(t, lHash, rHash)
+    assert.Equal(t, lHash, rHash)
 }
 
 func TestSchema_Hash_AdditionalPropsSliceNoMap(t *testing.T) {
-	left := `schema:
+    left := `schema:
   additionalProperties:
     - hello`
 
-	right := `schema:
+    right := `schema:
   additionalProperties:
     - hello`
 
-	var lNode, rNode yaml.Node
-	_ = yaml.Unmarshal([]byte(left), &lNode)
-	_ = yaml.Unmarshal([]byte(right), &rNode)
+    var lNode, rNode yaml.Node
+    _ = yaml.Unmarshal([]byte(left), &lNode)
+    _ = yaml.Unmarshal([]byte(right), &rNode)
 
-	lDoc, _ := ExtractSchema(lNode.Content[0], nil)
-	rDoc, _ := ExtractSchema(rNode.Content[0], nil)
+    lDoc, _ := ExtractSchema(lNode.Content[0], nil)
+    rDoc, _ := ExtractSchema(rNode.Content[0], nil)
 
-	assert.NotNil(t, lDoc)
-	assert.NotNil(t, rDoc)
+    assert.NotNil(t, lDoc)
+    assert.NotNil(t, rDoc)
 
-	lHash := lDoc.Value.Schema().Hash()
-	rHash := rDoc.Value.Schema().Hash()
+    lHash := lDoc.Value.Schema().Hash()
+    rHash := rDoc.Value.Schema().Hash()
 
-	assert.Equal(t, lHash, rHash)
+    assert.Equal(t, lHash, rHash)
 }
 
 func TestSchema_Hash_NotEqual(t *testing.T) {
-	left := `schema:
+    left := `schema:
   title: an OK message - but different
   items: true
   minContains: 3
@@ -1506,7 +1507,7 @@ func TestSchema_Hash_NotEqual(t *testing.T) {
       title: a proxy property
       type: string`
 
-	right := `schema:
+    right := `schema:
   title: an OK message
   items: false
   minContains: 2
@@ -1516,18 +1517,18 @@ func TestSchema_Hash_NotEqual(t *testing.T) {
       title: a proxy property
       type: string`
 
-	var lNode, rNode yaml.Node
-	_ = yaml.Unmarshal([]byte(left), &lNode)
-	_ = yaml.Unmarshal([]byte(right), &rNode)
+    var lNode, rNode yaml.Node
+    _ = yaml.Unmarshal([]byte(left), &lNode)
+    _ = yaml.Unmarshal([]byte(right), &rNode)
 
-	lDoc, _ := ExtractSchema(lNode.Content[0], nil)
-	rDoc, _ := ExtractSchema(rNode.Content[0], nil)
+    lDoc, _ := ExtractSchema(lNode.Content[0], nil)
+    rDoc, _ := ExtractSchema(rNode.Content[0], nil)
 
-	assert.False(t, low.AreEqual(lDoc.Value.Schema(), rDoc.Value.Schema()))
+    assert.False(t, low.AreEqual(lDoc.Value.Schema(), rDoc.Value.Schema()))
 }
 
 func TestSchema_Hash_EqualJumbled(t *testing.T) {
-	left := `schema:
+    left := `schema:
   title: an OK message
   description: a nice thing.
   properties:
@@ -1540,7 +1541,7 @@ func TestSchema_Hash_EqualJumbled(t *testing.T) {
       title: a proxy property
       type: string`
 
-	right := `schema:
+    right := `schema:
   description: a nice thing.
   properties:
     propA:
@@ -1553,17 +1554,17 @@ func TestSchema_Hash_EqualJumbled(t *testing.T) {
       type: int
   title: an OK message`
 
-	var lNode, rNode yaml.Node
-	_ = yaml.Unmarshal([]byte(left), &lNode)
-	_ = yaml.Unmarshal([]byte(right), &rNode)
+    var lNode, rNode yaml.Node
+    _ = yaml.Unmarshal([]byte(left), &lNode)
+    _ = yaml.Unmarshal([]byte(right), &rNode)
 
-	lDoc, _ := ExtractSchema(lNode.Content[0], nil)
-	rDoc, _ := ExtractSchema(rNode.Content[0], nil)
-	assert.True(t, low.AreEqual(lDoc.Value.Schema(), rDoc.Value.Schema()))
+    lDoc, _ := ExtractSchema(lNode.Content[0], nil)
+    rDoc, _ := ExtractSchema(rNode.Content[0], nil)
+    assert.True(t, low.AreEqual(lDoc.Value.Schema(), rDoc.Value.Schema()))
 }
 
 func test_get_allOf_schema_blob() string {
-	return `type: object
+    return `type: object
 description: allOf sequence check
 allOf:
   - type: object

--- a/datamodel/low/model_builder.go
+++ b/datamodel/low/model_builder.go
@@ -4,14 +4,14 @@
 package low
 
 import (
-	"fmt"
-	"reflect"
-	"strconv"
-	"strings"
-	"sync"
+    "fmt"
+    "reflect"
+    "strconv"
+    "strings"
+    "sync"
 
-	"github.com/pb33f/libopenapi/utils"
-	"gopkg.in/yaml.v3"
+    "github.com/pb33f/libopenapi/utils"
+    "gopkg.in/yaml.v3"
 )
 
 // BuildModel accepts a yaml.Node pointer and a model, which can be any struct. Using reflection, the model is
@@ -20,452 +20,468 @@ import (
 //
 // BuildModel is non-recursive and will only build out a single layer of the node tree.
 func BuildModel(node *yaml.Node, model interface{}) error {
-	if node == nil {
-		return nil
-	}
+    if node == nil {
+        return nil
+    }
 
-	if reflect.ValueOf(model).Type().Kind() != reflect.Pointer {
-		return fmt.Errorf("cannot build model on non-pointer: %v", reflect.ValueOf(model).Type().Kind())
-	}
-	v := reflect.ValueOf(model).Elem()
-	num := v.NumField()
-	for i := 0; i < num; i++ {
+    if reflect.ValueOf(model).Type().Kind() != reflect.Pointer {
+        return fmt.Errorf("cannot build model on non-pointer: %v", reflect.ValueOf(model).Type().Kind())
+    }
+    v := reflect.ValueOf(model).Elem()
+    num := v.NumField()
+    for i := 0; i < num; i++ {
 
-		fName := v.Type().Field(i).Name
+        fName := v.Type().Field(i).Name
 
-		if fName == "Extensions" {
-			continue // internal construct
-		}
+        if fName == "Extensions" {
+            continue // internal construct
+        }
 
-		if fName == "PathItems" {
-			continue // internal construct
-		}
+        if fName == "PathItems" {
+            continue // internal construct
+        }
 
-		kn, vn := utils.FindKeyNodeTop(strings.ToLower(fName), node.Content)
-		if vn == nil {
-			// no point in going on.
-			continue
-		}
+        kn, vn := utils.FindKeyNodeTop(strings.ToLower(fName), node.Content)
+        if vn == nil {
+            // no point in going on.
+            continue
+        }
 
-		field := v.FieldByName(fName)
-		kind := field.Kind()
-		switch kind {
-		case reflect.Struct, reflect.Slice, reflect.Map, reflect.Pointer:
-			err := SetField(&field, vn, kn)
-			if err != nil {
-				return err
-			}
-		default:
-			return fmt.Errorf("unable to parse unsupported type: %v", kind)
-		}
+        field := v.FieldByName(fName)
+        kind := field.Kind()
+        switch kind {
+        case reflect.Struct, reflect.Slice, reflect.Map, reflect.Pointer:
+            err := SetField(&field, vn, kn)
+            if err != nil {
+                return err
+            }
+        default:
+            return fmt.Errorf("unable to parse unsupported type: %v", kind)
+        }
 
-	}
+    }
 
-	return nil
+    return nil
 }
 
 // SetField accepts a field reflection value, a yaml.Node valueNode and a yaml.Node keyNode. Using reflection, the
 // function will attempt to set the value of the field based on the key and value nodes. This method is only useful
 // for low-level models, it has no value to high-level ones.
 func SetField(field *reflect.Value, valueNode *yaml.Node, keyNode *yaml.Node) error {
-	if valueNode == nil {
-		return nil
-	}
+    if valueNode == nil {
+        return nil
+    }
 
-	switch field.Type() {
+    switch field.Type() {
 
-	case reflect.TypeOf(map[string]NodeReference[any]{}):
-		if utils.IsNodeMap(valueNode) {
-			if field.CanSet() {
-				items := make(map[string]NodeReference[any])
-				var currentLabel string
-				for i, sliceItem := range valueNode.Content {
-					if i%2 == 0 {
-						currentLabel = sliceItem.Value
-						continue
-					}
-					var decoded map[string]interface{}
-					// I cannot think of a way to make this error out by this point.
-					_ = sliceItem.Decode(&decoded)
-					items[currentLabel] = NodeReference[any]{
-						Value:     decoded,
-						ValueNode: sliceItem,
-						KeyNode:   valueNode,
-					}
-				}
-				field.Set(reflect.ValueOf(items))
-			}
-		}
+    case reflect.TypeOf(map[string]NodeReference[any]{}):
+        if utils.IsNodeMap(valueNode) {
+            if field.CanSet() {
+                items := make(map[string]NodeReference[any])
+                var currentLabel string
+                for i, sliceItem := range valueNode.Content {
+                    if i%2 == 0 {
+                        currentLabel = sliceItem.Value
+                        continue
+                    }
+                    var decoded map[string]interface{}
+                    // I cannot think of a way to make this error out by this point.
+                    _ = sliceItem.Decode(&decoded)
+                    items[currentLabel] = NodeReference[any]{
+                        Value:     decoded,
+                        ValueNode: sliceItem,
+                        KeyNode:   valueNode,
+                    }
+                }
+                field.Set(reflect.ValueOf(items))
+            }
+        }
 
-	case reflect.TypeOf(map[string]NodeReference[string]{}):
+    case reflect.TypeOf(map[string]NodeReference[string]{}):
 
-		if utils.IsNodeMap(valueNode) {
-			if field.CanSet() {
-				items := make(map[string]NodeReference[string])
-				var currentLabel string
-				for i, sliceItem := range valueNode.Content {
-					if i%2 == 0 {
-						currentLabel = sliceItem.Value
-						continue
-					}
-					items[currentLabel] = NodeReference[string]{
-						Value:     fmt.Sprintf("%v", sliceItem.Value),
-						ValueNode: sliceItem,
-						KeyNode:   valueNode,
-					}
-				}
-				field.Set(reflect.ValueOf(items))
-			}
-		}
+        if utils.IsNodeMap(valueNode) {
+            if field.CanSet() {
+                items := make(map[string]NodeReference[string])
+                var currentLabel string
+                for i, sliceItem := range valueNode.Content {
+                    if i%2 == 0 {
+                        currentLabel = sliceItem.Value
+                        continue
+                    }
+                    items[currentLabel] = NodeReference[string]{
+                        Value:     fmt.Sprintf("%v", sliceItem.Value),
+                        ValueNode: sliceItem,
+                        KeyNode:   valueNode,
+                    }
+                }
+                field.Set(reflect.ValueOf(items))
+            }
+        }
 
-	case reflect.TypeOf(NodeReference[any]{}):
+    case reflect.TypeOf(NodeReference[any]{}):
 
-		var decoded interface{}
-		_ = valueNode.Decode(&decoded)
-		if field.CanSet() {
-			or := NodeReference[any]{Value: decoded, ValueNode: valueNode, KeyNode: keyNode}
-			field.Set(reflect.ValueOf(or))
-		}
+        var decoded interface{}
+        _ = valueNode.Decode(&decoded)
+        if field.CanSet() {
+            or := NodeReference[any]{Value: decoded, ValueNode: valueNode, KeyNode: keyNode}
+            field.Set(reflect.ValueOf(or))
+        }
 
-	case reflect.TypeOf([]NodeReference[any]{}):
+    case reflect.TypeOf([]NodeReference[any]{}):
 
-		if utils.IsNodeArray(valueNode) {
-			if field.CanSet() {
-				var items []NodeReference[any]
-				for _, sliceItem := range valueNode.Content {
-					var decoded map[string]interface{}
-					err := sliceItem.Decode(&decoded)
-					if err != nil {
-						return err
-					}
-					items = append(items, NodeReference[any]{
-						Value:     decoded,
-						ValueNode: sliceItem,
-						KeyNode:   valueNode,
-					})
-				}
-				field.Set(reflect.ValueOf(items))
-			}
-		}
+        if utils.IsNodeArray(valueNode) {
+            if field.CanSet() {
+                var items []NodeReference[any]
+                for _, sliceItem := range valueNode.Content {
+                    var decoded map[string]interface{}
+                    err := sliceItem.Decode(&decoded)
+                    if err != nil {
+                        return err
+                    }
+                    items = append(items, NodeReference[any]{
+                        Value:     decoded,
+                        ValueNode: sliceItem,
+                        KeyNode:   valueNode,
+                    })
+                }
+                field.Set(reflect.ValueOf(items))
+            }
+        }
 
-	case reflect.TypeOf(NodeReference[string]{}):
+    case reflect.TypeOf(NodeReference[string]{}):
 
-		if field.CanSet() {
-			nr := NodeReference[string]{
-				Value:     fmt.Sprintf("%v", valueNode.Value),
-				ValueNode: valueNode,
-				KeyNode:   keyNode,
-			}
-			field.Set(reflect.ValueOf(nr))
-		}
+        if field.CanSet() {
+            nr := NodeReference[string]{
+                Value:     fmt.Sprintf("%v", valueNode.Value),
+                ValueNode: valueNode,
+                KeyNode:   keyNode,
+            }
+            field.Set(reflect.ValueOf(nr))
+        }
 
-	case reflect.TypeOf(ValueReference[string]{}):
+    case reflect.TypeOf(ValueReference[string]{}):
 
-		if field.CanSet() {
-			nr := ValueReference[string]{
-				Value:     fmt.Sprintf("%v", valueNode.Value),
-				ValueNode: valueNode,
-			}
-			field.Set(reflect.ValueOf(nr))
-		}
+        if field.CanSet() {
+            nr := ValueReference[string]{
+                Value:     fmt.Sprintf("%v", valueNode.Value),
+                ValueNode: valueNode,
+            }
+            field.Set(reflect.ValueOf(nr))
+        }
 
-	case reflect.TypeOf(NodeReference[bool]{}):
+    case reflect.TypeOf(NodeReference[bool]{}):
 
-		if utils.IsNodeBoolValue(valueNode) {
-			if field.CanSet() {
-				bv, _ := strconv.ParseBool(valueNode.Value)
-				nr := NodeReference[bool]{
-					Value:     bv,
-					ValueNode: valueNode,
-					KeyNode:   keyNode,
-				}
-				field.Set(reflect.ValueOf(nr))
-			}
-		}
+        if utils.IsNodeBoolValue(valueNode) {
+            if field.CanSet() {
+                bv, _ := strconv.ParseBool(valueNode.Value)
+                nr := NodeReference[bool]{
+                    Value:     bv,
+                    ValueNode: valueNode,
+                    KeyNode:   keyNode,
+                }
+                field.Set(reflect.ValueOf(nr))
+            }
+        }
 
-	case reflect.TypeOf(NodeReference[int]{}):
+    case reflect.TypeOf(NodeReference[int]{}):
 
-		if utils.IsNodeIntValue(valueNode) {
-			if field.CanSet() {
-				fv, _ := strconv.Atoi(valueNode.Value)
-				nr := NodeReference[int]{
-					Value:     fv,
-					ValueNode: valueNode,
-					KeyNode:   keyNode,
-				}
-				field.Set(reflect.ValueOf(nr))
-			}
-		}
+        if utils.IsNodeIntValue(valueNode) {
+            if field.CanSet() {
+                fv, _ := strconv.Atoi(valueNode.Value)
+                nr := NodeReference[int]{
+                    Value:     fv,
+                    ValueNode: valueNode,
+                    KeyNode:   keyNode,
+                }
+                field.Set(reflect.ValueOf(nr))
+            }
+        }
 
-	case reflect.TypeOf(NodeReference[int64]{}):
+    case reflect.TypeOf(NodeReference[int64]{}):
 
-		if utils.IsNodeIntValue(valueNode) || utils.IsNodeFloatValue(valueNode) {
-			if field.CanSet() {
-				fv, _ := strconv.ParseInt(valueNode.Value, 10, 64)
-				nr := NodeReference[int64]{
-					Value:     fv,
-					ValueNode: valueNode,
-					KeyNode:   keyNode,
-				}
-				field.Set(reflect.ValueOf(nr))
-			}
-		}
+        if utils.IsNodeIntValue(valueNode) || utils.IsNodeFloatValue(valueNode) {
+            if field.CanSet() {
+                fv, _ := strconv.ParseInt(valueNode.Value, 10, 64)
+                nr := NodeReference[int64]{
+                    Value:     fv,
+                    ValueNode: valueNode,
+                    KeyNode:   keyNode,
+                }
+                field.Set(reflect.ValueOf(nr))
+            }
+        }
 
-	case reflect.TypeOf(NodeReference[float32]{}):
+    case reflect.TypeOf(NodeReference[float32]{}):
 
-		if utils.IsNodeFloatValue(valueNode) {
-			if field.CanSet() {
-				fv, _ := strconv.ParseFloat(valueNode.Value, 32)
-				nr := NodeReference[float32]{
-					Value:     float32(fv),
-					ValueNode: valueNode,
-					KeyNode:   keyNode,
-				}
-				field.Set(reflect.ValueOf(nr))
-			}
-		}
+        if utils.IsNodeFloatValue(valueNode) {
+            if field.CanSet() {
+                fv, _ := strconv.ParseFloat(valueNode.Value, 32)
+                nr := NodeReference[float32]{
+                    Value:     float32(fv),
+                    ValueNode: valueNode,
+                    KeyNode:   keyNode,
+                }
+                field.Set(reflect.ValueOf(nr))
+            }
+        }
 
-	case reflect.TypeOf(NodeReference[float64]{}):
+    case reflect.TypeOf(NodeReference[float64]{}):
 
-		if utils.IsNodeFloatValue(valueNode) {
-			if field.CanSet() {
-				fv, _ := strconv.ParseFloat(valueNode.Value, 64)
-				nr := NodeReference[float64]{
-					Value:     fv,
-					ValueNode: valueNode,
-					KeyNode:   keyNode,
-				}
-				field.Set(reflect.ValueOf(nr))
-			}
-		}
+        if utils.IsNodeFloatValue(valueNode) {
+            if field.CanSet() {
+                fv, _ := strconv.ParseFloat(valueNode.Value, 64)
+                nr := NodeReference[float64]{
+                    Value:     fv,
+                    ValueNode: valueNode,
+                    KeyNode:   keyNode,
+                }
+                field.Set(reflect.ValueOf(nr))
+            }
+        }
 
-	case reflect.TypeOf([]NodeReference[string]{}):
+    case reflect.TypeOf([]NodeReference[string]{}):
 
-		if utils.IsNodeArray(valueNode) {
-			if field.CanSet() {
-				var items []NodeReference[string]
-				for _, sliceItem := range valueNode.Content {
-					items = append(items, NodeReference[string]{
-						Value:     sliceItem.Value,
-						ValueNode: sliceItem,
-						KeyNode:   valueNode,
-					})
-				}
-				field.Set(reflect.ValueOf(items))
-			}
-		}
+        if utils.IsNodeArray(valueNode) {
+            if field.CanSet() {
+                var items []NodeReference[string]
+                for _, sliceItem := range valueNode.Content {
+                    items = append(items, NodeReference[string]{
+                        Value:     sliceItem.Value,
+                        ValueNode: sliceItem,
+                        KeyNode:   valueNode,
+                    })
+                }
+                field.Set(reflect.ValueOf(items))
+            }
+        }
 
-	case reflect.TypeOf([]NodeReference[float32]{}):
+    case reflect.TypeOf([]NodeReference[float32]{}):
 
-		if utils.IsNodeArray(valueNode) {
-			if field.CanSet() {
-				var items []NodeReference[float32]
-				for _, sliceItem := range valueNode.Content {
-					fv, _ := strconv.ParseFloat(sliceItem.Value, 32)
-					items = append(items, NodeReference[float32]{
-						Value:     float32(fv),
-						ValueNode: sliceItem,
-						KeyNode:   valueNode,
-					})
-				}
-				field.Set(reflect.ValueOf(items))
-			}
-		}
+        if utils.IsNodeArray(valueNode) {
+            if field.CanSet() {
+                var items []NodeReference[float32]
+                for _, sliceItem := range valueNode.Content {
+                    fv, _ := strconv.ParseFloat(sliceItem.Value, 32)
+                    items = append(items, NodeReference[float32]{
+                        Value:     float32(fv),
+                        ValueNode: sliceItem,
+                        KeyNode:   valueNode,
+                    })
+                }
+                field.Set(reflect.ValueOf(items))
+            }
+        }
 
-	case reflect.TypeOf([]NodeReference[float64]{}):
+    case reflect.TypeOf([]NodeReference[float64]{}):
 
-		if utils.IsNodeArray(valueNode) {
-			if field.CanSet() {
-				var items []NodeReference[float64]
-				for _, sliceItem := range valueNode.Content {
-					fv, _ := strconv.ParseFloat(sliceItem.Value, 64)
-					items = append(items, NodeReference[float64]{Value: fv, ValueNode: sliceItem})
-				}
-				field.Set(reflect.ValueOf(items))
-			}
-		}
+        if utils.IsNodeArray(valueNode) {
+            if field.CanSet() {
+                var items []NodeReference[float64]
+                for _, sliceItem := range valueNode.Content {
+                    fv, _ := strconv.ParseFloat(sliceItem.Value, 64)
+                    items = append(items, NodeReference[float64]{Value: fv, ValueNode: sliceItem})
+                }
+                field.Set(reflect.ValueOf(items))
+            }
+        }
 
-	case reflect.TypeOf([]NodeReference[int]{}):
+    case reflect.TypeOf([]NodeReference[int]{}):
 
-		if utils.IsNodeArray(valueNode) {
-			if field.CanSet() {
-				var items []NodeReference[int]
-				for _, sliceItem := range valueNode.Content {
-					iv, _ := strconv.Atoi(sliceItem.Value)
-					items = append(items, NodeReference[int]{
-						Value:     iv,
-						ValueNode: sliceItem,
-						KeyNode:   valueNode,
-					})
-				}
-				field.Set(reflect.ValueOf(items))
-			}
-		}
+        if utils.IsNodeArray(valueNode) {
+            if field.CanSet() {
+                var items []NodeReference[int]
+                for _, sliceItem := range valueNode.Content {
+                    iv, _ := strconv.Atoi(sliceItem.Value)
+                    items = append(items, NodeReference[int]{
+                        Value:     iv,
+                        ValueNode: sliceItem,
+                        KeyNode:   valueNode,
+                    })
+                }
+                field.Set(reflect.ValueOf(items))
+            }
+        }
 
-	case reflect.TypeOf([]NodeReference[int64]{}):
+    case reflect.TypeOf([]NodeReference[int64]{}):
 
-		if utils.IsNodeArray(valueNode) {
-			if field.CanSet() {
-				var items []NodeReference[int64]
-				for _, sliceItem := range valueNode.Content {
-					iv, _ := strconv.ParseInt(sliceItem.Value, 10, 64)
-					items = append(items, NodeReference[int64]{
-						Value:     iv,
-						ValueNode: sliceItem,
-						KeyNode:   valueNode,
-					})
-				}
-				field.Set(reflect.ValueOf(items))
-			}
-		}
+        if utils.IsNodeArray(valueNode) {
+            if field.CanSet() {
+                var items []NodeReference[int64]
+                for _, sliceItem := range valueNode.Content {
+                    iv, _ := strconv.ParseInt(sliceItem.Value, 10, 64)
+                    items = append(items, NodeReference[int64]{
+                        Value:     iv,
+                        ValueNode: sliceItem,
+                        KeyNode:   valueNode,
+                    })
+                }
+                field.Set(reflect.ValueOf(items))
+            }
+        }
 
-	case reflect.TypeOf([]NodeReference[bool]{}):
+    case reflect.TypeOf([]NodeReference[bool]{}):
 
-		if utils.IsNodeArray(valueNode) {
-			if field.CanSet() {
-				var items []NodeReference[bool]
-				for _, sliceItem := range valueNode.Content {
-					bv, _ := strconv.ParseBool(sliceItem.Value)
-					items = append(items, NodeReference[bool]{
-						Value:     bv,
-						ValueNode: sliceItem,
-						KeyNode:   valueNode,
-					})
-				}
-				field.Set(reflect.ValueOf(items))
-			}
-		}
+        if utils.IsNodeArray(valueNode) {
+            if field.CanSet() {
+                var items []NodeReference[bool]
+                for _, sliceItem := range valueNode.Content {
+                    bv, _ := strconv.ParseBool(sliceItem.Value)
+                    items = append(items, NodeReference[bool]{
+                        Value:     bv,
+                        ValueNode: sliceItem,
+                        KeyNode:   valueNode,
+                    })
+                }
+                field.Set(reflect.ValueOf(items))
+            }
+        }
 
-		// helper for unpacking string maps.
-	case reflect.TypeOf(map[KeyReference[string]]ValueReference[string]{}):
+        // helper for unpacking string maps.
+    case reflect.TypeOf(map[KeyReference[string]]ValueReference[string]{}):
 
-		if utils.IsNodeMap(valueNode) {
-			if field.CanSet() {
-				items := make(map[KeyReference[string]]ValueReference[string])
-				var cf *yaml.Node
-				for i, sliceItem := range valueNode.Content {
-					if i%2 == 0 {
-						cf = sliceItem
-						continue
-					}
-					items[KeyReference[string]{
-						Value:   cf.Value,
-						KeyNode: cf,
-					}] = ValueReference[string]{
-						Value:     sliceItem.Value,
-						ValueNode: sliceItem,
-					}
-				}
-				field.Set(reflect.ValueOf(items))
-			}
-		}
+        if utils.IsNodeMap(valueNode) {
+            if field.CanSet() {
+                items := make(map[KeyReference[string]]ValueReference[string])
+                var cf *yaml.Node
+                for i, sliceItem := range valueNode.Content {
+                    if i%2 == 0 {
+                        cf = sliceItem
+                        continue
+                    }
+                    items[KeyReference[string]{
+                        Value:   cf.Value,
+                        KeyNode: cf,
+                    }] = ValueReference[string]{
+                        Value:     sliceItem.Value,
+                        ValueNode: sliceItem,
+                    }
+                }
+                field.Set(reflect.ValueOf(items))
+            }
+        }
 
-	case reflect.TypeOf(KeyReference[map[KeyReference[string]]ValueReference[string]]{}):
+    case reflect.TypeOf(KeyReference[map[KeyReference[string]]ValueReference[string]]{}):
 
-		if utils.IsNodeMap(valueNode) {
-			if field.CanSet() {
-				items := make(map[KeyReference[string]]ValueReference[string])
-				var cf *yaml.Node
-				for i, sliceItem := range valueNode.Content {
-					if i%2 == 0 {
-						cf = sliceItem
-						continue
-					}
-					items[KeyReference[string]{
-						Value:   cf.Value,
-						KeyNode: cf,
-					}] = ValueReference[string]{
-						Value:     sliceItem.Value,
-						ValueNode: sliceItem,
-					}
-				}
-				ref := KeyReference[map[KeyReference[string]]ValueReference[string]]{
-					Value:   items,
-					KeyNode: keyNode,
-				}
-				field.Set(reflect.ValueOf(ref))
-			}
-		}
-	case reflect.TypeOf(NodeReference[map[KeyReference[string]]ValueReference[string]]{}):
-		if utils.IsNodeMap(valueNode) {
-			if field.CanSet() {
-				items := make(map[KeyReference[string]]ValueReference[string])
-				var cf *yaml.Node
-				for i, sliceItem := range valueNode.Content {
-					if i%2 == 0 {
-						cf = sliceItem
-						continue
-					}
-					items[KeyReference[string]{
-						Value:   cf.Value,
-						KeyNode: cf,
-					}] = ValueReference[string]{
-						Value:     sliceItem.Value,
-						ValueNode: sliceItem,
-					}
-				}
-				ref := NodeReference[map[KeyReference[string]]ValueReference[string]]{
-					Value:     items,
-					KeyNode:   keyNode,
-					ValueNode: valueNode,
-				}
-				field.Set(reflect.ValueOf(ref))
-			}
-		}
-	case reflect.TypeOf(NodeReference[[]ValueReference[string]]{}):
+        if utils.IsNodeMap(valueNode) {
+            if field.CanSet() {
+                items := make(map[KeyReference[string]]ValueReference[string])
+                var cf *yaml.Node
+                for i, sliceItem := range valueNode.Content {
+                    if i%2 == 0 {
+                        cf = sliceItem
+                        continue
+                    }
+                    items[KeyReference[string]{
+                        Value:   cf.Value,
+                        KeyNode: cf,
+                    }] = ValueReference[string]{
+                        Value:     sliceItem.Value,
+                        ValueNode: sliceItem,
+                    }
+                }
+                ref := KeyReference[map[KeyReference[string]]ValueReference[string]]{
+                    Value:   items,
+                    KeyNode: keyNode,
+                }
+                field.Set(reflect.ValueOf(ref))
+            }
+        }
+    case reflect.TypeOf(NodeReference[map[KeyReference[string]]ValueReference[string]]{}):
+        if utils.IsNodeMap(valueNode) {
+            if field.CanSet() {
+                items := make(map[KeyReference[string]]ValueReference[string])
+                var cf *yaml.Node
+                for i, sliceItem := range valueNode.Content {
+                    if i%2 == 0 {
+                        cf = sliceItem
+                        continue
+                    }
+                    items[KeyReference[string]{
+                        Value:   cf.Value,
+                        KeyNode: cf,
+                    }] = ValueReference[string]{
+                        Value:     sliceItem.Value,
+                        ValueNode: sliceItem,
+                    }
+                }
+                ref := NodeReference[map[KeyReference[string]]ValueReference[string]]{
+                    Value:     items,
+                    KeyNode:   keyNode,
+                    ValueNode: valueNode,
+                }
+                field.Set(reflect.ValueOf(ref))
+            }
+        }
+    case reflect.TypeOf(NodeReference[[]ValueReference[string]]{}):
 
-		if utils.IsNodeArray(valueNode) {
-			if field.CanSet() {
-				var items []ValueReference[string]
-				for _, sliceItem := range valueNode.Content {
-					items = append(items, ValueReference[string]{
-						Value:     sliceItem.Value,
-						ValueNode: sliceItem,
-					})
-				}
-				n := NodeReference[[]ValueReference[string]]{
-					Value:     items,
-					KeyNode:   keyNode,
-					ValueNode: valueNode,
-				}
-				field.Set(reflect.ValueOf(n))
-			}
-		}
+        if utils.IsNodeArray(valueNode) {
+            if field.CanSet() {
+                var items []ValueReference[string]
+                for _, sliceItem := range valueNode.Content {
+                    items = append(items, ValueReference[string]{
+                        Value:     sliceItem.Value,
+                        ValueNode: sliceItem,
+                    })
+                }
+                n := NodeReference[[]ValueReference[string]]{
+                    Value:     items,
+                    KeyNode:   keyNode,
+                    ValueNode: valueNode,
+                }
+                field.Set(reflect.ValueOf(n))
+            }
+        }
 
-	case reflect.TypeOf(NodeReference[[]ValueReference[any]]{}):
+    case reflect.TypeOf(NodeReference[[]ValueReference[any]]{}):
 
-		if utils.IsNodeArray(valueNode) {
-			if field.CanSet() {
-				var items []ValueReference[any]
-				for _, sliceItem := range valueNode.Content {
-					items = append(items, ValueReference[any]{
-						Value:     sliceItem.Value,
-						ValueNode: sliceItem,
-					})
-				}
-				n := NodeReference[[]ValueReference[any]]{
-					Value:     items,
-					KeyNode:   keyNode,
-					ValueNode: valueNode,
-				}
-				field.Set(reflect.ValueOf(n))
-			}
-		}
+        if utils.IsNodeArray(valueNode) {
+            if field.CanSet() {
+                var items []ValueReference[any]
+                for _, sliceItem := range valueNode.Content {
 
-	default:
-		// we want to ignore everything else, each model handles its own complex types.
-		break
-	}
-	return nil
+                    var val any
+                    if utils.IsNodeIntValue(sliceItem) || utils.IsNodeFloatValue(sliceItem) {
+                        if utils.IsNodeIntValue(sliceItem) {
+                            val, _ = strconv.ParseInt(sliceItem.Value, 10, 64)
+                        } else {
+                            val, _ = strconv.ParseFloat(sliceItem.Value, 64)
+                        }
+                    }
+                    if utils.IsNodeBoolValue(sliceItem) {
+                        val, _ = strconv.ParseBool(sliceItem.Value)
+                    }
+                    if utils.IsNodeStringValue(sliceItem) {
+                        val = sliceItem.Value
+                    }
+
+                    items = append(items, ValueReference[any]{
+                        Value:     val,
+                        ValueNode: sliceItem,
+                    })
+                }
+                n := NodeReference[[]ValueReference[any]]{
+                    Value:     items,
+                    KeyNode:   keyNode,
+                    ValueNode: valueNode,
+                }
+                field.Set(reflect.ValueOf(n))
+            }
+        }
+
+    default:
+        // we want to ignore everything else, each model handles its own complex types.
+        break
+    }
+    return nil
 }
 
 // BuildModelAsync is a convenience function for calling BuildModel from a goroutine, requires a sync.WaitGroup
 func BuildModelAsync(n *yaml.Node, model interface{}, lwg *sync.WaitGroup, errors *[]error) {
-	if n != nil {
-		err := BuildModel(n, model)
-		if err != nil {
-			*errors = append(*errors, err)
-		}
-	}
-	lwg.Done()
+    if n != nil {
+        err := BuildModel(n, model)
+        if err != nil {
+            *errors = append(*errors, err)
+        }
+    }
+    lwg.Done()
 }

--- a/datamodel/low/model_builder_test.go
+++ b/datamodel/low/model_builder_test.go
@@ -337,11 +337,6 @@ func TestSetField_Default_Helper(t *testing.T) {
 
 func TestHandleSlicesOfInts(t *testing.T) {
 
-    type cake struct {
-        thing int
-    }
-
-    // this should be ignored, no custom objects in here my friend.
     type internal struct {
         Thing NodeReference[[]ValueReference[any]]
     }
@@ -359,6 +354,26 @@ func TestHandleSlicesOfInts(t *testing.T) {
     assert.NoError(t, try)
     assert.Equal(t, int64(5), ins.Thing.Value[0].Value)
     assert.Equal(t, 1.234, ins.Thing.Value[1].Value)
+}
+
+func TestHandleSlicesOfBools(t *testing.T) {
+    type internal struct {
+        Thing NodeReference[[]ValueReference[any]]
+    }
+
+    yml := `thing:
+  - true
+  - false`
+
+    ins := new(internal)
+    var rootNode yaml.Node
+    mErr := yaml.Unmarshal([]byte(yml), &rootNode)
+    assert.NoError(t, mErr)
+
+    try := BuildModel(rootNode.Content[0], ins)
+    assert.NoError(t, try)
+    assert.Equal(t, true, ins.Thing.Value[0].Value)
+    assert.Equal(t, false, ins.Thing.Value[1].Value)
 }
 
 func TestSetField_Ignore(t *testing.T) {

--- a/datamodel/low/model_builder_test.go
+++ b/datamodel/low/model_builder_test.go
@@ -357,7 +357,8 @@ func TestHandleSlicesOfInts(t *testing.T) {
 
     try := BuildModel(rootNode.Content[0], ins)
     assert.NoError(t, try)
-    assert.Equal(t, 0, ins.Thing)
+    assert.Equal(t, int64(5), ins.Thing.Value[0].Value)
+    assert.Equal(t, 1.234, ins.Thing.Value[1].Value)
 }
 
 func TestSetField_Ignore(t *testing.T) {

--- a/datamodel/low/model_builder_test.go
+++ b/datamodel/low/model_builder_test.go
@@ -1,53 +1,53 @@
 package low
 
 import (
-	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
-	"sync"
-	"testing"
+    "github.com/stretchr/testify/assert"
+    "gopkg.in/yaml.v3"
+    "sync"
+    "testing"
 )
 
 type hotdog struct {
-	Name            NodeReference[string]
-	ValueName       ValueReference[string]
-	Fat             NodeReference[int]
-	Ketchup         NodeReference[float32]
-	Mustard         NodeReference[float64]
-	Grilled         NodeReference[bool]
-	MaxTemp         NodeReference[int]
-	MaxTempHigh     NodeReference[int64]
-	MaxTempAlt      []NodeReference[int]
-	Drinks          []NodeReference[string]
-	Sides           []NodeReference[float32]
-	BigSides        []NodeReference[float64]
-	Temps           []NodeReference[int]
-	HighTemps       []NodeReference[int64]
-	Buns            []NodeReference[bool]
-	UnknownElements NodeReference[any]
-	LotsOfUnknowns  []NodeReference[any]
-	Where           map[string]NodeReference[any]
-	There           map[string]NodeReference[string]
-	AllTheThings    NodeReference[map[KeyReference[string]]ValueReference[string]]
+    Name            NodeReference[string]
+    ValueName       ValueReference[string]
+    Fat             NodeReference[int]
+    Ketchup         NodeReference[float32]
+    Mustard         NodeReference[float64]
+    Grilled         NodeReference[bool]
+    MaxTemp         NodeReference[int]
+    MaxTempHigh     NodeReference[int64]
+    MaxTempAlt      []NodeReference[int]
+    Drinks          []NodeReference[string]
+    Sides           []NodeReference[float32]
+    BigSides        []NodeReference[float64]
+    Temps           []NodeReference[int]
+    HighTemps       []NodeReference[int64]
+    Buns            []NodeReference[bool]
+    UnknownElements NodeReference[any]
+    LotsOfUnknowns  []NodeReference[any]
+    Where           map[string]NodeReference[any]
+    There           map[string]NodeReference[string]
+    AllTheThings    NodeReference[map[KeyReference[string]]ValueReference[string]]
 }
 
 func TestBuildModel_Mismatch(t *testing.T) {
 
-	yml := `crisps: are tasty`
+    yml := `crisps: are tasty`
 
-	var rootNode yaml.Node
-	mErr := yaml.Unmarshal([]byte(yml), &rootNode)
-	assert.NoError(t, mErr)
+    var rootNode yaml.Node
+    mErr := yaml.Unmarshal([]byte(yml), &rootNode)
+    assert.NoError(t, mErr)
 
-	hd := hotdog{}
-	cErr := BuildModel(&rootNode, &hd)
-	assert.NoError(t, cErr)
-	assert.Empty(t, hd.Name)
+    hd := hotdog{}
+    cErr := BuildModel(&rootNode, &hd)
+    assert.NoError(t, cErr)
+    assert.Empty(t, hd.Name)
 
 }
 
 func TestBuildModel(t *testing.T) {
 
-	yml := `name: yummy
+    yml := `name: yummy
 valueName: yammy
 beef: true
 fat: 200
@@ -105,306 +105,331 @@ allTheThings:
   beer: isGood
   cake: isNice`
 
-	var rootNode yaml.Node
-	mErr := yaml.Unmarshal([]byte(yml), &rootNode)
-	assert.NoError(t, mErr)
+    var rootNode yaml.Node
+    mErr := yaml.Unmarshal([]byte(yml), &rootNode)
+    assert.NoError(t, mErr)
 
-	hd := hotdog{}
-	cErr := BuildModel(rootNode.Content[0], &hd)
-	assert.Equal(t, 200, hd.Fat.Value)
-	assert.Equal(t, 4, hd.Fat.ValueNode.Line)
-	assert.Equal(t, true, hd.Grilled.Value)
-	assert.Equal(t, "yummy", hd.Name.Value)
-	assert.Equal(t, "yammy", hd.ValueName.Value)
-	assert.Equal(t, float32(200.45), hd.Ketchup.Value)
-	assert.Len(t, hd.Drinks, 3)
-	assert.Len(t, hd.Sides, 4)
-	assert.Len(t, hd.BigSides, 4)
-	assert.Len(t, hd.Temps, 2)
-	assert.Len(t, hd.HighTemps, 2)
-	assert.Equal(t, int64(11732849090192923), hd.HighTemps[1].Value)
-	assert.Len(t, hd.MaxTempAlt, 5)
-	assert.Equal(t, int64(7392837462032342), hd.MaxTempHigh.Value)
-	assert.Equal(t, 2, hd.Temps[1].Value)
-	assert.Equal(t, 27, hd.Temps[1].ValueNode.Line)
-	assert.Len(t, hd.UnknownElements.Value, 2)
-	assert.Len(t, hd.LotsOfUnknowns, 3)
-	assert.Len(t, hd.Where, 2)
-	assert.Len(t, hd.There, 2)
-	assert.Equal(t, "bear", hd.There["care"].Value)
-	assert.Equal(t, 324938249028.98234892374892374923874823974, hd.Mustard.Value)
+    hd := hotdog{}
+    cErr := BuildModel(rootNode.Content[0], &hd)
+    assert.Equal(t, 200, hd.Fat.Value)
+    assert.Equal(t, 4, hd.Fat.ValueNode.Line)
+    assert.Equal(t, true, hd.Grilled.Value)
+    assert.Equal(t, "yummy", hd.Name.Value)
+    assert.Equal(t, "yammy", hd.ValueName.Value)
+    assert.Equal(t, float32(200.45), hd.Ketchup.Value)
+    assert.Len(t, hd.Drinks, 3)
+    assert.Len(t, hd.Sides, 4)
+    assert.Len(t, hd.BigSides, 4)
+    assert.Len(t, hd.Temps, 2)
+    assert.Len(t, hd.HighTemps, 2)
+    assert.Equal(t, int64(11732849090192923), hd.HighTemps[1].Value)
+    assert.Len(t, hd.MaxTempAlt, 5)
+    assert.Equal(t, int64(7392837462032342), hd.MaxTempHigh.Value)
+    assert.Equal(t, 2, hd.Temps[1].Value)
+    assert.Equal(t, 27, hd.Temps[1].ValueNode.Line)
+    assert.Len(t, hd.UnknownElements.Value, 2)
+    assert.Len(t, hd.LotsOfUnknowns, 3)
+    assert.Len(t, hd.Where, 2)
+    assert.Len(t, hd.There, 2)
+    assert.Equal(t, "bear", hd.There["care"].Value)
+    assert.Equal(t, 324938249028.98234892374892374923874823974, hd.Mustard.Value)
 
-	allTheThings := hd.AllTheThings.Value
-	for i := range allTheThings {
-		if i.Value == "beer" {
-			assert.Equal(t, "isGood", allTheThings[i].Value)
-		}
-		if i.Value == "cake" {
-			assert.Equal(t, "isNice", allTheThings[i].Value)
-		}
-	}
-	assert.NoError(t, cErr)
+    allTheThings := hd.AllTheThings.Value
+    for i := range allTheThings {
+        if i.Value == "beer" {
+            assert.Equal(t, "isGood", allTheThings[i].Value)
+        }
+        if i.Value == "cake" {
+            assert.Equal(t, "isNice", allTheThings[i].Value)
+        }
+    }
+    assert.NoError(t, cErr)
 }
 
 func TestBuildModel_UseCopyNotRef(t *testing.T) {
 
-	yml := `cake: -99999`
+    yml := `cake: -99999`
 
-	var rootNode yaml.Node
-	mErr := yaml.Unmarshal([]byte(yml), &rootNode)
-	assert.NoError(t, mErr)
+    var rootNode yaml.Node
+    mErr := yaml.Unmarshal([]byte(yml), &rootNode)
+    assert.NoError(t, mErr)
 
-	hd := hotdog{}
-	cErr := BuildModel(&rootNode, hd)
-	assert.Error(t, cErr)
-	assert.Empty(t, hd.Name)
+    hd := hotdog{}
+    cErr := BuildModel(&rootNode, hd)
+    assert.Error(t, cErr)
+    assert.Empty(t, hd.Name)
 
 }
 
 func TestBuildModel_UseUnsupportedPrimitive(t *testing.T) {
 
-	type notSupported struct {
-		cake string
-	}
-	ns := notSupported{}
-	yml := `cake: party`
+    type notSupported struct {
+        cake string
+    }
+    ns := notSupported{}
+    yml := `cake: party`
 
-	var rootNode yaml.Node
-	mErr := yaml.Unmarshal([]byte(yml), &rootNode)
-	assert.NoError(t, mErr)
+    var rootNode yaml.Node
+    mErr := yaml.Unmarshal([]byte(yml), &rootNode)
+    assert.NoError(t, mErr)
 
-	cErr := BuildModel(rootNode.Content[0], &ns)
-	assert.Error(t, cErr)
-	assert.Empty(t, ns.cake)
+    cErr := BuildModel(rootNode.Content[0], &ns)
+    assert.Error(t, cErr)
+    assert.Empty(t, ns.cake)
 
 }
 
 func TestBuildModel_UsingInternalConstructs(t *testing.T) {
 
-	type internal struct {
-		Extensions NodeReference[string]
-		PathItems  NodeReference[string]
-		Thing      NodeReference[string]
-	}
+    type internal struct {
+        Extensions NodeReference[string]
+        PathItems  NodeReference[string]
+        Thing      NodeReference[string]
+    }
 
-	yml := `extensions: one
+    yml := `extensions: one
 pathItems: two
 thing: yeah`
 
-	ins := new(internal)
-	var rootNode yaml.Node
-	mErr := yaml.Unmarshal([]byte(yml), &rootNode)
-	assert.NoError(t, mErr)
+    ins := new(internal)
+    var rootNode yaml.Node
+    mErr := yaml.Unmarshal([]byte(yml), &rootNode)
+    assert.NoError(t, mErr)
 
-	// try a null build
-	try := BuildModel(nil, ins)
-	assert.NoError(t, try)
+    // try a null build
+    try := BuildModel(nil, ins)
+    assert.NoError(t, try)
 
-	cErr := BuildModel(rootNode.Content[0], ins)
-	assert.NoError(t, cErr)
-	assert.Empty(t, ins.PathItems.Value)
-	assert.Empty(t, ins.Extensions.Value)
-	assert.Equal(t, "yeah", ins.Thing.Value)
+    cErr := BuildModel(rootNode.Content[0], ins)
+    assert.NoError(t, cErr)
+    assert.Empty(t, ins.PathItems.Value)
+    assert.Empty(t, ins.Extensions.Value)
+    assert.Equal(t, "yeah", ins.Thing.Value)
 }
 
 func TestSetField_NodeRefAny_Error(t *testing.T) {
 
-	type internal struct {
-		Thing []NodeReference[any]
-	}
+    type internal struct {
+        Thing []NodeReference[any]
+    }
 
-	yml := `thing:
+    yml := `thing:
   - 999
   - false`
 
-	ins := new(internal)
-	var rootNode yaml.Node
-	mErr := yaml.Unmarshal([]byte(yml), &rootNode)
-	assert.NoError(t, mErr)
+    ins := new(internal)
+    var rootNode yaml.Node
+    mErr := yaml.Unmarshal([]byte(yml), &rootNode)
+    assert.NoError(t, mErr)
 
-	try := BuildModel(rootNode.Content[0], ins)
-	assert.Error(t, try)
+    try := BuildModel(rootNode.Content[0], ins)
+    assert.Error(t, try)
 
 }
 
 func TestSetField_MapHelperWrapped(t *testing.T) {
 
-	type internal struct {
-		Thing KeyReference[map[KeyReference[string]]ValueReference[string]]
-	}
+    type internal struct {
+        Thing KeyReference[map[KeyReference[string]]ValueReference[string]]
+    }
 
-	yml := `thing: 
+    yml := `thing: 
   what: not
   chip: chop
   lip: lop`
 
-	ins := new(internal)
-	var rootNode yaml.Node
-	mErr := yaml.Unmarshal([]byte(yml), &rootNode)
-	assert.NoError(t, mErr)
+    ins := new(internal)
+    var rootNode yaml.Node
+    mErr := yaml.Unmarshal([]byte(yml), &rootNode)
+    assert.NoError(t, mErr)
 
-	try := BuildModel(rootNode.Content[0], ins)
-	assert.NoError(t, try)
-	assert.Len(t, ins.Thing.Value, 3)
+    try := BuildModel(rootNode.Content[0], ins)
+    assert.NoError(t, try)
+    assert.Len(t, ins.Thing.Value, 3)
 }
 
 func TestSetField_MapHelper(t *testing.T) {
 
-	type internal struct {
-		Thing map[KeyReference[string]]ValueReference[string]
-	}
+    type internal struct {
+        Thing map[KeyReference[string]]ValueReference[string]
+    }
 
-	yml := `thing: 
+    yml := `thing: 
   what: not
   chip: chop
   lip: lop`
 
-	ins := new(internal)
-	var rootNode yaml.Node
-	mErr := yaml.Unmarshal([]byte(yml), &rootNode)
-	assert.NoError(t, mErr)
+    ins := new(internal)
+    var rootNode yaml.Node
+    mErr := yaml.Unmarshal([]byte(yml), &rootNode)
+    assert.NoError(t, mErr)
 
-	try := BuildModel(rootNode.Content[0], ins)
-	assert.NoError(t, try)
-	assert.Len(t, ins.Thing, 3)
+    try := BuildModel(rootNode.Content[0], ins)
+    assert.NoError(t, try)
+    assert.Len(t, ins.Thing, 3)
 }
 
 func TestSetField_ArrayHelper(t *testing.T) {
 
-	type internal struct {
-		Thing NodeReference[[]ValueReference[string]]
-	}
+    type internal struct {
+        Thing NodeReference[[]ValueReference[string]]
+    }
 
-	yml := `thing: 
+    yml := `thing: 
   - nice
   - rice
   - slice`
 
-	ins := new(internal)
-	var rootNode yaml.Node
-	mErr := yaml.Unmarshal([]byte(yml), &rootNode)
-	assert.NoError(t, mErr)
+    ins := new(internal)
+    var rootNode yaml.Node
+    mErr := yaml.Unmarshal([]byte(yml), &rootNode)
+    assert.NoError(t, mErr)
 
-	try := BuildModel(rootNode.Content[0], ins)
-	assert.NoError(t, try)
-	assert.Len(t, ins.Thing.Value, 3)
+    try := BuildModel(rootNode.Content[0], ins)
+    assert.NoError(t, try)
+    assert.Len(t, ins.Thing.Value, 3)
 }
 
 func TestSetField_Enum_Helper(t *testing.T) {
 
-	type internal struct {
-		Thing NodeReference[[]ValueReference[any]]
-	}
+    type internal struct {
+        Thing NodeReference[[]ValueReference[any]]
+    }
 
-	yml := `thing: 
+    yml := `thing: 
   - nice
   - rice
   - slice`
 
-	ins := new(internal)
-	var rootNode yaml.Node
-	mErr := yaml.Unmarshal([]byte(yml), &rootNode)
-	assert.NoError(t, mErr)
+    ins := new(internal)
+    var rootNode yaml.Node
+    mErr := yaml.Unmarshal([]byte(yml), &rootNode)
+    assert.NoError(t, mErr)
 
-	try := BuildModel(rootNode.Content[0], ins)
-	assert.NoError(t, try)
-	assert.Len(t, ins.Thing.Value, 3)
+    try := BuildModel(rootNode.Content[0], ins)
+    assert.NoError(t, try)
+    assert.Len(t, ins.Thing.Value, 3)
 }
 
 func TestSetField_Default_Helper(t *testing.T) {
 
-	type cake struct {
-		thing int
-	}
+    type cake struct {
+        thing int
+    }
 
-	// this should be ignored, no custom objects in here my friend.
-	type internal struct {
-		Thing cake
-	}
+    // this should be ignored, no custom objects in here my friend.
+    type internal struct {
+        Thing cake
+    }
 
-	yml := `thing: 
+    yml := `thing: 
   type: cake`
 
-	ins := new(internal)
-	var rootNode yaml.Node
-	mErr := yaml.Unmarshal([]byte(yml), &rootNode)
-	assert.NoError(t, mErr)
+    ins := new(internal)
+    var rootNode yaml.Node
+    mErr := yaml.Unmarshal([]byte(yml), &rootNode)
+    assert.NoError(t, mErr)
 
-	try := BuildModel(rootNode.Content[0], ins)
-	assert.NoError(t, try)
-	assert.Equal(t, 0, ins.Thing.thing)
+    try := BuildModel(rootNode.Content[0], ins)
+    assert.NoError(t, try)
+    assert.Equal(t, 0, ins.Thing.thing)
+}
+
+func TestHandleSlicesOfInts(t *testing.T) {
+
+    type cake struct {
+        thing int
+    }
+
+    // this should be ignored, no custom objects in here my friend.
+    type internal struct {
+        Thing NodeReference[[]ValueReference[any]]
+    }
+
+    yml := `thing:
+  - 5
+  - 1.234`
+
+    ins := new(internal)
+    var rootNode yaml.Node
+    mErr := yaml.Unmarshal([]byte(yml), &rootNode)
+    assert.NoError(t, mErr)
+
+    try := BuildModel(rootNode.Content[0], ins)
+    assert.NoError(t, try)
+    assert.Equal(t, 0, ins.Thing)
 }
 
 func TestSetField_Ignore(t *testing.T) {
 
-	type Complex struct {
-		name string
-	}
-	type internal struct {
-		Thing *Complex
-	}
+    type Complex struct {
+        name string
+    }
+    type internal struct {
+        Thing *Complex
+    }
 
-	yml := `thing: 
+    yml := `thing: 
   - nice
   - rice
   - slice`
 
-	ins := new(internal)
-	var rootNode yaml.Node
-	mErr := yaml.Unmarshal([]byte(yml), &rootNode)
-	assert.NoError(t, mErr)
+    ins := new(internal)
+    var rootNode yaml.Node
+    mErr := yaml.Unmarshal([]byte(yml), &rootNode)
+    assert.NoError(t, mErr)
 
-	try := BuildModel(&rootNode, ins)
-	assert.NoError(t, try)
-	assert.Nil(t, ins.Thing)
+    try := BuildModel(&rootNode, ins)
+    assert.NoError(t, try)
+    assert.Nil(t, ins.Thing)
 }
 
 func TestBuildModelAsync(t *testing.T) {
 
-	type internal struct {
-		Thing KeyReference[map[KeyReference[string]]ValueReference[string]]
-	}
+    type internal struct {
+        Thing KeyReference[map[KeyReference[string]]ValueReference[string]]
+    }
 
-	yml := `thing: 
+    yml := `thing: 
   what: not
   chip: chop
   lip: lop`
 
-	ins := new(internal)
-	var rootNode yaml.Node
-	mErr := yaml.Unmarshal([]byte(yml), &rootNode)
-	assert.NoError(t, mErr)
+    ins := new(internal)
+    var rootNode yaml.Node
+    mErr := yaml.Unmarshal([]byte(yml), &rootNode)
+    assert.NoError(t, mErr)
 
-	var wg sync.WaitGroup
-	var errors []error
-	wg.Add(1)
-	BuildModelAsync(rootNode.Content[0], ins, &wg, &errors)
-	wg.Wait()
-	assert.Len(t, ins.Thing.Value, 3)
+    var wg sync.WaitGroup
+    var errors []error
+    wg.Add(1)
+    BuildModelAsync(rootNode.Content[0], ins, &wg, &errors)
+    wg.Wait()
+    assert.Len(t, ins.Thing.Value, 3)
 
 }
 
 func TestBuildModelAsync_Error(t *testing.T) {
 
-	type internal struct {
-		Thing []NodeReference[any]
-	}
+    type internal struct {
+        Thing []NodeReference[any]
+    }
 
-	yml := `thing:
+    yml := `thing:
   - 999
   - false`
 
-	ins := new(internal)
-	var rootNode yaml.Node
-	mErr := yaml.Unmarshal([]byte(yml), &rootNode)
-	assert.NoError(t, mErr)
+    ins := new(internal)
+    var rootNode yaml.Node
+    mErr := yaml.Unmarshal([]byte(yml), &rootNode)
+    assert.NoError(t, mErr)
 
-	var wg sync.WaitGroup
-	var errors []error
-	wg.Add(1)
-	BuildModelAsync(rootNode.Content[0], ins, &wg, &errors)
-	wg.Wait()
-	assert.Len(t, errors, 1)
-	assert.Len(t, ins.Thing, 0)
+    var wg sync.WaitGroup
+    var errors []error
+    wg.Add(1)
+    BuildModelAsync(rootNode.Content[0], ins, &wg, &errors)
+    wg.Wait()
+    assert.Len(t, errors, 1)
+    assert.Len(t, ins.Thing, 0)
 
 }

--- a/datamodel/schemas/oas3-schema.json
+++ b/datamodel/schemas/oas3-schema.json
@@ -46,7 +46,8 @@
     }
   },
   "patternProperties": {
-    "^x-": {}
+    "^x-": {
+    }
   },
   "additionalProperties": false,
   "definitions": {
@@ -90,7 +91,8 @@
         }
       },
       "patternProperties": {
-        "^x-": {}
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
@@ -110,7 +112,8 @@
         }
       },
       "patternProperties": {
-        "^x-": {}
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
@@ -129,7 +132,8 @@
         }
       },
       "patternProperties": {
-        "^x-": {}
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
@@ -153,7 +157,8 @@
         }
       },
       "patternProperties": {
-        "^x-": {}
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
@@ -177,7 +182,8 @@
         }
       },
       "patternProperties": {
-        "^x-": {}
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
@@ -321,7 +327,8 @@
         }
       },
       "patternProperties": {
-        "^x-": {}
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
@@ -395,7 +402,8 @@
         },
         "enum": {
           "type": "array",
-          "items": {},
+          "items": {
+          },
           "minItems": 1,
           "uniqueItems": false
         },
@@ -502,7 +510,8 @@
         "format": {
           "type": "string"
         },
-        "default": {},
+        "default": {
+        },
         "nullable": {
           "type": "boolean",
           "default": false
@@ -518,7 +527,8 @@
           "type": "boolean",
           "default": false
         },
-        "example": {},
+        "example": {
+        },
         "externalDocs": {
           "$ref": "#/definitions/ExternalDocumentation"
         },
@@ -531,7 +541,8 @@
         }
       },
       "patternProperties": {
-        "^x-": {}
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
@@ -575,7 +586,8 @@
         }
       },
       "patternProperties": {
-        "^x-": {}
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
@@ -622,7 +634,8 @@
         }
       },
       "patternProperties": {
-        "^x-": {}
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
@@ -639,7 +652,8 @@
             }
           ]
         },
-        "example": {},
+        "example": {
+        },
         "examples": {
           "type": "object",
           "additionalProperties": {
@@ -661,7 +675,8 @@
         }
       },
       "patternProperties": {
-        "^x-": {}
+        "^x-": {
+        }
       },
       "additionalProperties": false,
       "allOf": [
@@ -679,14 +694,16 @@
         "description": {
           "type": "string"
         },
-        "value": {},
+        "value": {
+        },
         "externalValue": {
           "type": "string",
           "format": "uri-reference"
         }
       },
       "patternProperties": {
-        "^x-": {}
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
@@ -740,7 +757,8 @@
           "minProperties": 1,
           "maxProperties": 1
         },
-        "example": {},
+        "example": {
+        },
         "examples": {
           "type": "object",
           "additionalProperties": {
@@ -756,7 +774,8 @@
         }
       },
       "patternProperties": {
-        "^x-": {}
+        "^x-": {
+        }
       },
       "additionalProperties": false,
       "allOf": [
@@ -774,7 +793,8 @@
         "^\\/": {
           "$ref": "#/definitions/PathItem"
         },
-        "^x-": {}
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
@@ -815,7 +835,8 @@
         "^(get|put|post|delete|options|head|patch|trace)$": {
           "$ref": "#/definitions/Operation"
         },
-        "^x-": {}
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
@@ -901,7 +922,8 @@
         }
       },
       "patternProperties": {
-        "^x-": {}
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
@@ -930,7 +952,8 @@
             }
           ]
         },
-        "^x-": {}
+        "^x-": {
+        }
       },
       "minProperties": 1,
       "additionalProperties": false
@@ -961,7 +984,8 @@
         }
       },
       "patternProperties": {
-        "^x-": {}
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
@@ -980,7 +1004,8 @@
         }
       },
       "patternProperties": {
-        "^x-": {}
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
@@ -1104,7 +1129,8 @@
           "minProperties": 1,
           "maxProperties": 1
         },
-        "example": {},
+        "example": {
+        },
         "examples": {
           "type": "object",
           "additionalProperties": {
@@ -1120,7 +1146,8 @@
         }
       },
       "patternProperties": {
-        "^x-": {}
+        "^x-": {
+        }
       },
       "additionalProperties": false,
       "required": [
@@ -1242,7 +1269,8 @@
         }
       },
       "patternProperties": {
-        "^x-": {}
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
@@ -1292,7 +1320,8 @@
         }
       },
       "patternProperties": {
-        "^x-": {}
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
@@ -1320,7 +1349,8 @@
         }
       },
       "patternProperties": {
-        "^x-": {}
+        "^x-": {
+        }
       },
       "additionalProperties": false,
       "oneOf": [
@@ -1372,7 +1402,8 @@
         }
       },
       "patternProperties": {
-        "^x-": {}
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
@@ -1398,7 +1429,8 @@
         }
       },
       "patternProperties": {
-        "^x-": {}
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
@@ -1419,7 +1451,8 @@
         }
       },
       "patternProperties": {
-        "^x-": {}
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
@@ -1446,7 +1479,8 @@
         }
       },
       "patternProperties": {
-        "^x-": {}
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
@@ -1473,7 +1507,8 @@
         }
       },
       "patternProperties": {
-        "^x-": {}
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
@@ -1500,7 +1535,8 @@
         }
       },
       "patternProperties": {
-        "^x-": {}
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
@@ -1532,7 +1568,8 @@
         }
       },
       "patternProperties": {
-        "^x-": {}
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
@@ -1548,9 +1585,11 @@
         },
         "parameters": {
           "type": "object",
-          "additionalProperties": {}
+          "additionalProperties": {
+          }
         },
-        "requestBody": {},
+        "requestBody": {
+        },
         "description": {
           "type": "string"
         },
@@ -1559,7 +1598,8 @@
         }
       },
       "patternProperties": {
-        "^x-": {}
+        "^x-": {
+        }
       },
       "additionalProperties": false,
       "not": {
@@ -1576,7 +1616,8 @@
         "$ref": "#/definitions/PathItem"
       },
       "patternProperties": {
-        "^x-": {}
+        "^x-": {
+        }
       }
     },
     "Encoding": {

--- a/datamodel/schemas/oas31-schema.json
+++ b/datamodel/schemas/oas31-schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://spec.openapis.org/oas/3.1/schema/2022-02-27",
+  "$id": "https://spec.openapis.org/oas/3.1/schema/2022-10-07",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "The description of OpenAPI v3.1.x documents without schema validation, as defined by https://spec.openapis.org/oas/v3.1.0",
   "type": "object",
@@ -22,7 +22,9 @@
         "$ref": "#/$defs/server"
       },
       "default": [
-        { "url": "/" }
+        {
+          "url": "/"
+        }
       ]
     },
     "paths": {
@@ -148,18 +150,15 @@
       "required": [
         "name"
       ],
-      "oneOf": [
-        {
-          "required": [
-            "identifier"
-          ]
-        },
-        {
-          "required": [
-            "url"
-          ]
+      "dependentSchemas": {
+        "identifier": {
+          "not": {
+            "required": [
+              "url"
+            ]
+          }
         }
-      ],
+      },
       "$ref": "#/$defs/specification-extensions",
       "unevaluatedProperties": false
     },
@@ -319,10 +318,29 @@
           "items": {
             "$ref": "#/$defs/parameter-or-reference"
           }
-        }
-      },
-      "patternProperties": {
-        "^(get|put|post|delete|options|head|patch|trace)$": {
+        },
+        "get": {
+          "$ref": "#/$defs/operation"
+        },
+        "put": {
+          "$ref": "#/$defs/operation"
+        },
+        "post": {
+          "$ref": "#/$defs/operation"
+        },
+        "delete": {
+          "$ref": "#/$defs/operation"
+        },
+        "options": {
+          "$ref": "#/$defs/operation"
+        },
+        "head": {
+          "$ref": "#/$defs/operation"
+        },
+        "patch": {
+          "$ref": "#/$defs/operation"
+        },
+        "trace": {
           "$ref": "#/$defs/operation"
         }
       },
@@ -822,7 +840,16 @@
       },
       "minProperties": 1,
       "$ref": "#/$defs/specification-extensions",
-      "unevaluatedProperties": false
+      "unevaluatedProperties": false,
+      "if": {
+        "$comment": "either default, or at least one response code property must exist",
+        "patternProperties": {
+          "^[1-5](?:[0-9]{2}|XX)$": false
+        }
+      },
+      "then" : {
+        "required": [ "default" ]
+      }
     },
     "response": {
       "$comment": "https://spec.openapis.org/oas/v3.1.0#response-object",
@@ -936,7 +963,9 @@
           "type": "string",
           "format": "uri-reference"
         },
-        "operationId": true,
+        "operationId": {
+          "type": "string"
+        },
         "parameters": {
           "$ref": "#/$defs/map-of-strings"
         },

--- a/datamodel/spec_info_test.go
+++ b/datamodel/spec_info_test.go
@@ -4,31 +4,31 @@
 package datamodel
 
 import (
-	"fmt"
-	"io/ioutil"
-	"testing"
+    "fmt"
+    "io/ioutil"
+    "testing"
 
-	"github.com/pb33f/libopenapi/utils"
-	"github.com/stretchr/testify/assert"
+    "github.com/pb33f/libopenapi/utils"
+    "github.com/stretchr/testify/assert"
 )
 
 const (
-	// OpenApi3 is used by all OpenAPI 3+ docs
-	OpenApi3 = "openapi"
+    // OpenApi3 is used by all OpenAPI 3+ docs
+    OpenApi3 = "openapi"
 
-	// OpenApi2 is used by all OpenAPI 2 docs, formerly known as swagger.
-	OpenApi2 = "swagger"
+    // OpenApi2 is used by all OpenAPI 2 docs, formerly known as swagger.
+    OpenApi2 = "swagger"
 
-	// AsyncApi is used by akk AsyncAPI docs, all versions.
-	AsyncApi = "asyncapi"
+    // AsyncApi is used by akk AsyncAPI docs, all versions.
+    AsyncApi = "asyncapi"
 )
 
 func TestSpecInfo_GetJSONParsingChannel(t *testing.T) {
 
-	// dumb, but we need to ensure coverage is as high as we can make it.
-	bchan := make(chan bool)
-	si := &SpecInfo{JsonParsingChannel: bchan}
-	assert.Equal(t, si.GetJSONParsingChannel(), bchan)
+    // dumb, but we need to ensure coverage is as high as we can make it.
+    bchan := make(chan bool)
+    si := &SpecInfo{JsonParsingChannel: bchan}
+    assert.Equal(t, si.GetJSONParsingChannel(), bchan)
 
 }
 
@@ -115,147 +115,147 @@ info:
   version: '0.1.0'`
 
 func TestExtractSpecInfo_ValidJSON(t *testing.T) {
-	r, e := ExtractSpecInfo([]byte(goodJSON))
-	assert.Greater(t, len(*r.SpecJSONBytes), 0)
-	assert.Error(t, e)
+    r, e := ExtractSpecInfo([]byte(goodJSON))
+    assert.Greater(t, len(*r.SpecJSONBytes), 0)
+    assert.Error(t, e)
 }
 
 func TestExtractSpecInfo_InvalidJSON(t *testing.T) {
-	_, e := ExtractSpecInfo([]byte(badJSON))
-	assert.Error(t, e)
+    _, e := ExtractSpecInfo([]byte(badJSON))
+    assert.Error(t, e)
 }
 
 func TestExtractSpecInfo_Nothing(t *testing.T) {
-	_, e := ExtractSpecInfo([]byte(""))
-	assert.Error(t, e)
+    _, e := ExtractSpecInfo([]byte(""))
+    assert.Error(t, e)
 }
 
 func TestExtractSpecInfo_ValidYAML(t *testing.T) {
-	r, e := ExtractSpecInfo([]byte(goodYAML))
-	assert.Greater(t, len(*r.SpecJSONBytes), 0)
-	assert.Error(t, e)
+    r, e := ExtractSpecInfo([]byte(goodYAML))
+    assert.Greater(t, len(*r.SpecJSONBytes), 0)
+    assert.Error(t, e)
 }
 
 func TestExtractSpecInfo_InvalidYAML(t *testing.T) {
-	_, e := ExtractSpecInfo([]byte(badYAML))
-	assert.Error(t, e)
+    _, e := ExtractSpecInfo([]byte(badYAML))
+    assert.Error(t, e)
 }
 
 func TestExtractSpecInfo_InvalidOpenAPIVersion(t *testing.T) {
-	_, e := ExtractSpecInfo([]byte(OpenApiOne))
-	assert.Error(t, e)
+    _, e := ExtractSpecInfo([]byte(OpenApiOne))
+    assert.Error(t, e)
 }
 
 func TestExtractSpecInfo_OpenAPI3(t *testing.T) {
 
-	r, e := ExtractSpecInfo([]byte(OpenApi3Spec))
-	assert.Nil(t, e)
-	assert.Equal(t, utils.OpenApi3, r.SpecType)
-	assert.Equal(t, "3.0.1", r.Version)
-	assert.Greater(t, len(*r.SpecJSONBytes), 0)
-	assert.Contains(t, r.APISchema, "https://spec.openapis.org/oas/3.0/schema/2021-09-28")
+    r, e := ExtractSpecInfo([]byte(OpenApi3Spec))
+    assert.Nil(t, e)
+    assert.Equal(t, utils.OpenApi3, r.SpecType)
+    assert.Equal(t, "3.0.1", r.Version)
+    assert.Greater(t, len(*r.SpecJSONBytes), 0)
+    assert.Contains(t, r.APISchema, "https://spec.openapis.org/oas/3.0/schema/2021-09-28")
 }
 
 func TestExtractSpecInfo_OpenAPIWat(t *testing.T) {
 
-	r, e := ExtractSpecInfo([]byte(OpenApiWat))
-	assert.Nil(t, e)
-	assert.Equal(t, OpenApi3, r.SpecType)
-	assert.Equal(t, "3.2", r.Version)
+    r, e := ExtractSpecInfo([]byte(OpenApiWat))
+    assert.Nil(t, e)
+    assert.Equal(t, OpenApi3, r.SpecType)
+    assert.Equal(t, "3.2", r.Version)
 }
 
 func TestExtractSpecInfo_OpenAPI31(t *testing.T) {
 
-	r, e := ExtractSpecInfo([]byte(OpenApi31))
-	assert.Nil(t, e)
-	assert.Equal(t, OpenApi3, r.SpecType)
-	assert.Equal(t, "3.1", r.Version)
-	assert.Contains(t, r.APISchema, "https://spec.openapis.org/oas/3.1/schema/2022-02-27")
+    r, e := ExtractSpecInfo([]byte(OpenApi31))
+    assert.Nil(t, e)
+    assert.Equal(t, OpenApi3, r.SpecType)
+    assert.Equal(t, "3.1", r.Version)
+    assert.Contains(t, r.APISchema, "https://spec.openapis.org/oas/3.1/schema/2022-10-07")
 }
 
 func TestExtractSpecInfo_OpenAPIFalse(t *testing.T) {
 
-	spec, e := ExtractSpecInfo([]byte(OpenApiFalse))
-	assert.NoError(t, e)
-	assert.Equal(t, "false", spec.Version)
+    spec, e := ExtractSpecInfo([]byte(OpenApiFalse))
+    assert.NoError(t, e)
+    assert.Equal(t, "false", spec.Version)
 }
 
 func TestExtractSpecInfo_OpenAPI2(t *testing.T) {
 
-	r, e := ExtractSpecInfo([]byte(OpenApi2Spec))
-	assert.Nil(t, e)
-	assert.Equal(t, OpenApi2, r.SpecType)
-	assert.Equal(t, "2.0.1", r.Version)
-	assert.Greater(t, len(*r.SpecJSONBytes), 0)
-	assert.Contains(t, r.APISchema, "http://swagger.io/v2/schema.json#")
+    r, e := ExtractSpecInfo([]byte(OpenApi2Spec))
+    assert.Nil(t, e)
+    assert.Equal(t, OpenApi2, r.SpecType)
+    assert.Equal(t, "2.0.1", r.Version)
+    assert.Greater(t, len(*r.SpecJSONBytes), 0)
+    assert.Contains(t, r.APISchema, "http://swagger.io/v2/schema.json#")
 }
 
 func TestExtractSpecInfo_OpenAPI2_OddVersion(t *testing.T) {
 
-	_, e := ExtractSpecInfo([]byte(OpenApi2SpecOdd))
-	assert.NotNil(t, e)
-	assert.Equal(t,
-		"spec is defined as a swagger (openapi 2.0) spec, but is an openapi 3 or unknown version", e.Error())
+    _, e := ExtractSpecInfo([]byte(OpenApi2SpecOdd))
+    assert.NotNil(t, e)
+    assert.Equal(t,
+        "spec is defined as a swagger (openapi 2.0) spec, but is an openapi 3 or unknown version", e.Error())
 }
 
 func TestExtractSpecInfo_AsyncAPI(t *testing.T) {
 
-	r, e := ExtractSpecInfo([]byte(AsyncAPISpec))
-	assert.Nil(t, e)
-	assert.Equal(t, AsyncApi, r.SpecType)
-	assert.Equal(t, "2.0.0", r.Version)
-	assert.Greater(t, len(*r.SpecJSONBytes), 0)
+    r, e := ExtractSpecInfo([]byte(AsyncAPISpec))
+    assert.Nil(t, e)
+    assert.Equal(t, AsyncApi, r.SpecType)
+    assert.Equal(t, "2.0.0", r.Version)
+    assert.Greater(t, len(*r.SpecJSONBytes), 0)
 }
 
 func TestExtractSpecInfo_AsyncAPI_OddVersion(t *testing.T) {
 
-	_, e := ExtractSpecInfo([]byte(AsyncAPISpecOdd))
-	assert.NotNil(t, e)
-	assert.Equal(t,
-		"spec is defined as asyncapi, but has a major version that is invalid", e.Error())
+    _, e := ExtractSpecInfo([]byte(AsyncAPISpecOdd))
+    assert.NotNil(t, e)
+    assert.Equal(t,
+        "spec is defined as asyncapi, but has a major version that is invalid", e.Error())
 }
 
 func TestExtractSpecInfo_BadVersion_OpenAPI3(t *testing.T) {
 
-	yml := `openapi:
+    yml := `openapi:
  should: fail`
 
-	_, err := ExtractSpecInfo([]byte(yml))
-	assert.Error(t, err)
+    _, err := ExtractSpecInfo([]byte(yml))
+    assert.Error(t, err)
 }
 
 func TestExtractSpecInfo_BadVersion_Swagger(t *testing.T) {
 
-	yml := `swagger:
+    yml := `swagger:
  should: fail`
 
-	_, err := ExtractSpecInfo([]byte(yml))
-	assert.Error(t, err)
+    _, err := ExtractSpecInfo([]byte(yml))
+    assert.Error(t, err)
 }
 
 func TestExtractSpecInfo_BadVersion_AsyncAPI(t *testing.T) {
 
-	yml := `asyncapi:
+    yml := `asyncapi:
  should: fail`
 
-	_, err := ExtractSpecInfo([]byte(yml))
-	assert.Error(t, err)
+    _, err := ExtractSpecInfo([]byte(yml))
+    assert.Error(t, err)
 }
 
 func ExampleExtractSpecInfo() {
 
-	// load bytes from openapi spec file.
-	bytes, _ := ioutil.ReadFile("../test_specs/petstorev3.json")
+    // load bytes from openapi spec file.
+    bytes, _ := ioutil.ReadFile("../test_specs/petstorev3.json")
 
-	// create a new *SpecInfo instance from loaded bytes
-	specInfo, err := ExtractSpecInfo(bytes)
-	if err != nil {
-		panic(fmt.Sprintf("cannot extract spec info: %e", err))
-	}
+    // create a new *SpecInfo instance from loaded bytes
+    specInfo, err := ExtractSpecInfo(bytes)
+    if err != nil {
+        panic(fmt.Sprintf("cannot extract spec info: %e", err))
+    }
 
-	// print out the version, format and filetype
-	fmt.Printf("the version of the spec is %s, the format is %s and the file type is %s",
-		specInfo.Version, specInfo.SpecFormat, specInfo.SpecFileType)
+    // print out the version, format and filetype
+    fmt.Printf("the version of the spec is %s, the format is %s and the file type is %s",
+        specInfo.Version, specInfo.SpecFormat, specInfo.SpecFileType)
 
-	// Output: the version of the spec is 3.0.2, the format is oas3 and the file type is json
+    // Output: the version of the spec is 3.0.2, the format is oas3 and the file type is json
 }

--- a/document_examples_test.go
+++ b/document_examples_test.go
@@ -665,5 +665,5 @@ func ExampleNewDocument_modifyAndReRender() {
     fmt.Printf("There were %d original paths. There are now %d paths in the document\n", originalPaths, newPaths)
     fmt.Printf("The original spec had %d bytes, the new one has %d\n", len(petstore), len(rawBytes))
     // Output: There were 13 original paths. There are now 14 paths in the document
-    //The original spec had 31143 bytes, the new one has 27857
+    //The original spec had 31143 bytes, the new one has 27841
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,307 +1,331 @@
 package utils
 
 import (
-	"encoding/json"
-	"fmt"
-	"net/url"
-	"regexp"
-	"strconv"
-	"strings"
+    "encoding/json"
+    "fmt"
+    "net/url"
+    "regexp"
+    "strconv"
+    "strings"
 
-	"github.com/vmware-labs/yaml-jsonpath/pkg/yamlpath"
-	"gopkg.in/yaml.v3"
+    "github.com/vmware-labs/yaml-jsonpath/pkg/yamlpath"
+    "gopkg.in/yaml.v3"
 )
 
 type Case int8
 
 const (
-	// OpenApi3 is used by all OpenAPI 3+ docs
-	OpenApi3 = "openapi"
+    // OpenApi3 is used by all OpenAPI 3+ docs
+    OpenApi3 = "openapi"
 
-	// OpenApi2 is used by all OpenAPI 2 docs, formerly known as swagger.
-	OpenApi2 = "swagger"
+    // OpenApi2 is used by all OpenAPI 2 docs, formerly known as swagger.
+    OpenApi2 = "swagger"
 
-	// AsyncApi is used by akk AsyncAPI docs, all versions.
-	AsyncApi = "asyncapi"
+    // AsyncApi is used by akk AsyncAPI docs, all versions.
+    AsyncApi = "asyncapi"
 
-	PascalCase Case = iota
-	CamelCase
-	ScreamingSnakeCase
-	SnakeCase
-	KebabCase
-	ScreamingKebabCase
-	RegularCase
-	UnknownCase
+    PascalCase Case = iota
+    CamelCase
+    ScreamingSnakeCase
+    SnakeCase
+    KebabCase
+    ScreamingKebabCase
+    RegularCase
+    UnknownCase
 )
 
 // FindNodes will find a node based on JSONPath, it accepts raw yaml/json as input.
 func FindNodes(yamlData []byte, jsonPath string) ([]*yaml.Node, error) {
-	jsonPath = FixContext(jsonPath)
+    jsonPath = FixContext(jsonPath)
 
-	var node yaml.Node
-	yaml.Unmarshal(yamlData, &node)
+    var node yaml.Node
+    yaml.Unmarshal(yamlData, &node)
 
-	path, err := yamlpath.NewPath(jsonPath)
-	if err != nil {
-		return nil, err
-	}
-	results, _ := path.Find(&node)
-	return results, nil
+    path, err := yamlpath.NewPath(jsonPath)
+    if err != nil {
+        return nil, err
+    }
+    results, _ := path.Find(&node)
+    return results, nil
 }
 
+// FindLastChildNode will find the last node in a tree, based on a starting node.
+// Deprecated: This function is deprecated, use FindLastChildNodeWithLevel instead.
+// this has the potential to cause a stack overflow, so use with caution. It will be removed later.
 func FindLastChildNode(node *yaml.Node) *yaml.Node {
-	s := len(node.Content) - 1
-	if s < 0 {
-		s = 0
-	}
-	if len(node.Content) > 0 && len(node.Content[s].Content) > 0 {
-		return FindLastChildNode(node.Content[s])
-	} else {
-		if len(node.Content) > 0 {
-			return node.Content[s]
-		}
-		return node
-	}
+    s := len(node.Content) - 1
+    if s < 0 {
+        s = 0
+    }
+    if len(node.Content) > 0 && len(node.Content[s].Content) > 0 {
+        return FindLastChildNode(node.Content[s])
+    } else {
+        if len(node.Content) > 0 {
+            return node.Content[s]
+        }
+        return node
+    }
+}
+
+// FindLastChildNodeWithLevel will find the last node in a tree, based on a starting node.
+// Will stop searching after 100 levels, because that's just silly, we probably have a loop.
+func FindLastChildNodeWithLevel(node *yaml.Node, level int) *yaml.Node {
+    if level > 100 {
+        return node // we've gone too far, give up.
+    }
+    s := len(node.Content) - 1
+    if s < 0 {
+        s = 0
+    }
+    if len(node.Content) > 0 && len(node.Content[s].Content) > 0 {
+        level++
+        return FindLastChildNodeWithLevel(node.Content[s], level)
+    } else {
+        if len(node.Content) > 0 {
+            return node.Content[s]
+        }
+        return node
+    }
 }
 
 // BuildPath will construct a JSONPath from a base and an array of strings.
 func BuildPath(basePath string, segs []string) string {
 
-	path := strings.Join(segs, ".")
+    path := strings.Join(segs, ".")
 
-	// trim that last period.
-	if len(path) > 0 && path[len(path)-1] == '.' {
-		path = path[:len(path)-1]
-	}
-	return fmt.Sprintf("%s.%s", basePath, path)
+    // trim that last period.
+    if len(path) > 0 && path[len(path)-1] == '.' {
+        path = path[:len(path)-1]
+    }
+    return fmt.Sprintf("%s.%s", basePath, path)
 }
 
 // FindNodesWithoutDeserializing will find a node based on JSONPath, without deserializing from yaml/json
 func FindNodesWithoutDeserializing(node *yaml.Node, jsonPath string) ([]*yaml.Node, error) {
-	jsonPath = FixContext(jsonPath)
+    jsonPath = FixContext(jsonPath)
 
-	path, err := yamlpath.NewPath(jsonPath)
-	if err != nil {
-		return nil, err
-	}
-	results, _ := path.Find(node)
-	return results, nil
+    path, err := yamlpath.NewPath(jsonPath)
+    if err != nil {
+        return nil, err
+    }
+    results, _ := path.Find(node)
+    return results, nil
 }
 
 // ConvertInterfaceIntoStringMap will convert an unknown input into a string map.
 func ConvertInterfaceIntoStringMap(context interface{}) map[string]string {
-	converted := make(map[string]string)
-	if context != nil {
-		if v, ok := context.(map[string]interface{}); ok {
-			for k, n := range v {
-				if s, okB := n.(string); okB {
-					converted[k] = s
-				}
-			}
-		}
-		if v, ok := context.(map[string]string); ok {
-			for k, n := range v {
-				converted[k] = n
-			}
-		}
-	}
-	return converted
+    converted := make(map[string]string)
+    if context != nil {
+        if v, ok := context.(map[string]interface{}); ok {
+            for k, n := range v {
+                if s, okB := n.(string); okB {
+                    converted[k] = s
+                }
+            }
+        }
+        if v, ok := context.(map[string]string); ok {
+            for k, n := range v {
+                converted[k] = n
+            }
+        }
+    }
+    return converted
 }
 
 // ConvertInterfaceToStringArray will convert an unknown input map type into a string array/slice
 func ConvertInterfaceToStringArray(raw interface{}) []string {
-	if vals, ok := raw.(map[string]interface{}); ok {
-		var s []string
-		for _, v := range vals {
-			if g, y := v.([]interface{}); y {
-				for _, q := range g {
-					s = append(s, fmt.Sprint(q))
-				}
-			}
-		}
-		return s
-	}
-	if vals, ok := raw.(map[string][]string); ok {
-		var s []string
-		for _, v := range vals {
-			s = append(s, v...)
-		}
-		return s
-	}
-	return nil
+    if vals, ok := raw.(map[string]interface{}); ok {
+        var s []string
+        for _, v := range vals {
+            if g, y := v.([]interface{}); y {
+                for _, q := range g {
+                    s = append(s, fmt.Sprint(q))
+                }
+            }
+        }
+        return s
+    }
+    if vals, ok := raw.(map[string][]string); ok {
+        var s []string
+        for _, v := range vals {
+            s = append(s, v...)
+        }
+        return s
+    }
+    return nil
 }
 
 // ConvertInterfaceArrayToStringArray will convert an unknown interface array type, into a string slice
 func ConvertInterfaceArrayToStringArray(raw interface{}) []string {
-	if vals, ok := raw.([]interface{}); ok {
-		s := make([]string, len(vals))
-		for i, v := range vals {
-			s[i] = fmt.Sprint(v)
-		}
-		return s
-	}
-	if vals, ok := raw.([]string); ok {
-		return vals
-	}
-	return nil
+    if vals, ok := raw.([]interface{}); ok {
+        s := make([]string, len(vals))
+        for i, v := range vals {
+            s[i] = fmt.Sprint(v)
+        }
+        return s
+    }
+    if vals, ok := raw.([]string); ok {
+        return vals
+    }
+    return nil
 }
 
 // ExtractValueFromInterfaceMap pulls out an unknown value from a map using a string key
 func ExtractValueFromInterfaceMap(name string, raw interface{}) interface{} {
 
-	if propMap, ok := raw.(map[string]interface{}); ok {
-		if props, okn := propMap[name].([]interface{}); okn {
-			return props
-		} else {
-			return propMap[name]
-		}
-	}
-	if propMap, ok := raw.(map[string][]string); ok {
-		return propMap[name]
-	}
+    if propMap, ok := raw.(map[string]interface{}); ok {
+        if props, okn := propMap[name].([]interface{}); okn {
+            return props
+        } else {
+            return propMap[name]
+        }
+    }
+    if propMap, ok := raw.(map[string][]string); ok {
+        return propMap[name]
+    }
 
-	return nil
+    return nil
 }
 
 // FindFirstKeyNode will locate the first key and value yaml.Node based on a key.
 func FindFirstKeyNode(key string, nodes []*yaml.Node, depth int) (keyNode *yaml.Node, valueNode *yaml.Node) {
-	if depth > 40 {
-		return nil, nil
-	}
-	for i, v := range nodes {
-		if key != "" && key == v.Value {
-			if i+1 >= len(nodes) {
-				return v, nodes[i] // this is the node we need.
-			}
-			return v, nodes[i+1] // next node is what we need.
-		}
-		if len(v.Content) > 0 {
-			depth++
-			x, y := FindFirstKeyNode(key, v.Content, depth)
-			if x != nil && y != nil {
-				return x, y
-			}
-		}
-	}
-	return nil, nil
+    if depth > 40 {
+        return nil, nil
+    }
+    for i, v := range nodes {
+        if key != "" && key == v.Value {
+            if i+1 >= len(nodes) {
+                return v, nodes[i] // this is the node we need.
+            }
+            return v, nodes[i+1] // next node is what we need.
+        }
+        if len(v.Content) > 0 {
+            depth++
+            x, y := FindFirstKeyNode(key, v.Content, depth)
+            if x != nil && y != nil {
+                return x, y
+            }
+        }
+    }
+    return nil, nil
 }
 
 // KeyNodeResult is a result from a KeyNodeSearch performed by the FindAllKeyNodesWithPath
 type KeyNodeResult struct {
-	KeyNode   *yaml.Node
-	ValueNode *yaml.Node
-	Parent    *yaml.Node
-	Path      []yaml.Node
+    KeyNode   *yaml.Node
+    ValueNode *yaml.Node
+    Parent    *yaml.Node
+    Path      []yaml.Node
 }
 
 // KeyNodeSearch keeps a track of everything we have found on our adventure down the trees.
 type KeyNodeSearch struct {
-	Key             string
-	Ignore          []string
-	Results         []*KeyNodeResult
-	AllowExtensions bool
+    Key             string
+    Ignore          []string
+    Results         []*KeyNodeResult
+    AllowExtensions bool
 }
 
 // FindKeyNodeTop is a non-recursive search of top level nodes for a key, will not look at content.
 // Returns the key and value
 func FindKeyNodeTop(key string, nodes []*yaml.Node) (keyNode *yaml.Node, valueNode *yaml.Node) {
-	for i, v := range nodes {
-		if i%2 != 0 {
-			continue
-		}
-		if strings.ToLower(key) == strings.ToLower(v.Value) {
-			return v, nodes[i+1] // next node is what we need.
-		}
-	}
-	return nil, nil
+    for i, v := range nodes {
+        if i%2 != 0 {
+            continue
+        }
+        if strings.ToLower(key) == strings.ToLower(v.Value) {
+            return v, nodes[i+1] // next node is what we need.
+        }
+    }
+    return nil, nil
 }
 
 // FindKeyNode is a non-recursive search of a *yaml.Node Content for a child node with a key.
 // Returns the key and value
 func FindKeyNode(key string, nodes []*yaml.Node) (keyNode *yaml.Node, valueNode *yaml.Node) {
 
-	//numNodes := len(nodes)
-	for i, v := range nodes {
-		if i%2 == 0 && key == v.Value {
-			return v, nodes[i+1] // next node is what we need.
-		}
-		for x, j := range v.Content {
-			if key == j.Value {
-				if IsNodeMap(v) {
-					if x+1 == len(v.Content) {
-						return v, v.Content[x]
-					}
-					return v, v.Content[x+1] // next node is what we need.
+    //numNodes := len(nodes)
+    for i, v := range nodes {
+        if i%2 == 0 && key == v.Value {
+            return v, nodes[i+1] // next node is what we need.
+        }
+        for x, j := range v.Content {
+            if key == j.Value {
+                if IsNodeMap(v) {
+                    if x+1 == len(v.Content) {
+                        return v, v.Content[x]
+                    }
+                    return v, v.Content[x+1] // next node is what we need.
 
-				}
-				if IsNodeArray(v) {
-					return v, v.Content[x]
-				}
-			}
-		}
-	}
-	return nil, nil
+                }
+                if IsNodeArray(v) {
+                    return v, v.Content[x]
+                }
+            }
+        }
+    }
+    return nil, nil
 }
 
 // FindKeyNodeFull is an overloaded version of FindKeyNode. This version however returns keys, labels and values.
 // generally different things are required from different node trees, so depending on what this function is looking at
 // it will return different things.
 func FindKeyNodeFull(key string, nodes []*yaml.Node) (keyNode *yaml.Node, labelNode *yaml.Node, valueNode *yaml.Node) {
-	for i := range nodes {
-		if i%2 == 0 && key == nodes[i].Value {
-			return nodes[i], nodes[i], nodes[i+1] // next node is what we need.
-		}
-	}
-	for _, v := range nodes {
-		for x := range v.Content {
-			if key == v.Content[x].Value {
-				if IsNodeMap(v) {
-					if x+1 == len(v.Content) {
-						return v, v.Content[x], v.Content[x]
-					}
-					return v, v.Content[x], v.Content[x+1]
-				}
-				if IsNodeArray(v) {
-					return v, v.Content[x], v.Content[x]
-				}
-			}
-		}
-	}
-	return nil, nil, nil
+    for i := range nodes {
+        if i%2 == 0 && key == nodes[i].Value {
+            return nodes[i], nodes[i], nodes[i+1] // next node is what we need.
+        }
+    }
+    for _, v := range nodes {
+        for x := range v.Content {
+            if key == v.Content[x].Value {
+                if IsNodeMap(v) {
+                    if x+1 == len(v.Content) {
+                        return v, v.Content[x], v.Content[x]
+                    }
+                    return v, v.Content[x], v.Content[x+1]
+                }
+                if IsNodeArray(v) {
+                    return v, v.Content[x], v.Content[x]
+                }
+            }
+        }
+    }
+    return nil, nil, nil
 }
 
 // FindKeyNodeFullTop is an overloaded version of FindKeyNodeFull. This version only looks at the top
 // level of the node and not the children.
 func FindKeyNodeFullTop(key string, nodes []*yaml.Node) (keyNode *yaml.Node, labelNode *yaml.Node, valueNode *yaml.Node) {
-	for i := range nodes {
-		if i%2 != 0 {
-			continue
-		}
-		if i%2 == 0 && key == nodes[i].Value {
-			return nodes[i], nodes[i], nodes[i+1] // next node is what we need.
-		}
-	}
-	return nil, nil, nil
+    for i := range nodes {
+        if i%2 != 0 {
+            continue
+        }
+        if i%2 == 0 && key == nodes[i].Value {
+            return nodes[i], nodes[i], nodes[i+1] // next node is what we need.
+        }
+    }
+    return nil, nil, nil
 }
 
 type ExtensionNode struct {
-	Key   *yaml.Node
-	Value *yaml.Node
+    Key   *yaml.Node
+    Value *yaml.Node
 }
 
 func FindExtensionNodes(nodes []*yaml.Node) []*ExtensionNode {
-	var extensions []*ExtensionNode
-	for i, v := range nodes {
-		if i%2 == 0 && strings.HasPrefix(v.Value, "x-") {
-			if i+1 < len(nodes) {
-				extensions = append(extensions, &ExtensionNode{
-					Key:   v,
-					Value: nodes[i+1],
-				})
-			}
-		}
-	}
-	return extensions
+    var extensions []*ExtensionNode
+    for i, v := range nodes {
+        if i%2 == 0 && strings.HasPrefix(v.Value, "x-") {
+            if i+1 < len(nodes) {
+                extensions = append(extensions, &ExtensionNode{
+                    Key:   v,
+                    Value: nodes[i+1],
+                })
+            }
+        }
+    }
+    return extensions
 }
 
 var ObjectLabel = "object"
@@ -315,299 +339,296 @@ var SchemaSource = "https://json-schema.org/draft/2020-12/schema"
 var SchemaId = "https://pb33f.io/openapi-changes/schema"
 
 func MakeTagReadable(node *yaml.Node) string {
-	switch node.Tag {
-	case "!!map":
-		return ObjectLabel
-	case "!!seq":
-		return ArrayLabel
-	case "!!str":
-		return StringLabel
-	case "!!int":
-		return IntegerLabel
-	case "!!float":
-		return NumberLabel
-	case "!!bool":
-		return BooleanLabel
-	}
-	return "unknown"
+    switch node.Tag {
+    case "!!map":
+        return ObjectLabel
+    case "!!seq":
+        return ArrayLabel
+    case "!!str":
+        return StringLabel
+    case "!!int":
+        return IntegerLabel
+    case "!!float":
+        return NumberLabel
+    case "!!bool":
+        return BooleanLabel
+    }
+    return "unknown"
 }
 
 // IsNodeMap checks if the node is a map type
 func IsNodeMap(node *yaml.Node) bool {
-	if node == nil {
-		return false
-	}
-	return node.Tag == "!!map"
+    if node == nil {
+        return false
+    }
+    return node.Tag == "!!map"
 }
 
 // IsNodePolyMorphic will return true if the node contains polymorphic keys.
 func IsNodePolyMorphic(node *yaml.Node) bool {
-	for i, v := range node.Content {
-		if i%2 == 0 {
-			if v.Value == "anyOf" || v.Value == "oneOf" || v.Value == "allOf" {
-				return true
-			}
-		}
-	}
-	return false
+    for i, v := range node.Content {
+        if i%2 == 0 {
+            if v.Value == "anyOf" || v.Value == "oneOf" || v.Value == "allOf" {
+                return true
+            }
+        }
+    }
+    return false
 }
 
 // IsNodeArray checks if a node is an array type
 func IsNodeArray(node *yaml.Node) bool {
-	if node == nil {
-		return false
-	}
-	return node.Tag == "!!seq"
+    if node == nil {
+        return false
+    }
+    return node.Tag == "!!seq"
 }
 
 // IsNodeStringValue checks if a node is a string value
 func IsNodeStringValue(node *yaml.Node) bool {
-	if node == nil {
-		return false
-	}
-	return node.Tag == "!!str"
+    if node == nil {
+        return false
+    }
+    return node.Tag == "!!str"
 }
 
 // IsNodeIntValue will check if a node is an int value
 func IsNodeIntValue(node *yaml.Node) bool {
-	if node == nil {
-		return false
-	}
-	return node.Tag == "!!int"
+    if node == nil {
+        return false
+    }
+    return node.Tag == "!!int"
 }
 
 // IsNodeFloatValue will check is a node is a float value.
 func IsNodeFloatValue(node *yaml.Node) bool {
-	if node == nil {
-		return false
-	}
-	return node.Tag == "!!float"
+    if node == nil {
+        return false
+    }
+    return node.Tag == "!!float"
 }
 
 // IsNodeBoolValue will check is a node is a bool
 func IsNodeBoolValue(node *yaml.Node) bool {
-	if node == nil {
-		return false
-	}
-	return node.Tag == "!!bool"
+    if node == nil {
+        return false
+    }
+    return node.Tag == "!!bool"
 }
 
 func IsNodeRefValue(node *yaml.Node) (bool, *yaml.Node, string) {
-	for i, r := range node.Content {
-		if i%2 == 0 {
-			if r.Value == "$ref" {
-				return true, r, node.Content[i+1].Value
-			}
-		}
-	}
-	return false, nil, ""
+    for i, r := range node.Content {
+        if i%2 == 0 {
+            if r.Value == "$ref" {
+                return true, r, node.Content[i+1].Value
+            }
+        }
+    }
+    return false, nil, ""
 }
 
 // FixContext will clean up a JSONpath string to be correctly traversable.
 func FixContext(context string) string {
-	tokens := strings.Split(context, ".")
-	var cleaned = []string{}
+    tokens := strings.Split(context, ".")
+    var cleaned = []string{}
 
-	for i, t := range tokens {
-		if v, err := strconv.Atoi(t); err == nil {
-			if v < 200 { // codes start here
-				if cleaned[i-1] != "" {
-					cleaned[i-1] += fmt.Sprintf("[%v]", t)
-				}
-			} else {
-				cleaned = append(cleaned, t)
-			}
-			continue
-		}
-		cleaned = append(cleaned, strings.ReplaceAll(t, "(root)", "$"))
-	}
+    for i, t := range tokens {
+        if v, err := strconv.Atoi(t); err == nil {
+            if v < 200 { // codes start here
+                if cleaned[i-1] != "" {
+                    cleaned[i-1] += fmt.Sprintf("[%v]", t)
+                }
+            } else {
+                cleaned = append(cleaned, t)
+            }
+            continue
+        }
+        cleaned = append(cleaned, strings.ReplaceAll(t, "(root)", "$"))
+    }
 
-	return strings.Join(cleaned, ".")
+    return strings.Join(cleaned, ".")
 }
 
 // IsJSON will tell you if a string is JSON or not.
 func IsJSON(testString string) bool {
-	if testString == "" {
-		return false
-	}
-	runes := []rune(strings.TrimSpace(testString))
-	if runes[0] == '{' && runes[len(runes)-1] == '}' {
-		return true
-	}
-	return false
+    if testString == "" {
+        return false
+    }
+    runes := []rune(strings.TrimSpace(testString))
+    if runes[0] == '{' && runes[len(runes)-1] == '}' {
+        return true
+    }
+    return false
 }
 
 // IsYAML will tell you if a string is YAML or not.
 func IsYAML(testString string) bool {
-	if testString == "" {
-		return false
-	}
-	if IsJSON(testString) {
-		return false
-	}
-	var n interface{}
-	err := yaml.Unmarshal([]byte(testString), &n)
-	if err != nil {
-		return false
-	}
-	_, err = yaml.Marshal(n)
-	return err == nil
+    if testString == "" {
+        return false
+    }
+    if IsJSON(testString) {
+        return false
+    }
+    var n interface{}
+    err := yaml.Unmarshal([]byte(testString), &n)
+    if err != nil {
+        return false
+    }
+    _, err = yaml.Marshal(n)
+    return err == nil
 }
 
 // ConvertYAMLtoJSON will do exactly what you think it will. It will deserialize YAML into serialized JSON.
 func ConvertYAMLtoJSON(yamlData []byte) ([]byte, error) {
-	var decodedYaml map[string]interface{}
-	err := yaml.Unmarshal(yamlData, &decodedYaml)
-	if err != nil {
-		return nil, err
-	}
-	// if the data can be decoded, it can be encoded (that's my view anyway). no need for an error check.
-	jsonData, _ := json.Marshal(decodedYaml)
-	return jsonData, nil
+    var decodedYaml map[string]interface{}
+    err := yaml.Unmarshal(yamlData, &decodedYaml)
+    if err != nil {
+        return nil, err
+    }
+    // if the data can be decoded, it can be encoded (that's my view anyway). no need for an error check.
+    jsonData, _ := json.Marshal(decodedYaml)
+    return jsonData, nil
 }
 
 // IsHttpVerb will check if an operation is valid or not.
 func IsHttpVerb(verb string) bool {
-	verbs := []string{"get", "post", "put", "patch", "delete", "options", "trace", "head"}
-	for _, v := range verbs {
-		if verb == v {
-			return true
-		}
-	}
-	return false
+    verbs := []string{"get", "post", "put", "patch", "delete", "options", "trace", "head"}
+    for _, v := range verbs {
+        if verb == v {
+            return true
+        }
+    }
+    return false
 }
 
 func ConvertComponentIdIntoFriendlyPathSearch(id string) (string, string) {
-	segs := strings.Split(id, "/")
-	name, _ := url.QueryUnescape(strings.ReplaceAll(segs[len(segs)-1], "~1", "/"))
-	var cleaned []string
+    segs := strings.Split(id, "/")
+    name, _ := url.QueryUnescape(strings.ReplaceAll(segs[len(segs)-1], "~1", "/"))
+    var cleaned []string
 
-	// check for strange spaces, chars and if found, wrap them up, clean them and create a new cleaned path.
-	for i := range segs {
-		reg, _ := regexp.MatchString("[%=;~.]", segs[i])
-		if reg {
-			segs[i], _ = url.QueryUnescape(strings.ReplaceAll(segs[i], "~1", "/"))
-			segs[i] = fmt.Sprintf("['%s']", segs[i])
-			if len(cleaned) > 0 {
-				cleaned[len(cleaned)-1] = fmt.Sprintf("%s%s", segs[i-1], segs[i])
-				continue
-			}
-		} else {
-			intVal, err := strconv.ParseInt(segs[i], 10, 32)
-			if err == nil && intVal <= 99 {
-				segs[i] = fmt.Sprintf("[%d]", intVal)
-				cleaned[len(cleaned)-1] = fmt.Sprintf("%s%s", cleaned[len(cleaned)-1], segs[i])
-				continue
-			}
-			if err == nil && intVal > 99 {
-				segs[i] = fmt.Sprintf("['%d']", intVal)
-				cleaned[len(cleaned)-1] = fmt.Sprintf("%s%s", cleaned[len(cleaned)-1], segs[i])
-				continue
-			}
-			cleaned = append(cleaned, segs[i])
-		}
-	}
-	_, err := strconv.ParseInt(name, 10, 32)
-	var replaced string
-	if err != nil {
-		replaced = strings.ReplaceAll(fmt.Sprintf("%s",
-			strings.Join(cleaned, ".")), "#", "$")
-	} else {
-		replaced = strings.ReplaceAll(fmt.Sprintf("%s",
-			strings.Join(cleaned, ".")), "#", "$")
-	}
+    // check for strange spaces, chars and if found, wrap them up, clean them and create a new cleaned path.
+    for i := range segs {
+        reg, _ := regexp.MatchString("[%=;~.]", segs[i])
+        if reg {
+            segs[i], _ = url.QueryUnescape(strings.ReplaceAll(segs[i], "~1", "/"))
+            segs[i] = fmt.Sprintf("['%s']", segs[i])
+            if len(cleaned) > 0 {
+                cleaned[len(cleaned)-1] = fmt.Sprintf("%s%s", segs[i-1], segs[i])
+                continue
+            }
+        } else {
+            intVal, err := strconv.ParseInt(segs[i], 10, 32)
+            if err == nil && intVal <= 99 {
+                segs[i] = fmt.Sprintf("[%d]", intVal)
+                cleaned[len(cleaned)-1] = fmt.Sprintf("%s%s", cleaned[len(cleaned)-1], segs[i])
+                continue
+            }
+            if err == nil && intVal > 99 {
+                segs[i] = fmt.Sprintf("['%d']", intVal)
+                cleaned[len(cleaned)-1] = fmt.Sprintf("%s%s", cleaned[len(cleaned)-1], segs[i])
+                continue
+            }
+            cleaned = append(cleaned, segs[i])
+        }
+    }
+    _, err := strconv.ParseInt(name, 10, 32)
+    var replaced string
+    if err != nil {
+        replaced = strings.ReplaceAll(fmt.Sprintf("%s",
+            strings.Join(cleaned, ".")), "#", "$")
+    } else {
+        replaced = strings.ReplaceAll(fmt.Sprintf("%s",
+            strings.Join(cleaned, ".")), "#", "$")
+    }
 
-	if len(replaced) > 0 {
-		if replaced[0] != '$' {
-			replaced = fmt.Sprintf("$%s", replaced)
-		}
-	}
-	return name, replaced
+    if len(replaced) > 0 {
+        if replaced[0] != '$' {
+            replaced = fmt.Sprintf("$%s", replaced)
+        }
+    }
+    return name, replaced
 }
 
 func ConvertComponentIdIntoPath(id string) (string, string) {
-	segs := strings.Split(id, "/")
-	name := segs[len(segs)-1]
+    segs := strings.Split(id, "/")
+    name := segs[len(segs)-1]
 
-	return name, strings.ReplaceAll(fmt.Sprintf("%s.%s",
-		strings.Join(segs[:len(segs)-1], "."), name), "#", "$")
+    return name, strings.ReplaceAll(fmt.Sprintf("%s.%s",
+        strings.Join(segs[:len(segs)-1], "."), name), "#", "$")
 }
 
 func RenderCodeSnippet(startNode *yaml.Node, specData []string, before, after int) string {
 
-	buf := new(strings.Builder)
+    buf := new(strings.Builder)
 
-	startLine := startNode.Line - before
-	endLine := startNode.Line + after
+    startLine := startNode.Line - before
+    endLine := startNode.Line + after
 
-	if startLine < 0 {
-		startLine = 0
-	}
+    if startLine < 0 {
+        startLine = 0
+    }
 
-	if endLine >= len(specData) {
-		endLine = len(specData) - 1
-	}
+    if endLine >= len(specData) {
+        endLine = len(specData) - 1
+    }
 
-	delta := endLine - startLine
+    delta := endLine - startLine
 
-	for i := 0; i < delta; i++ {
-		l := startLine + i
-		if l < len(specData) {
-			line := specData[l]
-			buf.WriteString(fmt.Sprintf("%s\n", line))
-		}
-	}
+    for i := 0; i < delta; i++ {
+        l := startLine + i
+        if l < len(specData) {
+            line := specData[l]
+            buf.WriteString(fmt.Sprintf("%s\n", line))
+        }
+    }
 
-	return buf.String()
+    return buf.String()
 }
 
 func DetectCase(input string) Case {
-	trim := strings.TrimSpace(input)
-	if trim == "" {
-		return UnknownCase
-	}
+    trim := strings.TrimSpace(input)
+    if trim == "" {
+        return UnknownCase
+    }
 
-	pascalCase := regexp.MustCompile("^[A-Z][a-z]+(?:[A-Z][a-z]+)*$")
-	camelCase := regexp.MustCompile("^[a-z]+(?:[A-Z][a-z]+)*$")
-	screamingSnakeCase := regexp.MustCompile("^[A-Z]+(_[A-Z]+)*$")
-	snakeCase := regexp.MustCompile("^[a-z]+(_[a-z]+)*$")
-	kebabCase := regexp.MustCompile("^[a-z]+(-[a-z]+)*$")
-	screamingKebabCase := regexp.MustCompile("^[A-Z]+(-[A-Z]+)*$")
-	if pascalCase.MatchString(trim) {
-		return PascalCase
-	}
-	if camelCase.MatchString(trim) {
-		return CamelCase
-	}
-	if screamingSnakeCase.MatchString(trim) {
-		return ScreamingSnakeCase
-	}
-	if snakeCase.MatchString(trim) {
-		return SnakeCase
-	}
-	if kebabCase.MatchString(trim) {
-		return KebabCase
-	}
-	if screamingKebabCase.MatchString(trim) {
-		return ScreamingKebabCase
-	}
-	return RegularCase
+    pascalCase := regexp.MustCompile("^[A-Z][a-z]+(?:[A-Z][a-z]+)*$")
+    camelCase := regexp.MustCompile("^[a-z]+(?:[A-Z][a-z]+)*$")
+    screamingSnakeCase := regexp.MustCompile("^[A-Z]+(_[A-Z]+)*$")
+    snakeCase := regexp.MustCompile("^[a-z]+(_[a-z]+)*$")
+    kebabCase := regexp.MustCompile("^[a-z]+(-[a-z]+)*$")
+    screamingKebabCase := regexp.MustCompile("^[A-Z]+(-[A-Z]+)*$")
+    if pascalCase.MatchString(trim) {
+        return PascalCase
+    }
+    if camelCase.MatchString(trim) {
+        return CamelCase
+    }
+    if screamingSnakeCase.MatchString(trim) {
+        return ScreamingSnakeCase
+    }
+    if snakeCase.MatchString(trim) {
+        return SnakeCase
+    }
+    if kebabCase.MatchString(trim) {
+        return KebabCase
+    }
+    if screamingKebabCase.MatchString(trim) {
+        return ScreamingKebabCase
+    }
+    return RegularCase
 }
 
 // CheckEnumForDuplicates will check an array of nodes to check if there are any duplicate values.
 func CheckEnumForDuplicates(seq []*yaml.Node) []*yaml.Node {
-	var res []*yaml.Node
-	seen := make(map[string]*yaml.Node)
+    var res []*yaml.Node
+    seen := make(map[string]*yaml.Node)
 
-	for _, enum := range seq {
-		if seen[enum.Value] != nil {
-			res = append(res, enum)
-			continue
-		}
-		seen[enum.Value] = enum
-	}
-	return res
+    for _, enum := range seq {
+        if seen[enum.Value] != nil {
+            res = append(res, enum)
+            continue
+        }
+        seen[enum.Value] = enum
+    }
+    return res
 }
-
-
-

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,11 +1,11 @@
 package utils
 
 import (
-	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
-	"io/ioutil"
-	"sync"
-	"testing"
+    "github.com/stretchr/testify/assert"
+    "gopkg.in/yaml.v3"
+    "io/ioutil"
+    "sync"
+    "testing"
 )
 
 type petstore []byte
@@ -13,745 +13,770 @@ type petstore []byte
 var once sync.Once
 
 var (
-	psBytes petstore
+    psBytes petstore
 )
 
 func getPetstore() petstore {
-	once.Do(func() {
-		psBytes, _ = ioutil.ReadFile("../test_specs/petstorev3.json")
-	})
-	return psBytes
+    once.Do(func() {
+        psBytes, _ = ioutil.ReadFile("../test_specs/petstorev3.json")
+    })
+    return psBytes
 }
 
 func TestRenderCodeSnippet(t *testing.T) {
-	code := []string{"hey", "ho", "let's", "go!"}
-	startNode := &yaml.Node{
-		Line: 1,
-	}
-	rendered := RenderCodeSnippet(startNode, code, 1, 3)
-	assert.Equal(t, "hey\nho\nlet's\n", rendered)
+    code := []string{"hey", "ho", "let's", "go!"}
+    startNode := &yaml.Node{
+        Line: 1,
+    }
+    rendered := RenderCodeSnippet(startNode, code, 1, 3)
+    assert.Equal(t, "hey\nho\nlet's\n", rendered)
 }
 
 func TestRenderCodeSnippet_BelowStart(t *testing.T) {
-	code := []string{"hey", "ho", "let's", "go!"}
-	startNode := &yaml.Node{
-		Line: 0,
-	}
-	rendered := RenderCodeSnippet(startNode, code, 1, 3)
-	assert.Equal(t, "hey\nho\nlet's\n", rendered)
+    code := []string{"hey", "ho", "let's", "go!"}
+    startNode := &yaml.Node{
+        Line: 0,
+    }
+    rendered := RenderCodeSnippet(startNode, code, 1, 3)
+    assert.Equal(t, "hey\nho\nlet's\n", rendered)
 }
 
 func TestFindNodes(t *testing.T) {
-	nodes, err := FindNodes(getPetstore(), "$.info.contact")
-	assert.NoError(t, err)
-	assert.NotNil(t, nodes)
-	assert.Len(t, nodes, 1)
+    nodes, err := FindNodes(getPetstore(), "$.info.contact")
+    assert.NoError(t, err)
+    assert.NotNil(t, nodes)
+    assert.Len(t, nodes, 1)
 }
 
 func TestFindNodes_BadPath(t *testing.T) {
-	nodes, err := FindNodes(getPetstore(), "I am not valid")
-	assert.Error(t, err)
-	assert.Nil(t, nodes)
+    nodes, err := FindNodes(getPetstore(), "I am not valid")
+    assert.Error(t, err)
+    assert.Nil(t, nodes)
 }
 
 func TestFindLastChildNode(t *testing.T) {
-	nodes, _ := FindNodes(getPetstore(), "$.info")
-	lastNode := FindLastChildNode(nodes[0])
-	assert.Equal(t, "1.0.11", lastNode.Value) // should be the version.
+    nodes, _ := FindNodes(getPetstore(), "$.info")
+    lastNode := FindLastChildNode(nodes[0])
+    assert.Equal(t, "1.0.11", lastNode.Value) // should be the version.
+    lastNodeDouble := FindLastChildNodeWithLevel(nodes[0], 0)
+    assert.Equal(t, lastNode, lastNodeDouble)
 }
 
 func TestFindLastChildNode_WithKids(t *testing.T) {
-	nodes, _ := FindNodes(getPetstore(), "$.paths./pet")
-	lastNode := FindLastChildNode(nodes[0])
-	assert.Equal(t, "read:pets", lastNode.Value)
+    nodes, _ := FindNodes(getPetstore(), "$.paths./pet")
+    lastNode := FindLastChildNode(nodes[0])
+    lastNodeDouble := FindLastChildNodeWithLevel(nodes[0], 0)
+    assert.Equal(t, lastNode, lastNodeDouble)
+    assert.Equal(t, "read:pets", lastNode.Value)
 }
 
 func TestFindLastChildNode_NotFound(t *testing.T) {
-	node := &yaml.Node{
-		Value: "same",
-	}
-	lastNode := FindLastChildNode(node)
-	assert.Equal(t, "same", lastNode.Value) // should be the same node
+    node := &yaml.Node{
+        Value: "same",
+    }
+    lastNode := FindLastChildNode(node)
+    assert.Equal(t, "same", lastNode.Value) // should be the same node
+    lastNodeDouble := FindLastChildNodeWithLevel(node, 0)
+    assert.Equal(t, lastNode, lastNodeDouble)
+}
+
+func genLoop(count int) *yaml.Node {
+    if count > 200 {
+        return nil
+    }
+    count++
+    return &yaml.Node{
+        Value: "same",
+        Content: []*yaml.Node{
+            genLoop(count),
+        },
+    }
+}
+
+func TestFindLastChildNode_TooDeep(t *testing.T) {
+    node := genLoop(0)
+    lastNodeDouble := FindLastChildNodeWithLevel(node, 0)
+    assert.NotNil(t, lastNodeDouble)
 }
 
 func TestBuildPath(t *testing.T) {
 
-	assert.Equal(t, "$.fresh.fish.and.chicken.nuggets",
-		BuildPath("$.fresh.fish", []string{"and", "chicken", "nuggets"}))
+    assert.Equal(t, "$.fresh.fish.and.chicken.nuggets",
+        BuildPath("$.fresh.fish", []string{"and", "chicken", "nuggets"}))
 }
 
 func TestBuildPath_WithTrailingPeriod(t *testing.T) {
 
-	assert.Equal(t, "$.fresh.fish.and.chicken.nuggets",
-		BuildPath("$.fresh.fish", []string{"and", "chicken", "nuggets", ""}))
+    assert.Equal(t, "$.fresh.fish.and.chicken.nuggets",
+        BuildPath("$.fresh.fish", []string{"and", "chicken", "nuggets", ""}))
 }
 
 func TestFindNodesWithoutDeserializing(t *testing.T) {
-	root, _ := FindNodes(getPetstore(), "$")
-	nodes, err := FindNodesWithoutDeserializing(root[0], "$.info.contact")
-	assert.NoError(t, err)
-	assert.NotNil(t, nodes)
-	assert.Len(t, nodes, 1)
+    root, _ := FindNodes(getPetstore(), "$")
+    nodes, err := FindNodesWithoutDeserializing(root[0], "$.info.contact")
+    assert.NoError(t, err)
+    assert.NotNil(t, nodes)
+    assert.Len(t, nodes, 1)
 }
 
 func TestFindNodesWithoutDeserializing_InvalidPath(t *testing.T) {
-	root, _ := FindNodes(getPetstore(), "$")
-	nodes, err := FindNodesWithoutDeserializing(root[0], "I love a good curry")
-	assert.Error(t, err)
-	assert.Nil(t, nodes)
+    root, _ := FindNodes(getPetstore(), "$")
+    nodes, err := FindNodesWithoutDeserializing(root[0], "I love a good curry")
+    assert.Error(t, err)
+    assert.Nil(t, nodes)
 }
 
 func TestConvertInterfaceIntoStringMap(t *testing.T) {
-	var d interface{}
-	n := make(map[string]string)
-	n["melody"] = "baby girl"
-	d = n
-	parsed := ConvertInterfaceIntoStringMap(d)
-	assert.Equal(t, "baby girl", parsed["melody"])
+    var d interface{}
+    n := make(map[string]string)
+    n["melody"] = "baby girl"
+    d = n
+    parsed := ConvertInterfaceIntoStringMap(d)
+    assert.Equal(t, "baby girl", parsed["melody"])
 }
 
 func TestConvertInterfaceIntoStringMap_NoType(t *testing.T) {
-	var d interface{}
-	n := make(map[string]interface{})
-	n["melody"] = "baby girl"
-	d = n
-	parsed := ConvertInterfaceIntoStringMap(d)
-	assert.Equal(t, "baby girl", parsed["melody"])
+    var d interface{}
+    n := make(map[string]interface{})
+    n["melody"] = "baby girl"
+    d = n
+    parsed := ConvertInterfaceIntoStringMap(d)
+    assert.Equal(t, "baby girl", parsed["melody"])
 }
 
 func TestConvertInterfaceToStringArray(t *testing.T) {
-	var d interface{}
-	n := make(map[string][]string)
-	n["melody"] = []string{"melody", "is", "my", "baby"}
-	d = n
-	parsed := ConvertInterfaceToStringArray(d)
-	assert.Equal(t, "baby", parsed[3])
+    var d interface{}
+    n := make(map[string][]string)
+    n["melody"] = []string{"melody", "is", "my", "baby"}
+    d = n
+    parsed := ConvertInterfaceToStringArray(d)
+    assert.Equal(t, "baby", parsed[3])
 }
 
 func TestConvertInterfaceToStringArray_NoType(t *testing.T) {
-	var d interface{}
-	m := make([]interface{}, 4)
-	n := make(map[string]interface{})
-	m[0] = "melody"
-	m[1] = "is"
-	m[2] = "my"
-	m[3] = "baby"
-	n["melody"] = m
-	d = n
-	parsed := ConvertInterfaceToStringArray(d)
-	assert.Equal(t, "baby", parsed[3])
+    var d interface{}
+    m := make([]interface{}, 4)
+    n := make(map[string]interface{})
+    m[0] = "melody"
+    m[1] = "is"
+    m[2] = "my"
+    m[3] = "baby"
+    n["melody"] = m
+    d = n
+    parsed := ConvertInterfaceToStringArray(d)
+    assert.Equal(t, "baby", parsed[3])
 }
 
 func TestConvertInterfaceToStringArray_Invalid(t *testing.T) {
-	var d interface{}
-	d = "I am a carrot"
-	parsed := ConvertInterfaceToStringArray(d)
-	assert.Nil(t, parsed)
+    var d interface{}
+    d = "I am a carrot"
+    parsed := ConvertInterfaceToStringArray(d)
+    assert.Nil(t, parsed)
 }
 
 func TestConvertInterfaceArrayToStringArray(t *testing.T) {
-	var d interface{}
-	m := []string{"maddox", "is", "my", "little", "champion"}
-	d = m
-	parsed := ConvertInterfaceArrayToStringArray(d)
-	assert.Equal(t, "little", parsed[3])
+    var d interface{}
+    m := []string{"maddox", "is", "my", "little", "champion"}
+    d = m
+    parsed := ConvertInterfaceArrayToStringArray(d)
+    assert.Equal(t, "little", parsed[3])
 }
 
 func TestConvertInterfaceArrayToStringArray_NoType(t *testing.T) {
-	var d interface{}
-	m := make([]interface{}, 4)
-	m[0] = "melody"
-	m[1] = "is"
-	m[2] = "my"
-	m[3] = "baby"
-	d = m
-	parsed := ConvertInterfaceArrayToStringArray(d)
-	assert.Equal(t, "baby", parsed[3])
+    var d interface{}
+    m := make([]interface{}, 4)
+    m[0] = "melody"
+    m[1] = "is"
+    m[2] = "my"
+    m[3] = "baby"
+    d = m
+    parsed := ConvertInterfaceArrayToStringArray(d)
+    assert.Equal(t, "baby", parsed[3])
 }
 
 func TestConvertInterfaceArrayToStringArray_Invalid(t *testing.T) {
-	var d interface{}
-	d = "weed is good"
-	parsed := ConvertInterfaceArrayToStringArray(d)
-	assert.Nil(t, parsed)
+    var d interface{}
+    d = "weed is good"
+    parsed := ConvertInterfaceArrayToStringArray(d)
+    assert.Nil(t, parsed)
 }
 
 func TestExtractValueFromInterfaceMap(t *testing.T) {
-	var d interface{}
-	m := make(map[string][]string)
-	m["melody"] = []string{"is", "my", "baby"}
-	d = m
-	parsed := ExtractValueFromInterfaceMap("melody", d)
-	assert.Equal(t, "baby", parsed.([]string)[2])
+    var d interface{}
+    m := make(map[string][]string)
+    m["melody"] = []string{"is", "my", "baby"}
+    d = m
+    parsed := ExtractValueFromInterfaceMap("melody", d)
+    assert.Equal(t, "baby", parsed.([]string)[2])
 }
 
 func TestExtractValueFromInterfaceMap_NoType(t *testing.T) {
-	var d interface{}
-	m := make(map[string]interface{})
-	n := make([]interface{}, 3)
-	n[0] = "maddy"
-	n[1] = "the"
-	n[2] = "champion"
-	m["maddy"] = n
-	d = m
-	parsed := ExtractValueFromInterfaceMap("maddy", d)
-	assert.Equal(t, "champion", parsed.([]interface{})[2])
+    var d interface{}
+    m := make(map[string]interface{})
+    n := make([]interface{}, 3)
+    n[0] = "maddy"
+    n[1] = "the"
+    n[2] = "champion"
+    m["maddy"] = n
+    d = m
+    parsed := ExtractValueFromInterfaceMap("maddy", d)
+    assert.Equal(t, "champion", parsed.([]interface{})[2])
 }
 
 func TestExtractValueFromInterfaceMap_Flat(t *testing.T) {
-	var d interface{}
-	m := make(map[string]interface{})
-	m["maddy"] = "niblet"
-	d = m
-	parsed := ExtractValueFromInterfaceMap("maddy", d)
-	assert.Equal(t, "niblet", parsed.(interface{}))
+    var d interface{}
+    m := make(map[string]interface{})
+    m["maddy"] = "niblet"
+    d = m
+    parsed := ExtractValueFromInterfaceMap("maddy", d)
+    assert.Equal(t, "niblet", parsed.(interface{}))
 }
 
 func TestExtractValueFromInterfaceMap_NotFound(t *testing.T) {
-	var d interface{}
-	d = "not a map"
-	parsed := ExtractValueFromInterfaceMap("melody", d)
-	assert.Nil(t, parsed)
+    var d interface{}
+    d = "not a map"
+    parsed := ExtractValueFromInterfaceMap("melody", d)
+    assert.Nil(t, parsed)
 }
 
 func TestFindFirstKeyNode(t *testing.T) {
-	nodes, _ := FindNodes(getPetstore(), "$")
-	key, value := FindFirstKeyNode("operationId", nodes, 0)
-	assert.NotNil(t, key)
-	assert.NotNil(t, value)
-	assert.Equal(t, 55, key.Line)
+    nodes, _ := FindNodes(getPetstore(), "$")
+    key, value := FindFirstKeyNode("operationId", nodes, 0)
+    assert.NotNil(t, key)
+    assert.NotNil(t, value)
+    assert.Equal(t, 55, key.Line)
 }
 
 func TestFindFirstKeyNode_NotFound(t *testing.T) {
-	nodes, _ := FindNodes(getPetstore(), "$")
-	key, value := FindFirstKeyNode("i-do-not-exist-in-the-doc", nodes, 0)
-	assert.Nil(t, key)
-	assert.Nil(t, value)
+    nodes, _ := FindNodes(getPetstore(), "$")
+    key, value := FindFirstKeyNode("i-do-not-exist-in-the-doc", nodes, 0)
+    assert.Nil(t, key)
+    assert.Nil(t, value)
 }
 
 func TestFindFirstKeyNode_TooDeep(t *testing.T) {
-	a, b := FindFirstKeyNode("", nil, 900)
-	assert.Nil(t, a)
-	assert.Nil(t, b)
+    a, b := FindFirstKeyNode("", nil, 900)
+    assert.Nil(t, a)
+    assert.Nil(t, b)
 }
 
 func TestFindFirstKeyNode_ValueIsKey(t *testing.T) {
 
-	a := &yaml.Node{
-		Value: "chicken",
-	}
+    a := &yaml.Node{
+        Value: "chicken",
+    }
 
-	b := &yaml.Node{
-		Value:   "nuggets",
-		Content: []*yaml.Node{a},
-	}
+    b := &yaml.Node{
+        Value:   "nuggets",
+        Content: []*yaml.Node{a},
+    }
 
-	c, d := FindFirstKeyNode("nuggets", []*yaml.Node{b}, 0)
-	assert.NotNil(t, c)
-	assert.NotNil(t, d)
-	assert.Equal(t, c, d)
+    c, d := FindFirstKeyNode("nuggets", []*yaml.Node{b}, 0)
+    assert.NotNil(t, c)
+    assert.NotNil(t, d)
+    assert.Equal(t, c, d)
 }
 
 func TestFindFirstKeyNode_Map(t *testing.T) {
-	nodes, _ := FindNodes(getPetstore(), "$")
-	key, value := FindFirstKeyNode("pet", nodes, 0)
-	assert.NotNil(t, key)
-	assert.NotNil(t, value)
-	assert.Equal(t, 27, key.Line)
+    nodes, _ := FindNodes(getPetstore(), "$")
+    key, value := FindFirstKeyNode("pet", nodes, 0)
+    assert.NotNil(t, key)
+    assert.NotNil(t, value)
+    assert.Equal(t, 27, key.Line)
 }
 
 func TestFindKeyNodeTop(t *testing.T) {
-	nodes, _ := FindNodes(getPetstore(), "$")
-	k, v := FindKeyNodeTop("info", nodes[0].Content)
-	assert.NotNil(t, k)
-	assert.NotNil(t, v)
-	assert.Equal(t, 3, k.Line)
+    nodes, _ := FindNodes(getPetstore(), "$")
+    k, v := FindKeyNodeTop("info", nodes[0].Content)
+    assert.NotNil(t, k)
+    assert.NotNil(t, v)
+    assert.Equal(t, 3, k.Line)
 }
 
 func TestFindKeyNodeTop_NotFound(t *testing.T) {
-	nodes, _ := FindNodes(getPetstore(), "$")
-	k, v := FindKeyNodeTop("i am a giant potato", nodes[0].Content)
-	assert.Nil(t, k)
-	assert.Nil(t, v)
+    nodes, _ := FindNodes(getPetstore(), "$")
+    k, v := FindKeyNodeTop("i am a giant potato", nodes[0].Content)
+    assert.Nil(t, k)
+    assert.Nil(t, v)
 }
 
 func TestFindKeyNode(t *testing.T) {
-	nodes, _ := FindNodes(getPetstore(), "$")
-	k, v := FindKeyNode("/pet", nodes[0].Content)
-	assert.NotNil(t, k)
-	assert.NotNil(t, v)
-	assert.Equal(t, 47, k.Line)
+    nodes, _ := FindNodes(getPetstore(), "$")
+    k, v := FindKeyNode("/pet", nodes[0].Content)
+    assert.NotNil(t, k)
+    assert.NotNil(t, v)
+    assert.Equal(t, 47, k.Line)
 }
 
 func TestFindKeyNode_ValueIsKey(t *testing.T) {
 
-	a := &yaml.Node{
-		Value: "chicken",
-	}
+    a := &yaml.Node{
+        Value: "chicken",
+    }
 
-	b := &yaml.Node{
-		Tag:     "!!map",
-		Value:   "nuggets",
-		Content: []*yaml.Node{a},
-	}
+    b := &yaml.Node{
+        Tag:     "!!map",
+        Value:   "nuggets",
+        Content: []*yaml.Node{a},
+    }
 
-	c, d := FindKeyNode("nuggets", []*yaml.Node{b, a})
-	assert.Equal(t, "nuggets", c.Value)
-	assert.Equal(t, "chicken", d.Value)
+    c, d := FindKeyNode("nuggets", []*yaml.Node{b, a})
+    assert.Equal(t, "nuggets", c.Value)
+    assert.Equal(t, "chicken", d.Value)
 
-	e := &yaml.Node{
-		Value: "pizza",
-	}
-	f := &yaml.Node{
-		Value: "pie",
-	}
-	b.Content = append(b.Content, e, f)
+    e := &yaml.Node{
+        Value: "pizza",
+    }
+    f := &yaml.Node{
+        Value: "pie",
+    }
+    b.Content = append(b.Content, e, f)
 
-	c, d = FindKeyNode("pie", []*yaml.Node{b, a})
-	assert.Equal(t, "nuggets", c.Value)
-	assert.Equal(t, "pie", d.Value)
+    c, d = FindKeyNode("pie", []*yaml.Node{b, a})
+    assert.Equal(t, "nuggets", c.Value)
+    assert.Equal(t, "pie", d.Value)
 
-	b.Tag = "!!seq"
+    b.Tag = "!!seq"
 
-	c, d = FindKeyNode("pie", []*yaml.Node{b, a})
-	assert.Equal(t, "nuggets", c.Value)
-	assert.Equal(t, "pie", d.Value)
+    c, d = FindKeyNode("pie", []*yaml.Node{b, a})
+    assert.Equal(t, "nuggets", c.Value)
+    assert.Equal(t, "pie", d.Value)
 
 }
 
 func TestFindExtensionNodes(t *testing.T) {
 
-	a := &yaml.Node{
-		Value: "x-coffee",
-	}
-	b := &yaml.Node{
-		Value: "required",
-	}
-	c := &yaml.Node{
-		Content: []*yaml.Node{a, b},
-	}
-	exts := FindExtensionNodes(c.Content)
-	assert.Len(t, exts, 1)
-	assert.Equal(t, "required", exts[0].Value.Value)
+    a := &yaml.Node{
+        Value: "x-coffee",
+    }
+    b := &yaml.Node{
+        Value: "required",
+    }
+    c := &yaml.Node{
+        Content: []*yaml.Node{a, b},
+    }
+    exts := FindExtensionNodes(c.Content)
+    assert.Len(t, exts, 1)
+    assert.Equal(t, "required", exts[0].Value.Value)
 
 }
 
 func TestFindKeyNodeFull(t *testing.T) {
 
-	a := &yaml.Node{
-		Value: "fish",
-	}
-	b := &yaml.Node{
-		Value: "paste",
-	}
+    a := &yaml.Node{
+        Value: "fish",
+    }
+    b := &yaml.Node{
+        Value: "paste",
+    }
 
-	c, d, e := FindKeyNodeFull("fish", []*yaml.Node{a, b})
-	assert.Equal(t, "fish", c.Value)
-	assert.Equal(t, "fish", d.Value)
-	assert.Equal(t, "paste", e.Value)
+    c, d, e := FindKeyNodeFull("fish", []*yaml.Node{a, b})
+    assert.Equal(t, "fish", c.Value)
+    assert.Equal(t, "fish", d.Value)
+    assert.Equal(t, "paste", e.Value)
 }
 
 func TestFindKeyNodeFull_MapValueIsLastNode(t *testing.T) {
 
-	f := &yaml.Node{
-		Value: "cheese",
-	}
-	h := &yaml.Node{
-		Tag:     "!!map",
-		Value:   "deserts", // this is invalid btw, but helps with mechanical understanding
-		Content: []*yaml.Node{f},
-	}
+    f := &yaml.Node{
+        Value: "cheese",
+    }
+    h := &yaml.Node{
+        Tag:     "!!map",
+        Value:   "deserts", // this is invalid btw, but helps with mechanical understanding
+        Content: []*yaml.Node{f},
+    }
 
-	c, d, e := FindKeyNodeFull("cheese", []*yaml.Node{h})
-	assert.Equal(t, "deserts", c.Value)
-	assert.Equal(t, "cheese", d.Value)
-	assert.Equal(t, "cheese", e.Value)
+    c, d, e := FindKeyNodeFull("cheese", []*yaml.Node{h})
+    assert.Equal(t, "deserts", c.Value)
+    assert.Equal(t, "cheese", d.Value)
+    assert.Equal(t, "cheese", e.Value)
 }
 
 func TestFindKeyNodeFull_Map(t *testing.T) {
 
-	f := &yaml.Node{
-		Value: "cheese",
-	}
-	g := &yaml.Node{
-		Value: "cake",
-	}
-	h := &yaml.Node{
-		Tag:     "!!map",
-		Value:   "deserts", // this is invalid btw, but helps with mechanical understanding
-		Content: []*yaml.Node{f, g},
-	}
+    f := &yaml.Node{
+        Value: "cheese",
+    }
+    g := &yaml.Node{
+        Value: "cake",
+    }
+    h := &yaml.Node{
+        Tag:     "!!map",
+        Value:   "deserts", // this is invalid btw, but helps with mechanical understanding
+        Content: []*yaml.Node{f, g},
+    }
 
-	c, d, e := FindKeyNodeFull("cheese", []*yaml.Node{h})
-	assert.Equal(t, "deserts", c.Value)
-	assert.Equal(t, "cheese", d.Value)
-	assert.Equal(t, "cake", e.Value)
+    c, d, e := FindKeyNodeFull("cheese", []*yaml.Node{h})
+    assert.Equal(t, "deserts", c.Value)
+    assert.Equal(t, "cheese", d.Value)
+    assert.Equal(t, "cake", e.Value)
 
 }
 
 func TestFindKeyNodeFull_Array(t *testing.T) {
 
-	f := &yaml.Node{
-		Value: "cheese",
-	}
-	g := &yaml.Node{
-		Value: "cake",
-	}
-	h := &yaml.Node{
-		Tag:     "!!seq",
-		Value:   "deserts", // this is invalid btw, but helps with mechanical understanding
-		Content: []*yaml.Node{f, g},
-	}
+    f := &yaml.Node{
+        Value: "cheese",
+    }
+    g := &yaml.Node{
+        Value: "cake",
+    }
+    h := &yaml.Node{
+        Tag:     "!!seq",
+        Value:   "deserts", // this is invalid btw, but helps with mechanical understanding
+        Content: []*yaml.Node{f, g},
+    }
 
-	c, d, e := FindKeyNodeFull("cheese", []*yaml.Node{h})
-	assert.Equal(t, "deserts", c.Value)
-	assert.Equal(t, "cheese", d.Value)
-	assert.Equal(t, "cheese", e.Value)
+    c, d, e := FindKeyNodeFull("cheese", []*yaml.Node{h})
+    assert.Equal(t, "deserts", c.Value)
+    assert.Equal(t, "cheese", d.Value)
+    assert.Equal(t, "cheese", e.Value)
 
 }
 
 func TestFindKeyNodeFull_Nothing(t *testing.T) {
-	c, d, e := FindKeyNodeFull("cheese", []*yaml.Node{})
-	assert.Nil(t, c)
-	assert.Nil(t, d)
-	assert.Nil(t, e)
+    c, d, e := FindKeyNodeFull("cheese", []*yaml.Node{})
+    assert.Nil(t, c)
+    assert.Nil(t, d)
+    assert.Nil(t, e)
 }
 
 func TestFindKeyNode_NotFound(t *testing.T) {
-	nodes, _ := FindNodes(getPetstore(), "$")
-	k, v := FindKeyNode("I am not anything at all", nodes[0].Content)
-	assert.Nil(t, k)
-	assert.Nil(t, v)
+    nodes, _ := FindNodes(getPetstore(), "$")
+    k, v := FindKeyNode("I am not anything at all", nodes[0].Content)
+    assert.Nil(t, k)
+    assert.Nil(t, v)
 }
 
 func TestFindKeyFullNodeTop(t *testing.T) {
-	a := &yaml.Node{
-		Value: "fish",
-	}
-	b := &yaml.Node{
-		Value: "paste",
-	}
+    a := &yaml.Node{
+        Value: "fish",
+    }
+    b := &yaml.Node{
+        Value: "paste",
+    }
 
-	c, d, e := FindKeyNodeFullTop("fish", []*yaml.Node{a, b})
-	assert.Equal(t, "fish", c.Value)
-	assert.Equal(t, "fish", d.Value)
-	assert.Equal(t, "paste", e.Value)
+    c, d, e := FindKeyNodeFullTop("fish", []*yaml.Node{a, b})
+    assert.Equal(t, "fish", c.Value)
+    assert.Equal(t, "fish", d.Value)
+    assert.Equal(t, "paste", e.Value)
 }
 
 func TestFindKeyFullNode_NotFound(t *testing.T) {
-	a := &yaml.Node{
-		Value: "fish",
-	}
-	b := &yaml.Node{
-		Value: "paste",
-	}
+    a := &yaml.Node{
+        Value: "fish",
+    }
+    b := &yaml.Node{
+        Value: "paste",
+    }
 
-	c, d, e := FindKeyNodeFullTop("lemons", []*yaml.Node{a, b})
-	assert.Nil(t, c)
-	assert.Nil(t, d)
-	assert.Nil(t, e)
+    c, d, e := FindKeyNodeFullTop("lemons", []*yaml.Node{a, b})
+    assert.Nil(t, c)
+    assert.Nil(t, d)
+    assert.Nil(t, e)
 }
 
 func TestMakeTagReadable(t *testing.T) {
-	n := &yaml.Node{
-		Tag: "!!map",
-	}
-	assert.Equal(t, ObjectLabel, MakeTagReadable(n))
-	n.Tag = "!!seq"
-	assert.Equal(t, ArrayLabel, MakeTagReadable(n))
-	n.Tag = "!!str"
-	assert.Equal(t, StringLabel, MakeTagReadable(n))
-	n.Tag = "!!int"
-	assert.Equal(t, IntegerLabel, MakeTagReadable(n))
-	n.Tag = "!!float"
-	assert.Equal(t, NumberLabel, MakeTagReadable(n))
-	n.Tag = "!!bool"
-	assert.Equal(t, BooleanLabel, MakeTagReadable(n))
-	n.Tag = "mr potato man is here"
-	assert.Equal(t, "unknown", MakeTagReadable(n))
+    n := &yaml.Node{
+        Tag: "!!map",
+    }
+    assert.Equal(t, ObjectLabel, MakeTagReadable(n))
+    n.Tag = "!!seq"
+    assert.Equal(t, ArrayLabel, MakeTagReadable(n))
+    n.Tag = "!!str"
+    assert.Equal(t, StringLabel, MakeTagReadable(n))
+    n.Tag = "!!int"
+    assert.Equal(t, IntegerLabel, MakeTagReadable(n))
+    n.Tag = "!!float"
+    assert.Equal(t, NumberLabel, MakeTagReadable(n))
+    n.Tag = "!!bool"
+    assert.Equal(t, BooleanLabel, MakeTagReadable(n))
+    n.Tag = "mr potato man is here"
+    assert.Equal(t, "unknown", MakeTagReadable(n))
 }
 
 func TestIsNodeMap(t *testing.T) {
-	n := &yaml.Node{
-		Tag: "!!map",
-	}
-	assert.True(t, IsNodeMap(n))
-	n.Tag = "!!pizza"
-	assert.False(t, IsNodeMap(n))
+    n := &yaml.Node{
+        Tag: "!!map",
+    }
+    assert.True(t, IsNodeMap(n))
+    n.Tag = "!!pizza"
+    assert.False(t, IsNodeMap(n))
 }
 
 func TestIsNodeMap_Nil(t *testing.T) {
-	assert.False(t, IsNodeMap(nil))
+    assert.False(t, IsNodeMap(nil))
 }
 
 func TestIsNodePolyMorphic(t *testing.T) {
-	n := &yaml.Node{
-		Content: []*yaml.Node{
-			{
-				Value: "anyOf",
-			},
-		},
-	}
-	assert.True(t, IsNodePolyMorphic(n))
-	n.Content[0].Value = "cakes"
-	assert.False(t, IsNodePolyMorphic(n))
+    n := &yaml.Node{
+        Content: []*yaml.Node{
+            {
+                Value: "anyOf",
+            },
+        },
+    }
+    assert.True(t, IsNodePolyMorphic(n))
+    n.Content[0].Value = "cakes"
+    assert.False(t, IsNodePolyMorphic(n))
 }
 
 func TestIsNodeArray(t *testing.T) {
-	n := &yaml.Node{
-		Tag: "!!seq",
-	}
-	assert.True(t, IsNodeArray(n))
-	n.Tag = "!!pizza"
-	assert.False(t, IsNodeArray(n))
+    n := &yaml.Node{
+        Tag: "!!seq",
+    }
+    assert.True(t, IsNodeArray(n))
+    n.Tag = "!!pizza"
+    assert.False(t, IsNodeArray(n))
 }
 
 func TestIsNodeArray_Nil(t *testing.T) {
-	assert.False(t, IsNodeArray(nil))
+    assert.False(t, IsNodeArray(nil))
 }
 
 func TestIsNodeStringValue(t *testing.T) {
-	n := &yaml.Node{
-		Tag: "!!str",
-	}
-	assert.True(t, IsNodeStringValue(n))
-	n.Tag = "!!pizza"
-	assert.False(t, IsNodeStringValue(n))
+    n := &yaml.Node{
+        Tag: "!!str",
+    }
+    assert.True(t, IsNodeStringValue(n))
+    n.Tag = "!!pizza"
+    assert.False(t, IsNodeStringValue(n))
 }
 
 func TestIsNodeStringValue_Nil(t *testing.T) {
-	assert.False(t, IsNodeStringValue(nil))
+    assert.False(t, IsNodeStringValue(nil))
 }
 
 func TestIsNodeIntValue(t *testing.T) {
-	n := &yaml.Node{
-		Tag: "!!int",
-	}
-	assert.True(t, IsNodeIntValue(n))
-	n.Tag = "!!pizza"
-	assert.False(t, IsNodeIntValue(n))
+    n := &yaml.Node{
+        Tag: "!!int",
+    }
+    assert.True(t, IsNodeIntValue(n))
+    n.Tag = "!!pizza"
+    assert.False(t, IsNodeIntValue(n))
 }
 
 func TestIsNodeIntValue_Nil(t *testing.T) {
-	assert.False(t, IsNodeIntValue(nil))
+    assert.False(t, IsNodeIntValue(nil))
 }
 
 func TestIsNodeFloatValue(t *testing.T) {
-	n := &yaml.Node{
-		Tag: "!!float",
-	}
-	assert.True(t, IsNodeFloatValue(n))
-	n.Tag = "!!pizza"
-	assert.False(t, IsNodeFloatValue(n))
+    n := &yaml.Node{
+        Tag: "!!float",
+    }
+    assert.True(t, IsNodeFloatValue(n))
+    n.Tag = "!!pizza"
+    assert.False(t, IsNodeFloatValue(n))
 }
 
 func TestIsNodeFloatValue_Nil(t *testing.T) {
-	assert.False(t, IsNodeFloatValue(nil))
+    assert.False(t, IsNodeFloatValue(nil))
 }
 
 func TestIsNodeBoolValue(t *testing.T) {
-	n := &yaml.Node{
-		Tag: "!!bool",
-	}
-	assert.True(t, IsNodeBoolValue(n))
-	n.Tag = "!!pizza"
-	assert.False(t, IsNodeBoolValue(n))
+    n := &yaml.Node{
+        Tag: "!!bool",
+    }
+    assert.True(t, IsNodeBoolValue(n))
+    n.Tag = "!!pizza"
+    assert.False(t, IsNodeBoolValue(n))
 }
 
 func TestIsNodeBoolValue_Nil(t *testing.T) {
-	assert.False(t, IsNodeBoolValue(nil))
+    assert.False(t, IsNodeBoolValue(nil))
 }
 
 func TestFixContext(t *testing.T) {
-	assert.Equal(t, "$.nuggets[12].name", FixContext("(root).nuggets.12.name"))
+    assert.Equal(t, "$.nuggets[12].name", FixContext("(root).nuggets.12.name"))
 }
 
 func TestFixContext_HttpCode(t *testing.T) {
-	assert.Equal(t, "$.nuggets.404.name", FixContext("(root).nuggets.404.name"))
+    assert.Equal(t, "$.nuggets.404.name", FixContext("(root).nuggets.404.name"))
 }
 
 func TestIsJSON(t *testing.T) {
-	assert.True(t, IsJSON("{'hello':'there'}"))
-	assert.False(t, IsJSON("potato shoes"))
-	assert.False(t, IsJSON(""))
+    assert.True(t, IsJSON("{'hello':'there'}"))
+    assert.False(t, IsJSON("potato shoes"))
+    assert.False(t, IsJSON(""))
 }
 
 func TestIsYAML(t *testing.T) {
-	assert.True(t, IsYAML("hello:\n  there:\n    my-name: is quobix"))
-	assert.True(t, IsYAML("potato shoes"))
-	assert.False(t, IsYAML("{'hello':'there'}"))
-	assert.False(t, IsYAML(""))
-	assert.False(t, IsYAML("8908: hello: yeah: \n12309812: :123"))
+    assert.True(t, IsYAML("hello:\n  there:\n    my-name: is quobix"))
+    assert.True(t, IsYAML("potato shoes"))
+    assert.False(t, IsYAML("{'hello':'there'}"))
+    assert.False(t, IsYAML(""))
+    assert.False(t, IsYAML("8908: hello: yeah: \n12309812: :123"))
 }
 
 func TestConvertYAMLtoJSON(t *testing.T) {
-	str, err := ConvertYAMLtoJSON([]byte("hello: there"))
-	assert.NoError(t, err)
-	assert.NotNil(t, str)
-	assert.Equal(t, "{\"hello\":\"there\"}", string(str))
+    str, err := ConvertYAMLtoJSON([]byte("hello: there"))
+    assert.NoError(t, err)
+    assert.NotNil(t, str)
+    assert.Equal(t, "{\"hello\":\"there\"}", string(str))
 
-	str, err = ConvertYAMLtoJSON([]byte("gonna: break: you:\nyeah:yeah:yeah"))
-	assert.Error(t, err)
-	assert.Nil(t, str)
+    str, err = ConvertYAMLtoJSON([]byte("gonna: break: you:\nyeah:yeah:yeah"))
+    assert.Error(t, err)
+    assert.Nil(t, str)
 }
 
 func TestIsHttpVerb(t *testing.T) {
-	assert.True(t, IsHttpVerb("get"))
-	assert.True(t, IsHttpVerb("post"))
-	assert.False(t, IsHttpVerb("nuggets"))
+    assert.True(t, IsHttpVerb("get"))
+    assert.True(t, IsHttpVerb("post"))
+    assert.False(t, IsHttpVerb("nuggets"))
 }
 
 func TestConvertComponentIdIntoFriendlyPathSearch(t *testing.T) {
-	segment, path := ConvertComponentIdIntoFriendlyPathSearch("#/chicken/chips/pizza/cake")
-	assert.Equal(t, "$.chicken.chips.pizza.cake", path)
-	assert.Equal(t, "cake", segment)
+    segment, path := ConvertComponentIdIntoFriendlyPathSearch("#/chicken/chips/pizza/cake")
+    assert.Equal(t, "$.chicken.chips.pizza.cake", path)
+    assert.Equal(t, "cake", segment)
 }
 
 func TestConvertComponentIdIntoFriendlyPathSearch_SuperCrazy(t *testing.T) {
-	segment, path := ConvertComponentIdIntoFriendlyPathSearch("#/paths/~1crazy~1ass~1references/get/responses/404/content/application~1xml;%20charset=utf-8/schema")
-	assert.Equal(t, "$.paths['/crazy/ass/references'].get.responses['404'].content['application/xml; charset=utf-8'].schema", path)
-	assert.Equal(t, "schema", segment)
+    segment, path := ConvertComponentIdIntoFriendlyPathSearch("#/paths/~1crazy~1ass~1references/get/responses/404/content/application~1xml;%20charset=utf-8/schema")
+    assert.Equal(t, "$.paths['/crazy/ass/references'].get.responses['404'].content['application/xml; charset=utf-8'].schema", path)
+    assert.Equal(t, "schema", segment)
 
 }
 
 func TestConvertComponentIdIntoFriendlyPathSearch_Crazy(t *testing.T) {
-	segment, path := ConvertComponentIdIntoFriendlyPathSearch("#/components/schemas/gpg-key/properties/subkeys/example/0/expires_at")
-	assert.Equal(t, "$.components.schemas.gpg-key.properties.subkeys.example[0].expires_at", path)
-	assert.Equal(t, "expires_at", segment)
+    segment, path := ConvertComponentIdIntoFriendlyPathSearch("#/components/schemas/gpg-key/properties/subkeys/example/0/expires_at")
+    assert.Equal(t, "$.components.schemas.gpg-key.properties.subkeys.example[0].expires_at", path)
+    assert.Equal(t, "expires_at", segment)
 }
 
 func TestConvertComponentIdIntoFriendlyPathSearch_Simple(t *testing.T) {
-	segment, path := ConvertComponentIdIntoFriendlyPathSearch("#/~1fresh~1pizza/get")
-	assert.Equal(t, "$['/fresh/pizza'].get", path)
-	assert.Equal(t, "get", segment)
+    segment, path := ConvertComponentIdIntoFriendlyPathSearch("#/~1fresh~1pizza/get")
+    assert.Equal(t, "$['/fresh/pizza'].get", path)
+    assert.Equal(t, "get", segment)
 }
 
 func TestConvertComponentIdIntoFriendlyPathSearch_Params(t *testing.T) {
-	segment, path := ConvertComponentIdIntoFriendlyPathSearch("#/why/0")
-	assert.Equal(t, "$.why[0]", path)
-	assert.Equal(t, "0", segment)
+    segment, path := ConvertComponentIdIntoFriendlyPathSearch("#/why/0")
+    assert.Equal(t, "$.why[0]", path)
+    assert.Equal(t, "0", segment)
 }
 
 func TestConvertComponentIdIntoFriendlyPathSearch_Crazy_Github(t *testing.T) {
-	segment, path := ConvertComponentIdIntoFriendlyPathSearch("#/paths/~1crazy~1ass~1references/get/responses/404/content/application~1xml;%20charset=utf-8/schema")
-	assert.Equal(t, "$.paths['/crazy/ass/references'].get.responses['404'].content['application/xml; charset=utf-8'].schema", path)
-	assert.Equal(t, "schema", segment)
+    segment, path := ConvertComponentIdIntoFriendlyPathSearch("#/paths/~1crazy~1ass~1references/get/responses/404/content/application~1xml;%20charset=utf-8/schema")
+    assert.Equal(t, "$.paths['/crazy/ass/references'].get.responses['404'].content['application/xml; charset=utf-8'].schema", path)
+    assert.Equal(t, "schema", segment)
 }
 
 func TestConvertComponentIdIntoFriendlyPathSearch_Crazy_DigitalOcean(t *testing.T) {
-	segment, path := ConvertComponentIdIntoFriendlyPathSearch("#/paths/~1v2~1customers~1my~1invoices~1%7Binvoice_uuid%7D/get/parameters/0")
-	assert.Equal(t, "$.paths['/v2/customers/my/invoices/{invoice_uuid}'].get.parameters[0]", path)
-	assert.Equal(t, "0", segment)
+    segment, path := ConvertComponentIdIntoFriendlyPathSearch("#/paths/~1v2~1customers~1my~1invoices~1%7Binvoice_uuid%7D/get/parameters/0")
+    assert.Equal(t, "$.paths['/v2/customers/my/invoices/{invoice_uuid}'].get.parameters[0]", path)
+    assert.Equal(t, "0", segment)
 }
 
 func TestConvertComponentIdIntoFriendlyPathSearch_Crazy_DigitalOcean_More(t *testing.T) {
-	segment, path := ConvertComponentIdIntoFriendlyPathSearch("#/paths/~1v2~1certificates/post/responses/201/content/application~1json/examples/Custom%20Certificate")
-	assert.Equal(t, "$.paths['/v2/certificates'].post.responses['201'].content['application/json'].examples['Custom Certificate']", path)
-	assert.Equal(t, "Custom Certificate", segment)
+    segment, path := ConvertComponentIdIntoFriendlyPathSearch("#/paths/~1v2~1certificates/post/responses/201/content/application~1json/examples/Custom%20Certificate")
+    assert.Equal(t, "$.paths['/v2/certificates'].post.responses['201'].content['application/json'].examples['Custom Certificate']", path)
+    assert.Equal(t, "Custom Certificate", segment)
 }
 
 func TestConvertComponentIdIntoFriendlyPathSearch_CrazyShort(t *testing.T) {
-	segment, path := ConvertComponentIdIntoFriendlyPathSearch("#/paths/~1crazy~1ass~1references")
-	assert.Equal(t, "$.paths['/crazy/ass/references']", path)
-	assert.Equal(t, "/crazy/ass/references", segment)
+    segment, path := ConvertComponentIdIntoFriendlyPathSearch("#/paths/~1crazy~1ass~1references")
+    assert.Equal(t, "$.paths['/crazy/ass/references']", path)
+    assert.Equal(t, "/crazy/ass/references", segment)
 }
 
 func TestConvertComponentIdIntoFriendlyPathSearch_Short(t *testing.T) {
-	segment, path := ConvertComponentIdIntoFriendlyPathSearch("/~1crazy~1ass~1references")
-	assert.Equal(t, "$['/crazy/ass/references']", path)
-	assert.Equal(t, "/crazy/ass/references", segment)
+    segment, path := ConvertComponentIdIntoFriendlyPathSearch("/~1crazy~1ass~1references")
+    assert.Equal(t, "$['/crazy/ass/references']", path)
+    assert.Equal(t, "/crazy/ass/references", segment)
 }
 
 func TestConvertComponentIdIntoFriendlyPathSearch_Array(t *testing.T) {
-	segment, path := ConvertComponentIdIntoFriendlyPathSearch("#/paths/~1crazy~1ass~1references/get/parameters/0")
-	assert.Equal(t, "$.paths['/crazy/ass/references'].get.parameters[0]", path)
-	assert.Equal(t, "0", segment)
+    segment, path := ConvertComponentIdIntoFriendlyPathSearch("#/paths/~1crazy~1ass~1references/get/parameters/0")
+    assert.Equal(t, "$.paths['/crazy/ass/references'].get.parameters[0]", path)
+    assert.Equal(t, "0", segment)
 }
 
 func TestConvertComponentIdIntoFriendlyPathSearch_HTTPCode(t *testing.T) {
-	segment, path := ConvertComponentIdIntoFriendlyPathSearch("#/paths/~1crazy~1ass~1references/get/responses/404")
-	assert.Equal(t, "$.paths['/crazy/ass/references'].get.responses['404']", path)
-	assert.Equal(t, "404", segment)
+    segment, path := ConvertComponentIdIntoFriendlyPathSearch("#/paths/~1crazy~1ass~1references/get/responses/404")
+    assert.Equal(t, "$.paths['/crazy/ass/references'].get.responses['404']", path)
+    assert.Equal(t, "404", segment)
 }
 
 func TestConvertComponentIdIntoPath(t *testing.T) {
-	segment, path := ConvertComponentIdIntoPath("#/chicken/chips/pizza/cake")
-	assert.Equal(t, "$.chicken.chips.pizza.cake", path)
-	assert.Equal(t, "cake", segment)
+    segment, path := ConvertComponentIdIntoPath("#/chicken/chips/pizza/cake")
+    assert.Equal(t, "$.chicken.chips.pizza.cake", path)
+    assert.Equal(t, "cake", segment)
 }
 
 func TestDetectCase(t *testing.T) {
-	assert.Equal(t, PascalCase, DetectCase("PizzaPie"))
-	assert.Equal(t, CamelCase, DetectCase("anyoneForTennis"))
-	assert.Equal(t, ScreamingSnakeCase, DetectCase("I_LOVE_BEER"))
-	assert.Equal(t, ScreamingKebabCase, DetectCase("I-LOVE-BURGERS"))
-	assert.Equal(t, SnakeCase, DetectCase("snakes_on_a_plane"))
-	assert.Equal(t, KebabCase, DetectCase("chicken-be-be-beef-or-pork"))
-	assert.Equal(t, RegularCase, DetectCase("kebab-TimeIn_london-TOWN"))
-	assert.Equal(t, UnknownCase, DetectCase(""))
+    assert.Equal(t, PascalCase, DetectCase("PizzaPie"))
+    assert.Equal(t, CamelCase, DetectCase("anyoneForTennis"))
+    assert.Equal(t, ScreamingSnakeCase, DetectCase("I_LOVE_BEER"))
+    assert.Equal(t, ScreamingKebabCase, DetectCase("I-LOVE-BURGERS"))
+    assert.Equal(t, SnakeCase, DetectCase("snakes_on_a_plane"))
+    assert.Equal(t, KebabCase, DetectCase("chicken-be-be-beef-or-pork"))
+    assert.Equal(t, RegularCase, DetectCase("kebab-TimeIn_london-TOWN"))
+    assert.Equal(t, UnknownCase, DetectCase(""))
 }
 
 func TestIsNodeRefValue(t *testing.T) {
 
-	f := &yaml.Node{
-		Value: "$ref",
-	}
-	g := &yaml.Node{
-		Value: "'#/somewhere/out-there'",
-	}
-	h := &yaml.Node{
-		Tag:     "!!map",
-		Content: []*yaml.Node{f, g},
-	}
+    f := &yaml.Node{
+        Value: "$ref",
+    }
+    g := &yaml.Node{
+        Value: "'#/somewhere/out-there'",
+    }
+    h := &yaml.Node{
+        Tag:     "!!map",
+        Content: []*yaml.Node{f, g},
+    }
 
-	ref, node, val := IsNodeRefValue(h)
+    ref, node, val := IsNodeRefValue(h)
 
-	assert.True(t, ref)
-	assert.Equal(t, "$ref", node.Value)
-	assert.Equal(t, "'#/somewhere/out-there'", val)
+    assert.True(t, ref)
+    assert.Equal(t, "$ref", node.Value)
+    assert.Equal(t, "'#/somewhere/out-there'", val)
 
 }
 
 func TestIsNodeRefValue_False(t *testing.T) {
 
-	f := &yaml.Node{
-		Value: "woof",
-	}
-	g := &yaml.Node{
-		Value: "dog",
-	}
-	h := &yaml.Node{
-		Tag:     "!!map",
-		Content: []*yaml.Node{f, g},
-	}
+    f := &yaml.Node{
+        Value: "woof",
+    }
+    g := &yaml.Node{
+        Value: "dog",
+    }
+    h := &yaml.Node{
+        Tag:     "!!map",
+        Content: []*yaml.Node{f, g},
+    }
 
-	ref, node, val := IsNodeRefValue(h)
+    ref, node, val := IsNodeRefValue(h)
 
-	assert.False(t, ref)
-	assert.Nil(t, node)
-	assert.Empty(t, val)
+    assert.False(t, ref)
+    assert.Nil(t, node)
+    assert.Empty(t, val)
 }
 
 func TestCheckEnumForDuplicates_Success(t *testing.T) {
-	yml := "- yes\n- no\n- crisps"
-	var rootNode yaml.Node
-	yaml.Unmarshal([]byte(yml), &rootNode)
-	assert.Len(t, CheckEnumForDuplicates(rootNode.Content[0].Content), 0)
+    yml := "- yes\n- no\n- crisps"
+    var rootNode yaml.Node
+    yaml.Unmarshal([]byte(yml), &rootNode)
+    assert.Len(t, CheckEnumForDuplicates(rootNode.Content[0].Content), 0)
 
 }
 
 func TestCheckEnumForDuplicates_Fail(t *testing.T) {
-	yml := "- yes\n- no\n- crisps\n- no"
-	var rootNode yaml.Node
-	yaml.Unmarshal([]byte(yml), &rootNode)
-	assert.Len(t, CheckEnumForDuplicates(rootNode.Content[0].Content), 1)
+    yml := "- yes\n- no\n- crisps\n- no"
+    var rootNode yaml.Node
+    yaml.Unmarshal([]byte(yml), &rootNode)
+    assert.Len(t, CheckEnumForDuplicates(rootNode.Content[0].Content), 1)
 
 }
 
 func TestCheckEnumForDuplicates_FailMultiple(t *testing.T) {
-	yml := "- yes\n- no\n- crisps\n- no\n- rice\n- yes\n- no"
+    yml := "- yes\n- no\n- crisps\n- no\n- rice\n- yes\n- no"
 
-	var rootNode yaml.Node
-	yaml.Unmarshal([]byte(yml), &rootNode)
-	assert.Len(t, CheckEnumForDuplicates(rootNode.Content[0].Content), 3)
+    var rootNode yaml.Node
+    yaml.Unmarshal([]byte(yml), &rootNode)
+    assert.Len(t, CheckEnumForDuplicates(rootNode.Content[0].Content), 3)
 }


### PR DESCRIPTION
UniqueValues was marked as an integer, not a boolean. Some other tweaks and tunes after cleaning up vacuum.

Numbers and integers are now correctly handled with some places. A number of primitives were being rendered back out as strings, which when read back in down stream, was causing some validation issues. 
