### PR TITLE
Added new extraction functions to control extensions

### DIFF
--- a/datamodel/low/extraction_functions_test.go
+++ b/datamodel/low/extraction_functions_test.go
@@ -973,6 +973,106 @@ one:
 
 }
 
+func TestExtractMap_NoLookupWithExtensions(t *testing.T) {
+
+	yml := `components:`
+
+	var idxNode yaml.Node
+	mErr := yaml.Unmarshal([]byte(yml), &idxNode)
+	assert.NoError(t, mErr)
+	idx := index.NewSpecIndex(&idxNode)
+
+	yml = `x-hey: you
+one:
+  x-choo: choo`
+
+	var cNode yaml.Node
+	e := yaml.Unmarshal([]byte(yml), &cNode)
+	assert.NoError(t, e)
+
+	things, err := ExtractMapNoLookupExtensions[*test_Good](cNode.Content[0], idx, true)
+	assert.NoError(t, err)
+	assert.Len(t, things, 2)
+
+	for k, v := range things {
+		if k.Value == "x-hey" {
+			continue
+		}
+		assert.Equal(t, "one", k.Value)
+		assert.Len(t, v.ValueNode.Content, 2)
+	}
+}
+
+func TestExtractMap_NoLookupWithoutExtensions(t *testing.T) {
+
+	yml := `components:`
+
+	var idxNode yaml.Node
+	mErr := yaml.Unmarshal([]byte(yml), &idxNode)
+	assert.NoError(t, mErr)
+	idx := index.NewSpecIndex(&idxNode)
+
+	yml = `x-hey: you
+one:
+  x-choo: choo`
+
+	var cNode yaml.Node
+	e := yaml.Unmarshal([]byte(yml), &cNode)
+	assert.NoError(t, e)
+
+	things, err := ExtractMapNoLookupExtensions[*test_Good](cNode.Content[0], idx, false)
+	assert.NoError(t, err)
+	assert.Len(t, things, 1)
+
+	for k, _ := range things {
+		assert.Equal(t, "one", k.Value)
+	}
+}
+
+func TestExtractMap_WithExtensions(t *testing.T) {
+
+	yml := `components:`
+
+	var idxNode yaml.Node
+	mErr := yaml.Unmarshal([]byte(yml), &idxNode)
+	assert.NoError(t, mErr)
+	idx := index.NewSpecIndex(&idxNode)
+
+	yml = `x-hey: you
+one:
+  x-choo: choo`
+
+	var cNode yaml.Node
+	e := yaml.Unmarshal([]byte(yml), &cNode)
+	assert.NoError(t, e)
+
+	things, _, _, err := ExtractMapExtensions[*test_Good]("one", cNode.Content[0], idx, true)
+	assert.NoError(t, err)
+	assert.Len(t, things, 1)
+}
+
+func TestExtractMap_WithoutExtensions(t *testing.T) {
+
+	yml := `components:`
+
+	var idxNode yaml.Node
+	mErr := yaml.Unmarshal([]byte(yml), &idxNode)
+	assert.NoError(t, mErr)
+	idx := index.NewSpecIndex(&idxNode)
+
+	yml = `x-hey: you
+one:
+  x-choo: choo`
+
+	var cNode yaml.Node
+	e := yaml.Unmarshal([]byte(yml), &cNode)
+	assert.NoError(t, e)
+
+	things, _, _, err := ExtractMapExtensions[*test_Good]("one", cNode.Content[0], idx, false)
+	assert.NoError(t, err)
+	assert.Len(t, things, 0)
+}
+
 func TestExtractMapFlatNoLookup_Ref(t *testing.T) {
 
 	yml := `components:

--- a/datamodel/low/v3/response.go
+++ b/datamodel/low/v3/response.go
@@ -17,7 +17,7 @@ import (
 //
 // Describes a single response from an API Operation, including design-time, static links to
 // operations based on the response.
-//  - https://spec.openapis.org/oas/v3.1.0#response-object
+//   - https://spec.openapis.org/oas/v3.1.0#response-object
 type Response struct {
 	Description low.NodeReference[string]
 	Headers     low.NodeReference[map[low.KeyReference[string]]low.ValueReference[*Header]]
@@ -58,7 +58,7 @@ func (r *Response) Build(root *yaml.Node, idx *index.SpecIndex) error {
 	r.Extensions = low.ExtractExtensions(root)
 
 	//extract headers
-	headers, lN, kN, err := low.ExtractMap[*Header](HeadersLabel, root, idx)
+	headers, lN, kN, err := low.ExtractMapExtensions[*Header](HeadersLabel, root, idx, true)
 	if err != nil {
 		return err
 	}

--- a/datamodel/low/v3/response_test.go
+++ b/datamodel/low/v3/response_test.go
@@ -64,7 +64,6 @@ default:
 	assert.Equal(t, "c009b2046101bc03df802b4cf23f78176931137e6115bf7b445ca46856c06b51",
 		low.GenerateHashString(&n))
 
-
 }
 
 func TestResponses_NoDefault(t *testing.T) {
@@ -214,6 +213,30 @@ func TestResponses_Build_FailBadLinks(t *testing.T) {
 
 	err = n.Build(idxNode.Content[0], idx)
 	assert.Error(t, err)
+
+}
+
+func TestResponses_Build_AllowXPrefixHeader(t *testing.T) {
+
+	yml := `"200":
+  headers:
+    x-header1:
+      schema:
+        type: string`
+
+	var idxNode yaml.Node
+	_ = yaml.Unmarshal([]byte(yml), &idxNode)
+	idx := index.NewSpecIndex(&idxNode)
+
+	var n Responses
+	err := low.BuildModel(&idxNode, &n)
+	assert.NoError(t, err)
+
+	err = n.Build(idxNode.Content[0], idx)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "string",
+		n.FindResponseByCode("200").Value.FindHeader("x-header1").Value.Schema.Value.Schema().Type.Value.A)
 
 }
 

--- a/datamodel/low/v3/responses.go
+++ b/datamodel/low/v3/responses.go
@@ -27,7 +27,7 @@ import (
 //
 // The Responses Object MUST contain at least one response code, and if only one response code is provided it SHOULD
 // be the response for a successful operation call.
-//  - https://spec.openapis.org/oas/v3.1.0#responses-object
+//   - https://spec.openapis.org/oas/v3.1.0#responses-object
 //
 // This structure is identical to the v2 version, however they use different response types, hence
 // the duplication. Perhaps in the future we could use generics here, but for now to keep things


### PR DESCRIPTION
New extraction functions added (that just wrap the old ones). The difference here is that the extensions can be included or ignored now. This has been added to address issue #24 where header keys can in fact include an extension prefix.