### PR TITLE
feat: Public methods now return MultiError instead of []error

### DIFF
--- a/error.go
+++ b/error.go
@@ -1,0 +1,85 @@
+// Copyright 2023 Princess B33f Heavy Industries
+// SPDX-License-Identifier: MIT
+
+package libopenapi
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+func errorMsg(msg string) *MultiError {
+	return &MultiError{errs: []error{errors.New(msg)}}
+}
+
+func errorMsgf(msg string, a ...any) *MultiError {
+	return &MultiError{errs: []error{fmt.Errorf(msg, a...)}}
+}
+
+func wrapErr(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &MultiError{errs: []error{err}}
+}
+
+func wrapErrs(err []error) error {
+	if len(err) == 0 {
+		return nil
+	}
+	return &MultiError{err}
+}
+
+type MultiError struct {
+	errs []error
+}
+
+func (e *MultiError) Append(err error) {
+	if err == nil {
+		return
+	}
+
+	var m *MultiError
+	if errors.As(err, &m) {
+		e.errs = append(e.errs, m.errs...)
+		return
+	}
+	e.errs = append(e.errs, err)
+}
+
+func (e *MultiError) Count() int {
+	return len(e.errs)
+}
+
+func (e *MultiError) Error() string {
+	var b strings.Builder
+	for i, err := range e.errs {
+		if err == nil {
+			b.WriteString(fmt.Sprintf("[%d] nil\n", i))
+			continue
+		}
+		b.WriteString(fmt.Sprintf("[%d] %s\n", i, err.Error()))
+	}
+	return b.String()
+}
+
+func (e *MultiError) Unwrap() []error {
+	return e.errs
+}
+
+// OrNil returns this instance of *MultiError or nil if there are no errors
+// This is useful because returning a &MultiError{} even if it's empty is
+// still considered an error.
+func (e *MultiError) OrNil() error {
+	if len(e.errs) == 0 {
+		return nil
+	}
+	return e
+}
+
+func (e *MultiError) Print() {
+	for i, err := range e.errs {
+		fmt.Printf("[%d] %s\n", i, err.Error())
+	}
+}

--- a/error_test.go
+++ b/error_test.go
@@ -1,0 +1,57 @@
+// Copyright 2023 Princess B33f Heavy Industries
+// SPDX-License-Identifier: MIT
+
+package libopenapi
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMultiError(t *testing.T) {
+	err := &MultiError{}
+	err.Append(errors.New("error 1"))
+	err.Append(errors.New("error 2"))
+	err.Append(wrapErr(errors.New("error 3")))
+	assert.Equal(t, "[0] error 1\n[1] error 2\n[2] error 3\n", err.Error())
+}
+
+func TestMultiError_OrNil(t *testing.T) {
+	err := &MultiError{}
+	err.Append(errors.New("error 1"))
+	err.Append(errors.New("error 2"))
+
+	// Append does not add nil errors
+	nilErr := &MultiError{}
+	err.Append(wrapErr(nilErr.OrNil()))
+
+	assert.Equal(t, "[0] error 1\n[1] error 2\n", err.Error())
+}
+
+func TestMultiError_NilError(t *testing.T) {
+	// When nil error added to the list.
+	err := &MultiError{errs: []error{
+		errors.New("error 1"),
+		nil,
+		errors.New("error 2"),
+	}}
+
+	// Should output as 'nil'
+	assert.Equal(t, "[0] error 1\n[1] nil\n[2] error 2\n", err.Error())
+}
+
+func ExampleMultiError_Print() {
+	err := &MultiError{}
+	err.Append(errors.New("error 1"))
+	err.Append(errors.New("error 2"))
+	err.Append(errors.New("error 3"))
+
+	err.Print()
+
+	// Output:
+	// [0] error 1
+	// [1] error 2
+	// [2] error 3
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pb33f/libopenapi
 
-go 1.18
+go 1.20
 
 require (
 	github.com/stretchr/testify v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,6 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/stretchr/testify v1.8.3 h1:RP3t2pwF7cMEbC1dqtB6poj3niw/9gnV4Cjg5oW5gtY=
-github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/vmware-labs/yaml-jsonpath v0.3.2 h1:/5QKeCBGdsInyDCyVNLbXyilb61MXGi9NP674f9Hobk=
 github.com/vmware-labs/yaml-jsonpath v0.3.2/go.mod h1:U6whw1z03QyqgWdgXxvVnQ90zN1BWz5V+51Ewf8k+rQ=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -80,8 +78,6 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.2.0 h1:PUR+T4wwASmuSTYdKjYHI5TD22Wy5ogLU5qZCOLxBrI=
-golang.org/x/sync v0.2.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/index/find_component_test.go
+++ b/index/find_component_test.go
@@ -5,6 +5,7 @@ package index
 
 import (
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 	"os"
 	"testing"
@@ -137,7 +138,7 @@ paths:
 
 	// extract crs param from index
 	crsParam := index.GetMappedReferences()["https://schemas.opengis.net/ogcapi/features/part2/1.0/openapi/ogcapi-features-2.yaml#/components/parameters/crs"]
-	assert.NotNil(t, crsParam)
+	require.NotNil(t, crsParam)
 	assert.True(t, crsParam.IsRemote)
 	assert.Equal(t, "crs", crsParam.Node.Content[1].Value)
 	assert.Equal(t, "query", crsParam.Node.Content[3].Value)


### PR DESCRIPTION
## Purpose
The current code base returns multiple errors which is inconvenient to use if multiple errors are not useful to the caller. Instead this PR creates an error that implements the `Unwrap() []error` method which can be used to retrieve multiple errors. This interface was introduced in `go 1.20`

## Implementation
* Added `type MultiError struct` 
* Added `errorMsg()` and `errorMsgf()` (Although that could be narrowed down to just `errorMsg()` with the capability to handle optional formatted text)

## Versioning
This PR significantly breaks compatibility of the public interfaces. If this PR is acceptable, we should bump to `v1` before merging.

## Postscript
My editor naturally indents with a TAB, and as this project uses SPACES for indentation this PR mixes TABS and SPACES. If this PR is to be accepted I'll fix accordingly. 

Reference: https://github.com/pb33f/libopenapi/issues/117