### PR TITLE
Added general linting support for non openapi files.

### DIFF
--- a/datamodel/document_config.go
+++ b/datamodel/document_config.go
@@ -36,6 +36,10 @@ type DocumentConfiguration struct {
 	// AvoidIndexBuild will avoid building the index. This is disabled by default, only use if you are sure you don't need it.
 	// This is useful for developers building out models that should be indexed later on.
 	AvoidIndexBuild bool
+
+	// BypassDocumentCheck will bypass the document check. This is disabled by default. This will allow any document to
+	// passed in and used. Only enable this when parsing non openapi documents.
+	BypassDocumentCheck bool
 }
 
 func NewOpenDocumentConfiguration() *DocumentConfiguration {

--- a/datamodel/spec_info_test.go
+++ b/datamodel/spec_info_test.go
@@ -173,6 +173,40 @@ func TestExtractSpecInfo_OpenAPI31(t *testing.T) {
 	assert.Contains(t, r.APISchema, "https://spec.openapis.org/oas/3.1/schema/2022-10-07")
 }
 
+func TestExtractSpecInfo_AnyDocument(t *testing.T) {
+
+	random := `something: yeah
+nothing:
+  - one
+  - two
+why:
+  yes: no`
+
+	r, e := ExtractSpecInfoWithDocumentCheck([]byte(random), true)
+	assert.Nil(t, e)
+	assert.NotNil(t, r.RootNode)
+	assert.Equal(t, "something", r.RootNode.Content[0].Content[0].Value)
+	assert.Len(t, *r.SpecBytes, 55)
+}
+
+func TestExtractSpecInfo_AnyDocumentFromConfig(t *testing.T) {
+
+	random := `something: yeah
+nothing:
+  - one
+  - two
+why:
+  yes: no`
+
+	r, e := ExtractSpecInfoWithConfig([]byte(random), &DocumentConfiguration{
+		BypassDocumentCheck: true,
+	})
+	assert.Nil(t, e)
+	assert.NotNil(t, r.RootNode)
+	assert.Equal(t, "something", r.RootNode.Content[0].Content[0].Value)
+	assert.Len(t, *r.SpecBytes, 55)
+}
+
 func TestExtractSpecInfo_OpenAPIFalse(t *testing.T) {
 
 	spec, e := ExtractSpecInfo([]byte(OpenApiFalse))

--- a/datamodel/spec_info_test.go
+++ b/datamodel/spec_info_test.go
@@ -189,6 +189,17 @@ why:
 	assert.Len(t, *r.SpecBytes, 55)
 }
 
+func TestExtractSpecInfo_AnyDocument_JSON(t *testing.T) {
+
+	random := `{ "something" : "yeah"}`
+
+	r, e := ExtractSpecInfoWithDocumentCheck([]byte(random), true)
+	assert.Nil(t, e)
+	assert.NotNil(t, r.RootNode)
+	assert.Equal(t, "something", r.RootNode.Content[0].Content[0].Value)
+	assert.Len(t, *r.SpecBytes, 23)
+}
+
 func TestExtractSpecInfo_AnyDocumentFromConfig(t *testing.T) {
 
 	random := `something: yeah

--- a/document.go
+++ b/document.go
@@ -112,7 +112,11 @@ type DocumentModel[T v2high.Swagger | v3high.Document] struct {
 // then you can use the NewDocumentWithConfiguration() function instead, which allows you to set a configuration that
 // will allow you to control if file or remote references are allowed.
 func NewDocument(specByteArray []byte) (Document, error) {
-	info, err := datamodel.ExtractSpecInfo(specByteArray)
+	return NewDocumentWithTypeCheck(specByteArray, false)
+}
+
+func NewDocumentWithTypeCheck(specByteArray []byte, bypassCheck bool) (Document, error) {
+	info, err := datamodel.ExtractSpecInfoWithDocumentCheck(specByteArray, bypassCheck)
 	if err != nil {
 		return nil, err
 	}
@@ -125,7 +129,14 @@ func NewDocument(specByteArray []byte) (Document, error) {
 // NewDocumentWithConfiguration is the same as NewDocument, except it's a convenience function that calls NewDocument
 // under the hood and then calls SetConfiguration() on the returned Document.
 func NewDocumentWithConfiguration(specByteArray []byte, configuration *datamodel.DocumentConfiguration) (Document, error) {
-	d, err := NewDocument(specByteArray)
+	var d Document
+	var err error
+	if configuration != nil && configuration.BypassDocumentCheck {
+		d, err = NewDocumentWithTypeCheck(specByteArray, true)
+	} else {
+		d, err = NewDocument(specByteArray)
+	}
+
 	if d != nil {
 		d.SetConfiguration(configuration)
 	}

--- a/document_test.go
+++ b/document_test.go
@@ -291,11 +291,22 @@ func TestDocument_RenderAndReload_Swagger(t *testing.T) {
 
 func TestDocument_BuildModelPreBuild(t *testing.T) {
 	petstore, _ := ioutil.ReadFile("test_specs/petstorev3.json")
-	doc, _ := NewDocument(petstore)
-	doc.BuildV3Model()
-	doc.BuildV3Model()
-	_, _, _, e := doc.RenderAndReload()
+	_, e := NewDocument(petstore)
 	assert.Len(t, e, 0)
+}
+
+func TestDocument_AnyDoc(t *testing.T) {
+	anything := []byte(`{"chickens": "3.0.0", "burgers": {"title": "hello"}}`)
+	_, e := NewDocumentWithTypeCheck(anything, true)
+	assert.NoError(t, e)
+}
+
+func TestDocument_AnyDocWithConfig(t *testing.T) {
+	anything := []byte(`{"chickens": "3.0.0", "burgers": {"title": "hello"}}`)
+	_, e := NewDocumentWithConfiguration(anything, &datamodel.DocumentConfiguration{
+		BypassDocumentCheck: true,
+	})
+	assert.NoError(t, e)
 }
 
 func TestDocument_BuildModelCircular(t *testing.T) {

--- a/document_test.go
+++ b/document_test.go
@@ -291,8 +291,12 @@ func TestDocument_RenderAndReload_Swagger(t *testing.T) {
 
 func TestDocument_BuildModelPreBuild(t *testing.T) {
 	petstore, _ := ioutil.ReadFile("test_specs/petstorev3.json")
-	_, e := NewDocument(petstore)
-	assert.Len(t, e, 0)
+	doc, e := NewDocument(petstore)
+	assert.NoError(t, e)
+	doc.BuildV3Model()
+	doc.BuildV3Model()
+	_, _, _, er := doc.RenderAndReload()
+	assert.Len(t, er, 0)
 }
 
 func TestDocument_AnyDoc(t *testing.T) {


### PR DESCRIPTION
This allows vacuum to operate outside of the OpenAPI world. Exciting!


New `DocumentConfiguration` property added.

`BypassDocumentCheck` will bypass the document check. This is disabled by default. This will allow any document to
passed in and used. Should only be enabled when loading non OpenAPI docs.
