### PR TITLE
Fix race condition in Schema & Comparisons 

### DIFF
--- a/datamodel/high/base/schema.go
+++ b/datamodel/high/base/schema.go
@@ -431,15 +431,13 @@ func NewSchema(schema *base.Schema) *Schema {
 	}
 
 	completeChildren := 0
-	completedProps := 0
-	totalProps := len(schema.DependentSchemas.Value) + len(schema.PatternProperties.Value)
-	if totalProps+children > 0 {
+	if children > 0 {
 	allDone:
 		for true {
 			select {
 			case <-polyCompletedChan:
 				completeChildren++
-				if totalProps == completedProps && children == completeChildren {
+				if  children == completeChildren {
 					break allDone
 				}
 			}

--- a/what-changed/model/comparison_functions.go
+++ b/what-changed/model/comparison_functions.go
@@ -233,10 +233,10 @@ func CheckMapForChangesWithComp[T any, R any](expLeft, expRight map[low.KeyRefer
 	checkLeft := func(k string, doneChan chan bool, f, g map[string]string, p, h map[string]low.ValueReference[T]) {
 		rhash := g[k]
 		if rhash == "" {
+			chLock.Lock()
 			if p[k].GetValueNode().Value == "" {
 				p[k].GetValueNode().Value = k
 			}
-			chLock.Lock()
 			CreateChange(changes, ObjectRemoved, label,
 				p[k].GetValueNode(), nil, true,
 				p[k].GetValue(), nil)
@@ -293,10 +293,10 @@ func checkRightValue[T any](k string, doneChan chan bool, f map[string]string, p
 
 	lhash := f[k]
 	if lhash == "" {
+		lock.Lock()
 		if p[k].GetValueNode().Value == "" {
 			p[k].GetValueNode().Value = k // this is kinda dirty, but I don't want to duplicate code so sue me.
 		}
-		lock.Lock()
 		CreateChange(changes, ObjectAdded, label,
 			nil, p[k].GetValueNode(), false,
 			nil, p[k].GetValue())


### PR DESCRIPTION
### Purpose
Found race conditions in `comparison_functions.go` and `high/base/schema.go`. 

### Implementation
* Removed asynchronous nature of `buildProps()` in `NewSchema()`
* In `CheckMapForChangesWithComp()` the lock now covers writes `p[k].GetValueNode().Value = k` when they occur.