### PR TITLE
Use EqualFold ti avoid memory reallocations

### DIFF
--- a/datamodel/low/extraction_functions.go
+++ b/datamodel/low/extraction_functions.go
@@ -22,7 +22,7 @@ func FindItemInMap[T any](item string, collection map[KeyReference[string]]Value
 		if n.Value == item {
 			return &o
 		}
-		if strings.ToLower(n.Value) == strings.ToLower(item) {
+		if strings.EqualFold(item, n.Value) {
 			return &o
 		}
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -233,7 +233,8 @@ func FindKeyNodeTop(key string, nodes []*yaml.Node) (keyNode *yaml.Node, valueNo
 		if i%2 != 0 {
 			continue
 		}
-		if strings.ToLower(key) == strings.ToLower(v.Value) {
+
+		if strings.EqualFold(key, v.Value) {
 			return v, nodes[i+1] // next node is what we need.
 		}
 	}


### PR DESCRIPTION
On very large specs `ToLower` becomes a bottleneck since it reallocates a lot 