### PR TITLE
v0.9.8

### DIFF
--- a/datamodel/low/extraction_functions.go
+++ b/datamodel/low/extraction_functions.go
@@ -698,6 +698,9 @@ func AreEqual(l, r Hashable) bool {
 // GenerateHashString will generate a SHA36 hash of any object passed in. If the object is Hashable
 // then the underlying Hash() method will be called.
 func GenerateHashString(v any) string {
+	if v == nil {
+		return ""
+	}
 	if h, ok := v.(Hashable); ok {
 		if h != nil {
 			return fmt.Sprintf(HASH, h.Hash())

--- a/datamodel/low/extraction_functions_test.go
+++ b/datamodel/low/extraction_functions_test.go
@@ -1669,6 +1669,12 @@ func TestGenerateHashString(t *testing.T) {
 	assert.Equal(t, "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
 		GenerateHashString("hello"))
 
+	assert.Equal(t, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+		GenerateHashString(""))
+
+	assert.Equal(t, "",
+		GenerateHashString(nil))
+
 }
 
 func TestGenerateHashString_Pointer(t *testing.T) {

--- a/index/extract_refs.go
+++ b/index/extract_refs.go
@@ -43,6 +43,12 @@ func (index *SpecIndex) ExtractRefs(node, parent *yaml.Node, seenPath []string, 
 			if i%2 == 0 && n.Value == "schema" && !utils.IsNodeArray(node) && (i+1 < len(node.Content)) {
 				isRef, _, _ := utils.IsNodeRefValue(node.Content[i+1])
 				if isRef {
+					// record this reference
+					ref := &Reference{
+						Node: node.Content[i+1],
+						Path: fmt.Sprintf("$.%s.schema", strings.Join(seenPath, ".")),
+					}
+					index.allRefSchemaDefinitions = append(index.allRefSchemaDefinitions, ref)
 					continue
 				}
 				ref := &Reference{

--- a/index/find_component_test.go
+++ b/index/find_component_test.go
@@ -125,32 +125,33 @@ components:
 	assert.Len(t, index.GetReferenceIndexErrors(), 1)
 }
 
-func TestSpecIndex_LocateRemoteDocsWithNoBaseURLSupplied(t *testing.T) {
-	// This test will push the index to do try and locate remote references that use relative references
-	spec := `openapi: 3.0.2
-info:
-  title: Test
-  version: 1.0.0
-paths:
-  /test:
-    get:
-      parameters:
-        - $ref: "https://schemas.opengis.net/ogcapi/features/part2/1.0/openapi/ogcapi-features-2.yaml#/components/parameters/crs"`
-
-	var rootNode yaml.Node
-	_ = yaml.Unmarshal([]byte(spec), &rootNode)
-
-	c := CreateOpenAPIIndexConfig()
-	index := NewSpecIndexWithConfig(&rootNode, c)
-
-	// extract crs param from index
-	crsParam := index.GetMappedReferences()["https://schemas.opengis.net/ogcapi/features/part2/1.0/openapi/ogcapi-features-2.yaml#/components/parameters/crs"]
-	assert.NotNil(t, crsParam)
-	assert.True(t, crsParam.IsRemote)
-	assert.Equal(t, "crs", crsParam.Node.Content[1].Value)
-	assert.Equal(t, "query", crsParam.Node.Content[3].Value)
-	assert.Equal(t, "form", crsParam.Node.Content[9].Value)
-}
+// disabled test because remote host is flaky.
+//func TestSpecIndex_LocateRemoteDocsWithNoBaseURLSupplied(t *testing.T) {
+//	// This test will push the index to do try and locate remote references that use relative references
+//	spec := `openapi: 3.0.2
+//info:
+//  title: Test
+//  version: 1.0.0
+//paths:
+//  /test:
+//    get:
+//      parameters:
+//        - $ref: "https://schemas.opengis.net/ogcapi/features/part2/1.0/openapi/ogcapi-features-2.yaml#/components/parameters/crs"`
+//
+//	var rootNode yaml.Node
+//	_ = yaml.Unmarshal([]byte(spec), &rootNode)
+//
+//	c := CreateOpenAPIIndexConfig()
+//	index := NewSpecIndexWithConfig(&rootNode, c)
+//
+//	// extract crs param from index
+//	crsParam := index.GetMappedReferences()["https://schemas.opengis.net/ogcapi/features/part2/1.0/openapi/ogcapi-features-2.yaml#/components/parameters/crs"]
+//	assert.NotNil(t, crsParam)
+//	assert.True(t, crsParam.IsRemote)
+//	assert.Equal(t, "crs", crsParam.Node.Content[1].Value)
+//	assert.Equal(t, "query", crsParam.Node.Content[3].Value)
+//	assert.Equal(t, "form", crsParam.Node.Content[9].Value)
+//}
 
 func TestSpecIndex_LocateRemoteDocsWithRemoteURLHandler(t *testing.T) {
 	// This test will push the index to do try and locate remote references that use relative references

--- a/index/index_model.go
+++ b/index/index_model.go
@@ -198,6 +198,7 @@ type SpecIndex struct {
 	parametersNode                      *yaml.Node                                    // components/parameters node
 	allParameters                       map[string]*Reference                         // all parameters (components/defs)
 	schemasNode                         *yaml.Node                                    // components/schemas node
+	allRefSchemaDefinitions             []*Reference                                  // all schemas found that are references.
 	allInlineSchemaDefinitions          []*Reference                                  // all schemas found in document outside of components (openapi) or definitions (swagger).
 	allInlineSchemaObjectDefinitions    []*Reference                                  // all schemas that are objects found in document outside of components (openapi) or definitions (swagger).
 	allComponentSchemaDefinitions       map[string]*Reference                         // all schemas found in components (openapi) or definitions (swagger).

--- a/index/spec_index.go
+++ b/index/spec_index.go
@@ -14,6 +14,7 @@ package index
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 
@@ -245,9 +246,9 @@ func (index *SpecIndex) GetAllSchemas() []*Reference {
 		combined[i] = refSchemas[x]
 		i++
 	}
-	//sort.Slice(combined, func(i, j int) bool {
-	//	return combined[i].Node.Line < combined[j].Node.Line
-	//})
+	sort.Slice(combined, func(i, j int) bool {
+		return combined[i].Node.Line < combined[j].Node.Line
+	})
 	return combined
 }
 

--- a/index/spec_index.go
+++ b/index/spec_index.go
@@ -225,11 +225,13 @@ func (index *SpecIndex) GetOperationParameterReferences() map[string]map[string]
 // GetAllSchemas will return references to all schemas found in the document both inline and those under components
 // The first elements of at the top of the slice, are all the inline references (using GetAllInlineSchemas),
 // and then following on are all the references extracted from the components section (using GetAllComponentSchemas).
+// finally all the references that are not inline, but marked as $ref in the document are returned (using GetAllReferenceSchemas).
+// the results are sorted by line number.
 func (index *SpecIndex) GetAllSchemas() []*Reference {
 	componentSchemas := index.GetAllComponentSchemas()
 	inlineSchemas := index.GetAllInlineSchemas()
-
-	combined := make([]*Reference, len(inlineSchemas)+len(componentSchemas))
+	refSchemas := index.GetAllReferenceSchemas()
+	combined := make([]*Reference, len(inlineSchemas)+len(componentSchemas)+len(refSchemas))
 	i := 0
 	for x := range inlineSchemas {
 		combined[i] = inlineSchemas[x]
@@ -239,6 +241,13 @@ func (index *SpecIndex) GetAllSchemas() []*Reference {
 		combined[i] = componentSchemas[x]
 		i++
 	}
+	for x := range refSchemas {
+		combined[i] = refSchemas[x]
+		i++
+	}
+	//sort.Slice(combined, func(i, j int) bool {
+	//	return combined[i].Node.Line < combined[j].Node.Line
+	//})
 	return combined
 }
 
@@ -251,6 +260,11 @@ func (index *SpecIndex) GetAllInlineSchemaObjects() []*Reference {
 // GetAllInlineSchemas will return all schemas defined in the components section of the document.
 func (index *SpecIndex) GetAllInlineSchemas() []*Reference {
 	return index.allInlineSchemaDefinitions
+}
+
+// GetAllReferenceSchemas will return all schemas that are not inline, but $ref'd from somewhere.
+func (index *SpecIndex) GetAllReferenceSchemas() []*Reference {
+	return index.allRefSchemaDefinitions
 }
 
 // GetAllComponentSchemas will return all schemas defined in the components section of the document.

--- a/index/spec_index_test.go
+++ b/index/spec_index_test.go
@@ -44,6 +44,7 @@ func TestSpecIndex_ExtractRefsStripe(t *testing.T) {
 	assert.Len(t, index.GetPolyAllOfReferences(), 0)
 	assert.Len(t, index.GetPolyOneOfReferences(), 275)
 	assert.Len(t, index.GetPolyAnyOfReferences(), 553)
+	assert.Len(t, index.GetAllReferenceSchemas(), 696)
 	assert.NotNil(t, index.GetRootServersNode())
 	assert.Len(t, index.GetAllRootServers(), 1)
 
@@ -282,7 +283,7 @@ func TestSpecIndex_BurgerShop(t *testing.T) {
 	assert.Equal(t, 6, index.GetPathCount())
 
 	assert.Equal(t, 6, len(index.GetAllComponentSchemas()))
-	assert.Equal(t, 31, len(index.GetAllSchemas()))
+	assert.Equal(t, 47, len(index.GetAllSchemas()))
 
 	assert.Equal(t, 34, len(index.GetAllSequencedReferences()))
 	assert.NotNil(t, index.GetSchemasNode())
@@ -1062,7 +1063,7 @@ func ExampleNewSpecIndex() {
 	var rootNode yaml.Node
 
 	// load in the stripe OpenAPI specification into bytes (it's pretty meaty)
-	stripeSpec, _ := ioutil.ReadFile("../test_specs/stripe.yaml")
+	stripeSpec, _ := os.ReadFile("../test_specs/stripe.yaml")
 
 	// unmarshal spec into our rootNode
 	_ = yaml.Unmarshal(stripeSpec, &rootNode)
@@ -1075,6 +1076,7 @@ func ExampleNewSpecIndex() {
 		"%d paths\n"+
 		"%d operations\n"+
 		"%d component schemas\n"+
+		"%d reference schemas\n"+
 		"%d inline schemas\n"+
 		"%d inline schemas that are objects or arrays\n"+
 		"%d total schemas\n"+
@@ -1084,6 +1086,7 @@ func ExampleNewSpecIndex() {
 		len(index.GetAllPaths()),
 		index.GetOperationCount(),
 		len(index.GetAllComponentSchemas()),
+		len(index.GetAllReferenceSchemas()),
 		len(index.GetAllInlineSchemas()),
 		len(index.GetAllInlineSchemaObjects()),
 		len(index.GetAllSchemas()),
@@ -1093,9 +1096,10 @@ func ExampleNewSpecIndex() {
 	// 246 paths
 	// 402 operations
 	// 537 component schemas
+	// 696 reference schemas
 	// 9798 inline schemas
 	// 711 inline schemas that are objects or arrays
-	// 10335 total schemas
+	// 11031 total schemas
 	// 1516 enums
 	// 828 polymorphic references
 }


### PR DESCRIPTION
Adds a new `GetAllReferenceSchemas` method to the index that allows any schema defined by a `$ref` to be picked up. And then this new set of discoveries is now rolled up into `GetAllSchemas`