### PR TITLE
nil pointer check added to prevent panic.

### DIFF
--- a/datamodel/high/node_builder.go
+++ b/datamodel/high/node_builder.go
@@ -435,7 +435,7 @@ func (n *NodeBuilder) AddYAMLNode(parent *yaml.Node, entry *NodeEntry) *yaml.Nod
 			if glu, ok := sqi.(GoesLowUntyped); ok {
 				if glu != nil {
 					ut := glu.GoLowUntyped()
-					if !reflect.ValueOf(ut).IsNil() {
+					if ut != nil && !reflect.ValueOf(ut).IsNil() {
 						r := ut.(low.IsReferenced)
 						if ut != nil && r.GetReference() != "" &&
 							ut.(low.IsReferenced).IsReference() {


### PR DESCRIPTION
When building docs from scratch, a slice not backed by a low-level model could throw an NPE, which is now fixed.

non-breaking change.