### PR TITLE
Expose key node in low schema proxy

### DIFF
--- a/datamodel/high/base/contact_test.go
+++ b/datamodel/high/base/contact_test.go
@@ -70,7 +70,7 @@ email: buckaroo@pb33f.io
 	// build low
 	var lowContact lowbase.Contact
 	_ = lowmodel.BuildModel(cNode.Content[0], &lowContact)
-	_ = lowContact.Build(cNode.Content[0], nil)
+	_ = lowContact.Build(nil, cNode.Content[0], nil)
 
 	// build high
 	highContact := NewContact(&lowContact)

--- a/datamodel/high/base/dynamic_value_test.go
+++ b/datamodel/high/base/dynamic_value_test.go
@@ -116,7 +116,7 @@ func TestDynamicValue_MarshalYAMLInline(t *testing.T) {
 	_ = yaml.Unmarshal([]byte(ymlSchema), &node)
 
 	lowProxy := new(lowbase.SchemaProxy)
-	err := lowProxy.Build(node.Content[0], idx)
+	err := lowProxy.Build(nil, node.Content[0], idx)
 	assert.NoError(t, err)
 
 	lowRef := low.NodeReference[*lowbase.SchemaProxy]{
@@ -160,7 +160,7 @@ func TestDynamicValue_MarshalYAMLInline_Error(t *testing.T) {
 	_ = yaml.Unmarshal([]byte(ymlSchema), &node)
 
 	lowProxy := new(lowbase.SchemaProxy)
-	err := lowProxy.Build(node.Content[0], idx)
+	err := lowProxy.Build(nil, node.Content[0], idx)
 	assert.NoError(t, err)
 
 	lowRef := low.NodeReference[*lowbase.SchemaProxy]{

--- a/datamodel/high/base/example_test.go
+++ b/datamodel/high/base/example_test.go
@@ -29,7 +29,7 @@ x-hack: code`
 	var lowExample lowbase.Example
 	_ = lowmodel.BuildModel(cNode.Content[0], &lowExample)
 
-	_ = lowExample.Build(cNode.Content[0], nil)
+	_ = lowExample.Build(&cNode, cNode.Content[0], nil)
 
 	// build high
 	highExample := NewExample(&lowExample)
@@ -59,7 +59,7 @@ func TestExtractExamples(t *testing.T) {
 	var lowExample lowbase.Example
 	_ = lowmodel.BuildModel(cNode.Content[0], &lowExample)
 
-	_ = lowExample.Build(cNode.Content[0], nil)
+	_ = lowExample.Build(nil, cNode.Content[0], nil)
 
 	examplesMap := make(map[lowmodel.KeyReference[string]]lowmodel.ValueReference[*lowbase.Example])
 	examplesMap[lowmodel.KeyReference[string]{
@@ -89,7 +89,7 @@ x-hack: code`
 	_ = lowmodel.BuildModel(node.Content[0], &lowExample)
 
 	// build out low-level example
-	_ = lowExample.Build(node.Content[0], nil)
+	_ = lowExample.Build(nil, node.Content[0], nil)
 
 	// create a new high-level example
 	highExample := NewExample(&lowExample)

--- a/datamodel/high/base/external_doc_test.go
+++ b/datamodel/high/base/external_doc_test.go
@@ -26,7 +26,7 @@ x-hack: code`
 	var lowExt lowbase.ExternalDoc
 	_ = lowmodel.BuildModel(cNode.Content[0], &lowExt)
 
-	_ = lowExt.Build(cNode.Content[0], nil)
+	_ = lowExt.Build(nil, cNode.Content[0], nil)
 
 	highExt := NewExternalDoc(&lowExt)
 
@@ -61,7 +61,7 @@ x-hack: code`
 	_ = lowmodel.BuildModel(node.Content[0], &lowExt)
 
 	// build out low-level properties (like extensions)
-	_ = lowExt.Build(node.Content[0], nil)
+	_ = lowExt.Build(nil, node.Content[0], nil)
 
 	// create new high-level ExternalDoc
 	highExt := NewExternalDoc(&lowExt)

--- a/datamodel/high/base/info_test.go
+++ b/datamodel/high/base/info_test.go
@@ -32,7 +32,7 @@ x-cli-name: chicken cli`
 
 	var lowInfo lowbase.Info
 	_ = lowmodel.BuildModel(cNode.Content[0], &lowInfo)
-	_ = lowInfo.Build(cNode.Content[0], nil)
+	_ = lowInfo.Build(nil, cNode.Content[0], nil)
 
 	highInfo := NewInfo(&lowInfo)
 
@@ -74,7 +74,7 @@ version: 1.2.3`
 	// build out the low-level model
 	var lowInfo lowbase.Info
 	_ = lowmodel.BuildModel(&node, &lowInfo)
-	_ = lowInfo.Build(node.Content[0], nil)
+	_ = lowInfo.Build(nil, node.Content[0], nil)
 
 	// build the high level model
 	highInfo := NewInfo(&lowInfo)
@@ -97,7 +97,7 @@ url: https://opensource.org/licenses/MIT`
 	// build out the low-level model
 	var lowLicense lowbase.License
 	_ = lowmodel.BuildModel(node.Content[0], &lowLicense)
-	_ = lowLicense.Build(node.Content[0], nil)
+	_ = lowLicense.Build(nil, node.Content[0], nil)
 
 	// build the high level model
 	highLicense := NewLicense(&lowLicense)
@@ -140,7 +140,7 @@ func TestInfo_Render(t *testing.T) {
 	// build low
 	var lowInfo lowbase.Info
 	_ = lowmodel.BuildModel(cNode.Content[0], &lowInfo)
-	_ = lowInfo.Build(cNode.Content[0], nil)
+	_ = lowInfo.Build(nil, cNode.Content[0], nil)
 
 	// build high
 	highInfo := NewInfo(&lowInfo)
@@ -181,7 +181,7 @@ x-cake:
 	// build low
 	var lowInfo lowbase.Info
 	_ = lowmodel.BuildModel(cNode.Content[0], &lowInfo)
-	_ = lowInfo.Build(cNode.Content[0], nil)
+	_ = lowInfo.Build(nil, cNode.Content[0], nil)
 
 	// build high
 	highInfo := NewInfo(&lowInfo)

--- a/datamodel/high/base/licence_test.go
+++ b/datamodel/high/base/licence_test.go
@@ -44,7 +44,7 @@ url: https://pb33f.io/not-real
 	// build low
 	var lowLicense lowbase.License
 	_ = lowmodel.BuildModel(cNode.Content[0], &lowLicense)
-	_ = lowLicense.Build(cNode.Content[0], nil)
+	_ = lowLicense.Build(nil, cNode.Content[0], nil)
 
 	// build high
 	highLicense := NewLicense(&lowLicense)
@@ -92,7 +92,7 @@ func TestLicense_Render_IdentifierAndURL_Error(t *testing.T) {
 	// build low
 	var lowLicense lowbase.License
 	_ = lowmodel.BuildModel(cNode.Content[0], &lowLicense)
-	err := lowLicense.Build(cNode.Content[0], nil)
+	err := lowLicense.Build(nil, cNode.Content[0], nil)
 
 	assert.Error(t, err)
 }

--- a/datamodel/high/base/schema_proxy_test.go
+++ b/datamodel/high/base/schema_proxy_test.go
@@ -40,7 +40,7 @@ func TestSchemaProxy_MarshalYAML(t *testing.T) {
 	_ = yaml.Unmarshal([]byte(ymlSchema), &node)
 
 	lowProxy := new(lowbase.SchemaProxy)
-	err := lowProxy.Build(node.Content[0], idx)
+	err := lowProxy.Build(nil, node.Content[0], idx)
 	assert.NoError(t, err)
 
 	lowRef := low.NodeReference[*lowbase.SchemaProxy]{

--- a/datamodel/high/base/schema_test.go
+++ b/datamodel/high/base/schema_test.go
@@ -49,7 +49,7 @@ func TestNewSchemaProxy(t *testing.T) {
 	_ = yaml.Unmarshal([]byte(yml), &compNode)
 
 	sp := new(lowbase.SchemaProxy)
-	err := sp.Build(compNode.Content[0], idx)
+	err := sp.Build(nil, compNode.Content[0], idx)
 	assert.NoError(t, err)
 
 	lowproxy := low.NodeReference[*lowbase.SchemaProxy]{
@@ -90,7 +90,7 @@ func TestNewSchemaProxyRender(t *testing.T) {
 	_ = yaml.Unmarshal([]byte(yml), &compNode)
 
 	sp := new(lowbase.SchemaProxy)
-	err := sp.Build(compNode.Content[0], idx)
+	err := sp.Build(nil, compNode.Content[0], idx)
 	assert.NoError(t, err)
 
 	lowproxy := low.NodeReference[*lowbase.SchemaProxy]{
@@ -274,7 +274,7 @@ $anchor: anchor`
 	_ = yaml.Unmarshal([]byte(testSpec), &compNode)
 
 	sp := new(lowbase.SchemaProxy)
-	err := sp.Build(compNode.Content[0], nil)
+	err := sp.Build(nil, compNode.Content[0], nil)
 	assert.NoError(t, err)
 
 	lowproxy := low.NodeReference[*lowbase.SchemaProxy]{
@@ -348,7 +348,7 @@ func TestSchemaObjectWithAllOfSequenceOrder(t *testing.T) {
 	}
 
 	sp := new(lowbase.SchemaProxy)
-	err := sp.Build(compNode.Content[0], nil)
+	err := sp.Build(nil, compNode.Content[0], nil)
 	assert.NoError(t, err)
 
 	lowproxy := low.NodeReference[*lowbase.SchemaProxy]{
@@ -485,7 +485,7 @@ required: [cake, fish]`
 	_ = yaml.Unmarshal([]byte(testSpec), &compNode)
 
 	sp := new(lowbase.SchemaProxy)
-	err := sp.Build(compNode.Content[0], nil)
+	err := sp.Build(nil, compNode.Content[0], nil)
 	assert.NoError(t, err)
 
 	lowproxy := low.NodeReference[*lowbase.SchemaProxy]{
@@ -499,10 +499,10 @@ required: [cake, fish]`
 	assert.NotNil(t, compiled)
 	assert.Nil(t, schemaProxy.GetBuildError())
 
-    assert.True(t, compiled.ExclusiveMaximum.A)
-    assert.Equal(t, float64(123), compiled.Properties["somethingB"].Schema().ExclusiveMinimum.B)
-    assert.Equal(t, float64(334), compiled.Properties["somethingB"].Schema().ExclusiveMaximum.B)
-    assert.Len(t, compiled.Properties["somethingB"].Schema().Properties["somethingBProp"].Schema().Type, 2)
+	assert.True(t, compiled.ExclusiveMaximum.A)
+	assert.Equal(t, float64(123), compiled.Properties["somethingB"].Schema().ExclusiveMinimum.B)
+	assert.Equal(t, float64(334), compiled.Properties["somethingB"].Schema().ExclusiveMaximum.B)
+	assert.Len(t, compiled.Properties["somethingB"].Schema().Properties["somethingBProp"].Schema().Type, 2)
 
 	assert.Equal(t, "nice", compiled.AdditionalProperties.(*SchemaProxy).Schema().Description)
 
@@ -541,7 +541,7 @@ func TestSchemaProxy_GoLow(t *testing.T) {
 	_ = yaml.Unmarshal([]byte(ymlSchema), &node)
 
 	lowProxy := new(lowbase.SchemaProxy)
-	err := lowProxy.Build(node.Content[0], idx)
+	err := lowProxy.Build(nil, node.Content[0], idx)
 	assert.NoError(t, err)
 
 	lowRef := low.NodeReference[*lowbase.SchemaProxy]{
@@ -587,25 +587,25 @@ type: number
 }
 
 func TestSchemaNumberMultipleOfInt(t *testing.T) {
-    yml := `
+	yml := `
 type: number
 multipleOf: 5
 `
 	highSchema := getHighSchema(t, yml)
 
 	value := float64(5)
-    assert.EqualValues(t, &value, highSchema.MultipleOf)
+	assert.EqualValues(t, &value, highSchema.MultipleOf)
 }
 
 func TestSchemaNumberMultipleOfFloat(t *testing.T) {
-    yml := `
+	yml := `
 type: number
 multipleOf: 0.5
 `
-    highSchema := getHighSchema(t, yml)
+	highSchema := getHighSchema(t, yml)
 
-    value := 0.5
-    assert.EqualValues(t, &value, highSchema.MultipleOf)
+	value := 0.5
+	assert.EqualValues(t, &value, highSchema.MultipleOf)
 }
 
 func TestSchemaNumberMinimumInt(t *testing.T) {
@@ -616,17 +616,17 @@ minimum: 5
 	highSchema := getHighSchema(t, yml)
 
 	value := float64(5)
-    assert.EqualValues(t, &value, highSchema.Minimum)
+	assert.EqualValues(t, &value, highSchema.Minimum)
 }
 
 func TestSchemaNumberMinimumFloat(t *testing.T) {
-    yml := `
+	yml := `
 type: number
 minimum: 0.5
 `
-    highSchema := getHighSchema(t, yml)
+	highSchema := getHighSchema(t, yml)
 
-    value := 0.5
+	value := 0.5
 	assert.EqualValues(t, &value, highSchema.Minimum)
 }
 
@@ -638,7 +638,7 @@ minimum: 0
 	highSchema := getHighSchema(t, yml)
 
 	value := float64(0)
-    assert.EqualValues(t, &value, highSchema.Minimum)
+	assert.EqualValues(t, &value, highSchema.Minimum)
 }
 
 func TestSchemaNumberExclusiveMinimum(t *testing.T) {
@@ -661,7 +661,7 @@ maximum: 5
 	highSchema := getHighSchema(t, yml)
 
 	value := float64(5)
-    assert.EqualValues(t, &value, highSchema.Maximum)
+	assert.EqualValues(t, &value, highSchema.Maximum)
 }
 
 func TestSchemaNumberMaximumZero(t *testing.T) {
@@ -672,7 +672,7 @@ maximum: 0
 	highSchema := getHighSchema(t, yml)
 
 	value := float64(0)
-    assert.EqualValues(t, &value, highSchema.Maximum)
+	assert.EqualValues(t, &value, highSchema.Maximum)
 }
 
 func TestSchemaNumberExclusiveMaximum(t *testing.T) {
@@ -757,7 +757,7 @@ properties:
 	// build out the low-level model
 	var lowSchema lowbase.SchemaProxy
 	_ = low.BuildModel(node.Content[0], &lowSchema)
-	_ = lowSchema.Build(node.Content[0], nil)
+	_ = lowSchema.Build(nil, node.Content[0], nil)
 
 	// build the high level schema proxy
 	highSchema := NewSchemaProxy(&low.NodeReference[*lowbase.SchemaProxy]{
@@ -817,7 +817,7 @@ allOf:
 	_ = yaml.Unmarshal([]byte(testSpec), &compNode)
 
 	sp := new(lowbase.SchemaProxy)
-	err := sp.Build(compNode.Content[0], nil)
+	err := sp.Build(nil, compNode.Content[0], nil)
 	assert.NoError(t, err)
 
 	lowproxy := low.NodeReference[*lowbase.SchemaProxy]{
@@ -881,7 +881,7 @@ items:
 	_ = yaml.Unmarshal([]byte(testSpec), &compNode)
 
 	sp := new(lowbase.SchemaProxy)
-	err := sp.Build(compNode.Content[0], nil)
+	err := sp.Build(nil, compNode.Content[0], nil)
 	assert.NoError(t, err)
 
 	lowproxy := low.NodeReference[*lowbase.SchemaProxy]{
@@ -944,7 +944,7 @@ xml:
 	_ = yaml.Unmarshal([]byte(testSpec), &compNode)
 
 	sp := new(lowbase.SchemaProxy)
-	err := sp.Build(compNode.Content[0], nil)
+	err := sp.Build(nil, compNode.Content[0], nil)
 	assert.NoError(t, err)
 
 	lowproxy := low.NodeReference[*lowbase.SchemaProxy]{
@@ -973,7 +973,7 @@ func TestNewSchemaProxy_RenderSchemaCheckDiscriminatorMappingOrder(t *testing.T)
 	_ = yaml.Unmarshal([]byte(testSpec), &compNode)
 
 	sp := new(lowbase.SchemaProxy)
-	err := sp.Build(compNode.Content[0], nil)
+	err := sp.Build(nil, compNode.Content[0], nil)
 	assert.NoError(t, err)
 
 	lowproxy := low.NodeReference[*lowbase.SchemaProxy]{
@@ -1001,7 +1001,7 @@ func TestNewSchemaProxy_RenderSchemaCheckAdditionalPropertiesSlice(t *testing.T)
 	_ = yaml.Unmarshal([]byte(testSpec), &compNode)
 
 	sp := new(lowbase.SchemaProxy)
-	err := sp.Build(compNode.Content[0], nil)
+	err := sp.Build(nil, compNode.Content[0], nil)
 	assert.NoError(t, err)
 
 	lowproxy := low.NodeReference[*lowbase.SchemaProxy]{
@@ -1027,7 +1027,7 @@ func TestNewSchemaProxy_RenderSchemaCheckAdditionalPropertiesSliceMap(t *testing
 	_ = yaml.Unmarshal([]byte(testSpec), &compNode)
 
 	sp := new(lowbase.SchemaProxy)
-	err := sp.Build(compNode.Content[0], nil)
+	err := sp.Build(nil, compNode.Content[0], nil)
 	assert.NoError(t, err)
 
 	lowproxy := low.NodeReference[*lowbase.SchemaProxy]{
@@ -1050,7 +1050,7 @@ func TestNewSchemaProxy_CheckDefaultBooleanFalse(t *testing.T) {
 	_ = yaml.Unmarshal([]byte(testSpec), &compNode)
 
 	sp := new(lowbase.SchemaProxy)
-	err := sp.Build(compNode.Content[0], nil)
+	err := sp.Build(nil, compNode.Content[0], nil)
 	assert.NoError(t, err)
 
 	lowproxy := low.NodeReference[*lowbase.SchemaProxy]{
@@ -1073,7 +1073,7 @@ func TestNewSchemaProxy_RenderAdditionalPropertiesFalse(t *testing.T) {
 	_ = yaml.Unmarshal([]byte(testSpec), &compNode)
 
 	sp := new(lowbase.SchemaProxy)
-	err := sp.Build(compNode.Content[0], nil)
+	err := sp.Build(nil, compNode.Content[0], nil)
 	assert.NoError(t, err)
 
 	lowproxy := low.NodeReference[*lowbase.SchemaProxy]{
@@ -1117,7 +1117,7 @@ components:
 
 	sp := new(lowbase.SchemaProxy)
 
-	err := sp.Build(compNode.Content[0], idx)
+	err := sp.Build(nil, compNode.Content[0], idx)
 	assert.NoError(t, err)
 
 	lowproxy := low.NodeReference[*lowbase.SchemaProxy]{
@@ -1169,7 +1169,7 @@ components:
 
 	sp := new(lowbase.SchemaProxy)
 
-	err := sp.Build(compNode.Content[0], idx)
+	err := sp.Build(nil, compNode.Content[0], idx)
 	assert.NoError(t, err)
 
 	lowproxy := low.NodeReference[*lowbase.SchemaProxy]{

--- a/datamodel/high/base/security_requirement_test.go
+++ b/datamodel/high/base/security_requirement_test.go
@@ -28,7 +28,7 @@ cake:
 	var lowExt lowbase.SecurityRequirement
 	_ = lowmodel.BuildModel(cNode.Content[0], &lowExt)
 
-	_ = lowExt.Build(cNode.Content[0], nil)
+	_ = lowExt.Build(nil, cNode.Content[0], nil)
 
 	highExt := NewSecurityRequirement(&lowExt)
 

--- a/datamodel/high/base/tag_test.go
+++ b/datamodel/high/base/tag_test.go
@@ -28,7 +28,7 @@ x-hack: code`
 
 	var lowTag lowbase.Tag
 	_ = lowmodel.BuildModel(cNode.Content[0], &lowTag)
-	_ = lowTag.Build(cNode.Content[0], nil)
+	_ = lowTag.Build(nil, cNode.Content[0], nil)
 
 	highTag := NewTag(&lowTag)
 
@@ -75,7 +75,7 @@ x-hack: code`
 	// build out the low-level model
 	var lowTag lowbase.Tag
 	_ = lowmodel.BuildModel(node.Content[0], &lowTag)
-	_ = lowTag.Build(node.Content[0], nil)
+	_ = lowTag.Build(nil, node.Content[0], nil)
 
 	// build the high level tag
 	highTag := NewTag(&lowTag)

--- a/datamodel/high/v2/path_item_test.go
+++ b/datamodel/high/v2/path_item_test.go
@@ -36,7 +36,7 @@ options:
 
 	var n v2.PathItem
 	_ = low.BuildModel(&idxNode, &n)
-	_ = n.Build(idxNode.Content[0], idx)
+	_ = n.Build(nil, idxNode.Content[0], idx)
 
 	r := NewPathItem(&n)
 

--- a/datamodel/high/v3/callback_test.go
+++ b/datamodel/high/v3/callback_test.go
@@ -65,7 +65,7 @@ func TestCallback_MarshalYAML(t *testing.T) {
 
 	var n v3.Callback
 	_ = low.BuildModel(idxNode.Content[0], &n)
-	_ = n.Build(idxNode.Content[0], idx)
+	_ = n.Build(nil, idxNode.Content[0], idx)
 
 	r := NewCallback(&n)
 

--- a/datamodel/high/v3/media_type_test.go
+++ b/datamodel/high/v3/media_type_test.go
@@ -161,7 +161,7 @@ func TestMediaType_Examples(t *testing.T) {
 
 	var n v3.MediaType
 	_ = low.BuildModel(idxNode.Content[0], &n)
-	_ = n.Build(idxNode.Content[0], idx)
+	_ = n.Build(nil, idxNode.Content[0], idx)
 
 	r := NewMediaType(&n)
 

--- a/datamodel/high/v3/oauth_flows_test.go
+++ b/datamodel/high/v3/oauth_flows_test.go
@@ -43,7 +43,7 @@ clientCredentials:
 
 	var n v3.OAuthFlows
 	_ = low.BuildModel(&idxNode, &n)
-	_ = n.Build(idxNode.Content[0], idx)
+	_ = n.Build(nil, idxNode.Content[0], idx)
 
 	r := NewOAuthFlows(&n)
 

--- a/datamodel/high/v3/operation_test.go
+++ b/datamodel/high/v3/operation_test.go
@@ -43,7 +43,7 @@ callbacks:
 
 	var n v3.Operation
 	_ = low.BuildModel(&idxNode, &n)
-	_ = n.Build(idxNode.Content[0], idx)
+	_ = n.Build(nil, idxNode.Content[0], idx)
 
 	r := NewOperation(&n)
 
@@ -140,7 +140,7 @@ security: []`
 
 	var n v3.Operation
 	_ = low.BuildModel(&idxNode, &n)
-	_ = n.Build(idxNode.Content[0], idx)
+	_ = n.Build(nil, idxNode.Content[0], idx)
 
 	r := NewOperation(&n)
 
@@ -158,7 +158,7 @@ func TestOperation_NoSecurity(t *testing.T) {
 
 	var n v3.Operation
 	_ = low.BuildModel(&idxNode, &n)
-	_ = n.Build(idxNode.Content[0], idx)
+	_ = n.Build(nil, idxNode.Content[0], idx)
 
 	r := NewOperation(&n)
 

--- a/datamodel/high/v3/path_item_test.go
+++ b/datamodel/high/v3/path_item_test.go
@@ -28,7 +28,7 @@ func TestPathItem(t *testing.T) {
 
 	var n v3.PathItem
 	_ = low.BuildModel(&idxNode, &n)
-	_ = n.Build(idxNode.Content[0], idx)
+	_ = n.Build(nil, idxNode.Content[0], idx)
 
 	r := NewPathItem(&n)
 
@@ -62,7 +62,7 @@ trace:
 
 	var n v3.PathItem
 	_ = low.BuildModel(&idxNode, &n)
-	_ = n.Build(idxNode.Content[0], idx)
+	_ = n.Build(nil, idxNode.Content[0], idx)
 
 	r := NewPathItem(&n)
 

--- a/datamodel/high/v3/paths_test.go
+++ b/datamodel/high/v3/paths_test.go
@@ -37,7 +37,7 @@ func TestPaths_MarshalYAML(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.NoError(t, err)
 
 	high := NewPaths(&n)
@@ -89,7 +89,7 @@ func TestPaths_MarshalYAMLInline(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.NoError(t, err)
 
 	high := NewPaths(&n)

--- a/datamodel/high/v3/response_test.go
+++ b/datamodel/high/v3/response_test.go
@@ -38,7 +38,7 @@ links:
 
 	var n v3.Response
 	_ = low.BuildModel(idxNode.Content[0], &n)
-	_ = n.Build(idxNode.Content[0], idx)
+	_ = n.Build(nil, idxNode.Content[0], idx)
 
 	r := NewResponse(&n)
 
@@ -69,7 +69,7 @@ links:
 
 	var n v3.Response
 	_ = low.BuildModel(idxNode.Content[0], &n)
-	_ = n.Build(idxNode.Content[0], idx)
+	_ = n.Build(nil, idxNode.Content[0], idx)
 
 	r := NewResponse(&n)
 
@@ -97,7 +97,7 @@ links:
 
 	var n v3.Response
 	_ = low.BuildModel(idxNode.Content[0], &n)
-	_ = n.Build(idxNode.Content[0], idx)
+	_ = n.Build(nil, idxNode.Content[0], idx)
 
 	r := NewResponse(&n)
 

--- a/datamodel/high/v3/responses_test.go
+++ b/datamodel/high/v3/responses_test.go
@@ -30,7 +30,7 @@ func TestNewResponses(t *testing.T) {
 
 	var n v3.Responses
 	_ = low.BuildModel(&idxNode, &n)
-	_ = n.Build(idxNode.Content[0], idx)
+	_ = n.Build(nil, idxNode.Content[0], idx)
 
 	r := NewResponses(&n)
 
@@ -60,7 +60,7 @@ func TestResponses_MarshalYAML(t *testing.T) {
 
 	var n v3.Responses
 	_ = low.BuildModel(idxNode.Content[0], &n)
-	_ = n.Build(idxNode.Content[0], idx)
+	_ = n.Build(nil, idxNode.Content[0], idx)
 
 	r := NewResponses(&n)
 
@@ -90,7 +90,7 @@ func TestResponses_MarshalYAMLInline(t *testing.T) {
 
 	var n v3.Responses
 	_ = low.BuildModel(idxNode.Content[0], &n)
-	_ = n.Build(idxNode.Content[0], idx)
+	_ = n.Build(nil, idxNode.Content[0], idx)
 
 	r := NewResponses(&n)
 

--- a/datamodel/high/v3/security_scheme_test.go
+++ b/datamodel/high/v3/security_scheme_test.go
@@ -31,7 +31,7 @@ func TestSecurityScheme_MarshalYAML(t *testing.T) {
 
 	var n v3.SecurityScheme
 	_ = low.BuildModel(idxNode.Content[0], &n)
-	_ = n.Build(idxNode.Content[0], idx)
+	_ = n.Build(nil, idxNode.Content[0], idx)
 
 	r := NewSecurityScheme(&n)
 

--- a/datamodel/low/base/contact.go
+++ b/datamodel/low/base/contact.go
@@ -23,7 +23,7 @@ type Contact struct {
 }
 
 // Build is not implemented for Contact (there is nothing to build).
-func (c *Contact) Build(_ *yaml.Node, _ *index.SpecIndex) error {
+func (c *Contact) Build(_, _ *yaml.Node, _ *index.SpecIndex) error {
 	c.Reference = new(low.Reference)
 	// not implemented.
 	return nil

--- a/datamodel/low/base/example.go
+++ b/datamodel/low/base/example.go
@@ -60,7 +60,7 @@ func (ex *Example) Hash() [32]byte {
 }
 
 // Build extracts extensions and example value
-func (ex *Example) Build(root *yaml.Node, idx *index.SpecIndex) error {
+func (ex *Example) Build(_, root *yaml.Node, idx *index.SpecIndex) error {
 	root = utils.NodeAlias(root)
 	utils.CheckForMergeNodes(root)
 	ex.Reference = new(low.Reference)

--- a/datamodel/low/base/example_test.go
+++ b/datamodel/low/base/example_test.go
@@ -26,7 +26,7 @@ x-cake: hot`
 	err := low.BuildModel(idxNode.Content[0], &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.NoError(t, err)
 	assert.Equal(t, "hot", n.Summary.Value)
 	assert.Equal(t, "cakes", n.Description.Value)
@@ -52,7 +52,7 @@ x-cake: hot`
 	err := low.BuildModel(idxNode.Content[0], &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.NoError(t, err)
 	assert.Equal(t, "hot", n.Summary.Value)
 	assert.Equal(t, "cakes", n.Description.Value)
@@ -79,7 +79,7 @@ value:
 	err := low.BuildModel(idxNode.Content[0], &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.NoError(t, err)
 	assert.Equal(t, "hot", n.Summary.Value)
 	assert.Equal(t, "cakes", n.Description.Value)
@@ -110,7 +110,7 @@ value:
 	err := low.BuildModel(idxNode.Content[0], &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.NoError(t, err)
 	assert.Equal(t, "hot", n.Summary.Value)
 	assert.Equal(t, "cakes", n.Description.Value)
@@ -142,7 +142,7 @@ func TestExample_Build_Success_MergeNode(t *testing.T) {
 	err := low.BuildModel(idxNode.Content[0], &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.NoError(t, err)
 	assert.Equal(t, "hot", n.Summary.Value)
 	assert.Equal(t, "cakes", n.Description.Value)
@@ -237,8 +237,8 @@ x-burger: nice`
 	var rDoc Example
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	assert.Equal(t, lDoc.Hash(), rDoc.Hash())
 	assert.Len(t, lDoc.GetExtensions(), 1)

--- a/datamodel/low/base/external_doc.go
+++ b/datamodel/low/base/external_doc.go
@@ -33,7 +33,7 @@ func (ex *ExternalDoc) FindExtension(ext string) *low.ValueReference[any] {
 }
 
 // Build will extract extensions from the ExternalDoc instance.
-func (ex *ExternalDoc) Build(root *yaml.Node, idx *index.SpecIndex) error {
+func (ex *ExternalDoc) Build(_, root *yaml.Node, idx *index.SpecIndex) error {
 	root = utils.NodeAlias(root)
 	utils.CheckForMergeNodes(root)
 	ex.Reference = new(low.Reference)

--- a/datamodel/low/base/external_doc_test.go
+++ b/datamodel/low/base/external_doc_test.go
@@ -23,7 +23,7 @@ func TestExternalDoc_FindExtension(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.NoError(t, err)
 	assert.Equal(t, "cake", n.FindExtension("x-fish").Value)
 
@@ -44,7 +44,7 @@ x-b33f: princess`
 	err := low.BuildModel(idxNode.Content[0], &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.NoError(t, err)
 	assert.Equal(t, "https://pb33f.io", n.URL.Value)
 	assert.Equal(t, "the ranch", n.Description.Value)
@@ -73,8 +73,8 @@ description: the ranch`
 	var rDoc ExternalDoc
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	assert.Equal(t, lDoc.Hash(), rDoc.Hash())
 	assert.Len(t, lDoc.GetExtensions(), 1)

--- a/datamodel/low/base/info.go
+++ b/datamodel/low/base/info.go
@@ -45,7 +45,7 @@ func (i *Info) GetExtensions() map[low.KeyReference[string]]low.ValueReference[a
 }
 
 // Build will extract out the Contact and Info objects from the supplied root node.
-func (i *Info) Build(root *yaml.Node, idx *index.SpecIndex) error {
+func (i *Info) Build(_, root *yaml.Node, idx *index.SpecIndex) error {
 	root = utils.NodeAlias(root)
 	utils.CheckForMergeNodes(root)
 	i.Reference = new(low.Reference)

--- a/datamodel/low/base/info_test.go
+++ b/datamodel/low/base/info_test.go
@@ -34,7 +34,7 @@ x-cli-name: pizza cli`
 	err := low.BuildModel(idxNode.Content[0], &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil,idxNode.Content[0], idx)
 	assert.NoError(t, err)
 
 	assert.Equal(t, "pizza", n.Title.Value)
@@ -61,13 +61,13 @@ x-cli-name: pizza cli`
 
 func TestContact_Build(t *testing.T) {
 	n := &Contact{}
-	k := n.Build(nil, nil)
+	k := n.Build(nil, nil, nil)
 	assert.Nil(t, k)
 }
 
 func TestLicense_Build(t *testing.T) {
 	n := &License{}
-	k := n.Build(nil, nil)
+	k := n.Build(nil, nil, nil)
 	assert.Nil(t, k)
 }
 
@@ -107,8 +107,8 @@ x-b33f: princess`
 	var rDoc Info
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	assert.Equal(t, lDoc.Hash(), rDoc.Hash())
 }

--- a/datamodel/low/base/license.go
+++ b/datamodel/low/base/license.go
@@ -25,7 +25,7 @@ type License struct {
 }
 
 // Build out a license, complain if both a URL and identifier are present as they are mutually exclusive
-func (l *License) Build(root *yaml.Node, idx *index.SpecIndex) error {
+func (l *License) Build(_, root *yaml.Node, idx *index.SpecIndex) error {
 	root = utils.NodeAlias(root)
 	utils.CheckForMergeNodes(root)
 	l.Reference = new(low.Reference)

--- a/datamodel/low/base/license_test.go
+++ b/datamodel/low/base/license_test.go
@@ -70,7 +70,7 @@ description: the ranch`
 	var lDoc License
 	err := low.BuildModel(lNode.Content[0], &lDoc)
 
-	err = lDoc.Build(lNode.Content[0], nil)
+	err = lDoc.Build(nil, lNode.Content[0], nil)
 
 	assert.Error(t, err)
 	assert.Equal(t, "license cannot have both a URL and an identifier, they are mutually exclusive", err.Error())

--- a/datamodel/low/base/schema.go
+++ b/datamodel/low/base/schema.go
@@ -752,7 +752,7 @@ func (s *Schema) Build(root *yaml.Node, idx *index.SpecIndex) error {
 	if extDocNode != nil {
 		var exDoc ExternalDoc
 		_ = low.BuildModel(extDocNode, &exDoc)
-		_ = exDoc.Build(extDocNode, idx) // throws no errors, can't check for one.
+		_ = exDoc.Build(extDocLabel, extDocNode, idx) // throws no errors, can't check for one.
 		s.ExternalDocs = low.NodeReference[*ExternalDoc]{Value: &exDoc, KeyNode: extDocLabel, ValueNode: extDocNode}
 	}
 

--- a/datamodel/low/base/schema_proxy.go
+++ b/datamodel/low/base/schema_proxy.go
@@ -54,10 +54,12 @@ type SchemaProxy struct {
 }
 
 // Build will prepare the SchemaProxy for rendering, it does not build the Schema, only sets up internal state.
-func (sp *SchemaProxy) Build(root *yaml.Node, idx *index.SpecIndex) error {
-	sp.vn = root
+// Key maybe nil if absent.
+func (sp *SchemaProxy) Build(key, value *yaml.Node, idx *index.SpecIndex) error {
+	sp.kn = key
+	sp.vn = value
 	sp.idx = idx
-	if rf, _, r := utils.IsNodeRefValue(root); rf {
+	if rf, _, r := utils.IsNodeRefValue(value); rf {
 		sp.isReference = true
 		sp.referenceLookup = r
 	}
@@ -125,6 +127,11 @@ func (sp *SchemaProxy) SetReference(ref string) {
 // IsSchemaReference()
 func (sp *SchemaProxy) GetSchemaReference() string {
 	return sp.referenceLookup
+}
+
+// GetKeyNode will return the yaml.Node pointer that is a key for value node.
+func (sp *SchemaProxy) GetKeyNode() *yaml.Node {
+	return sp.kn
 }
 
 // GetValueNode will return the yaml.Node pointer used by the proxy to generate the Schema.

--- a/datamodel/low/base/schema_proxy_test.go
+++ b/datamodel/low/base/schema_proxy_test.go
@@ -19,7 +19,7 @@ description: something`
 	var idxNode yaml.Node
 	_ = yaml.Unmarshal([]byte(yml), &idxNode)
 
-	err := sch.Build(nil, idxNode.Content[0], nil)
+	err := sch.Build(&idxNode, idxNode.Content[0], nil)
 	assert.NoError(t, err)
 
 	assert.Equal(t, "db2a35dd6fb3d9481d0682571b9d687616bb2a34c1887f7863f0b2e769ca7b23",
@@ -27,6 +27,7 @@ description: something`
 
 	assert.Equal(t, "something", sch.Schema().Description.Value)
 	assert.Empty(t, sch.GetSchemaReference())
+	assert.NotNil(t, sch.GetKeyNode())
 	assert.NotNil(t, sch.GetValueNode())
 	assert.False(t, sch.IsSchemaReference())
 	assert.False(t, sch.IsReference())

--- a/datamodel/low/base/schema_proxy_test.go
+++ b/datamodel/low/base/schema_proxy_test.go
@@ -19,7 +19,7 @@ description: something`
 	var idxNode yaml.Node
 	_ = yaml.Unmarshal([]byte(yml), &idxNode)
 
-	err := sch.Build(idxNode.Content[0], nil)
+	err := sch.Build(nil, idxNode.Content[0], nil)
 	assert.NoError(t, err)
 
 	assert.Equal(t, "db2a35dd6fb3d9481d0682571b9d687616bb2a34c1887f7863f0b2e769ca7b23",
@@ -50,7 +50,7 @@ func TestSchemaProxy_Build_CheckRef(t *testing.T) {
 	var idxNode yaml.Node
 	_ = yaml.Unmarshal([]byte(yml), &idxNode)
 
-	err := sch.Build(idxNode.Content[0], nil)
+	err := sch.Build(nil, idxNode.Content[0], nil)
 	assert.NoError(t, err)
 	assert.True(t, sch.IsSchemaReference())
 	assert.Equal(t, "wat", sch.GetSchemaReference())
@@ -66,7 +66,7 @@ func TestSchemaProxy_Build_HashInline(t *testing.T) {
 	var idxNode yaml.Node
 	_ = yaml.Unmarshal([]byte(yml), &idxNode)
 
-	err := sch.Build(idxNode.Content[0], nil)
+	err := sch.Build(nil, idxNode.Content[0], nil)
 	assert.NoError(t, err)
 	assert.False(t, sch.IsSchemaReference())
 	assert.NotNil(t, sch.Schema())
@@ -88,7 +88,7 @@ x-common-definitions:
 	var idxNode yaml.Node
 	_ = yaml.Unmarshal([]byte(yml), &idxNode)
 
-	err := sch.Build(idxNode.Content[0], nil)
+	err := sch.Build(nil, idxNode.Content[0], nil)
 	assert.NoError(t, err)
 	assert.Len(t, sch.Schema().Enum.Value, 3)
 	assert.Equal(t, "The type of life cycle", sch.Schema().Description.Value)

--- a/datamodel/low/base/security_requirement.go
+++ b/datamodel/low/base/security_requirement.go
@@ -28,7 +28,7 @@ type SecurityRequirement struct {
 }
 
 // Build will extract security requirements from the node (the structure is odd, to be honest)
-func (s *SecurityRequirement) Build(root *yaml.Node, _ *index.SpecIndex) error {
+func (s *SecurityRequirement) Build(_, root *yaml.Node, _ *index.SpecIndex) error {
 	root = utils.NodeAlias(root)
 	utils.CheckForMergeNodes(root)
 	s.Reference = new(low.Reference)

--- a/datamodel/low/base/security_requirement_test.go
+++ b/datamodel/low/base/security_requirement_test.go
@@ -33,8 +33,8 @@ one:
 	var idxNode2 yaml.Node
 	_ = yaml.Unmarshal([]byte(yml2), &idxNode2)
 
-	_ = sr.Build(idxNode.Content[0], nil)
-	_ = sr2.Build(idxNode2.Content[0], nil)
+	_ = sr.Build(nil, idxNode.Content[0], nil)
+	_ = sr2.Build(nil, idxNode2.Content[0], nil)
 
 	assert.Len(t, sr.Requirements.Value, 2)
 	assert.Len(t, sr.GetKeys(), 2)

--- a/datamodel/low/base/tag.go
+++ b/datamodel/low/base/tag.go
@@ -34,7 +34,7 @@ func (t *Tag) FindExtension(ext string) *low.ValueReference[any] {
 }
 
 // Build will extract extensions and external docs for the Tag.
-func (t *Tag) Build(root *yaml.Node, idx *index.SpecIndex) error {
+func (t *Tag) Build(_, root *yaml.Node, idx *index.SpecIndex) error {
 	root = utils.NodeAlias(root)
 	utils.CheckForMergeNodes(root)
 	t.Reference = new(low.Reference)

--- a/datamodel/low/base/tag_test.go
+++ b/datamodel/low/base/tag_test.go
@@ -27,7 +27,7 @@ x-coffee: tasty`
 	err := low.BuildModel(idxNode.Content[0], &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.NoError(t, err)
 	assert.Equal(t, "a tag", n.Name.Value)
 	assert.Equal(t, "a description", n.Description.Value)
@@ -52,7 +52,7 @@ externalDocs:
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 }
 
@@ -79,8 +79,8 @@ x-b33f: princess`
 	var rDoc Tag
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	assert.Equal(t, lDoc.Hash(), rDoc.Hash())
 

--- a/datamodel/low/extraction_functions.go
+++ b/datamodel/low/extraction_functions.go
@@ -118,7 +118,7 @@ func LocateRefNode(root *yaml.Node, idx *index.SpecIndex) (*yaml.Node, error) {
 
 // ExtractObjectRaw will extract a typed Buildable[N] object from a root yaml.Node. The 'raw' aspect is
 // that there is no NodeReference wrapper around the result returned, just the raw object.
-func ExtractObjectRaw[T Buildable[N], N any](root *yaml.Node, idx *index.SpecIndex) (T, error, bool, string) {
+func ExtractObjectRaw[T Buildable[N], N any](key, root *yaml.Node, idx *index.SpecIndex) (T, error, bool, string) {
 	var circError error
 	var isReference bool
 	var referenceValue string
@@ -143,7 +143,7 @@ func ExtractObjectRaw[T Buildable[N], N any](root *yaml.Node, idx *index.SpecInd
 	if err != nil {
 		return n, err, isReference, referenceValue
 	}
-	err = n.Build(root, idx)
+	err = n.Build(key, root, idx)
 	if err != nil {
 		return n, err, isReference, referenceValue
 	}
@@ -211,7 +211,7 @@ func ExtractObject[T Buildable[N], N any](label string, root *yaml.Node, idx *in
 	if ln == nil {
 		return NodeReference[T]{}, nil
 	}
-	err = n.Build(vn, idx)
+	err = n.Build(ln, vn, idx)
 	if err != nil {
 		return NodeReference[T]{}, err
 	}
@@ -316,7 +316,7 @@ func ExtractArray[T Buildable[N], N any](label string, root *yaml.Node, idx *ind
 			if err != nil {
 				return []ValueReference[T]{}, ln, vn, err
 			}
-			berr := n.Build(node, idx)
+			berr := n.Build(ln, node, idx)
 			if berr != nil {
 				return nil, ln, vn, berr
 			}
@@ -423,7 +423,7 @@ func ExtractMapNoLookupExtensions[PT Buildable[N], N any](
 			if err != nil {
 				return nil, err
 			}
-			berr := n.Build(node, idx)
+			berr := n.Build(currentKey, node, idx)
 			if berr != nil {
 				return nil, berr
 			}
@@ -531,7 +531,7 @@ func ExtractMapExtensions[PT Buildable[N], N any](
 			var n PT = new(N)
 			value = utils.NodeAlias(value)
 			_ = BuildModel(value, n)
-			err := n.Build(value, idx)
+			err := n.Build(label, value, idx)
 			if err != nil {
 				ec <- err
 				return

--- a/datamodel/low/extraction_functions_test.go
+++ b/datamodel/low/extraction_functions_test.go
@@ -140,7 +140,7 @@ type pizza struct {
 	Description NodeReference[string]
 }
 
-func (p *pizza) Build(_ *yaml.Node, _ *index.SpecIndex) error {
+func (p *pizza) Build(_, _ *yaml.Node, _ *index.SpecIndex) error {
 	return nil
 }
 
@@ -341,7 +341,7 @@ type test_borked struct {
 	DontWork int
 }
 
-func (t test_borked) Build(root *yaml.Node, idx *index.SpecIndex) error {
+func (t test_borked) Build(_, root *yaml.Node, idx *index.SpecIndex) error {
 	return fmt.Errorf("I am always going to fail, every thing")
 }
 
@@ -349,7 +349,7 @@ type test_noGood struct {
 	DontWork int
 }
 
-func (t *test_noGood) Build(root *yaml.Node, idx *index.SpecIndex) error {
+func (t *test_noGood) Build(_, root *yaml.Node, idx *index.SpecIndex) error {
 	return fmt.Errorf("I am always going to fail a core build")
 }
 
@@ -357,7 +357,7 @@ type test_almostGood struct {
 	AlmostWork NodeReference[int]
 }
 
-func (t *test_almostGood) Build(root *yaml.Node, idx *index.SpecIndex) error {
+func (t *test_almostGood) Build(_, root *yaml.Node, idx *index.SpecIndex) error {
 	return fmt.Errorf("I am always going to fail a build out")
 }
 
@@ -365,7 +365,7 @@ type test_Good struct {
 	AlmostWork NodeReference[int]
 }
 
-func (t *test_Good) Build(root *yaml.Node, idx *index.SpecIndex) error {
+func (t *test_Good) Build(_, root *yaml.Node, idx *index.SpecIndex) error {
 	return nil
 }
 
@@ -519,7 +519,7 @@ func TestExtractObjectRaw(t *testing.T) {
 	var cNode yaml.Node
 	_ = yaml.Unmarshal([]byte(yml), &cNode)
 
-	tag, err, _, _ := ExtractObjectRaw[*pizza](cNode.Content[0], idx)
+	tag, err, _, _ := ExtractObjectRaw[*pizza](nil, cNode.Content[0], idx)
 	assert.NoError(t, err)
 	assert.NotNil(t, tag)
 	assert.Equal(t, "hello pizza", tag.Description.Value)
@@ -542,7 +542,7 @@ func TestExtractObjectRaw_With_Ref(t *testing.T) {
 	var cNode yaml.Node
 	_ = yaml.Unmarshal([]byte(yml), &cNode)
 
-	tag, err, isRef, rv := ExtractObjectRaw[*pizza](cNode.Content[0], idx)
+	tag, err, isRef, rv := ExtractObjectRaw[*pizza](nil, cNode.Content[0], idx)
 	assert.NoError(t, err)
 	assert.NotNil(t, tag)
 	assert.Equal(t, "hello", tag.Description.Value)
@@ -572,7 +572,7 @@ func TestExtractObjectRaw_Ref_Circular(t *testing.T) {
 	var cNode yaml.Node
 	_ = yaml.Unmarshal([]byte(yml), &cNode)
 
-	tag, err, _, _ := ExtractObjectRaw[*pizza](cNode.Content[0], idx)
+	tag, err, _, _ := ExtractObjectRaw[*pizza](nil, cNode.Content[0], idx)
 	assert.Error(t, err)
 	assert.NotNil(t, tag)
 
@@ -594,7 +594,7 @@ func TestExtractObjectRaw_RefBroken(t *testing.T) {
 	var cNode yaml.Node
 	_ = yaml.Unmarshal([]byte(yml), &cNode)
 
-	tag, err, _, _ := ExtractObjectRaw[*pizza](cNode.Content[0], idx)
+	tag, err, _, _ := ExtractObjectRaw[*pizza](nil, cNode.Content[0], idx)
 	assert.Error(t, err)
 	assert.Nil(t, tag)
 
@@ -616,7 +616,7 @@ func TestExtractObjectRaw_Ref_NonBuildable(t *testing.T) {
 	var cNode yaml.Node
 	_ = yaml.Unmarshal([]byte(yml), &cNode)
 
-	_, err, _, _ := ExtractObjectRaw[*test_noGood](cNode.Content[0], idx)
+	_, err, _, _ := ExtractObjectRaw[*test_noGood](nil, cNode.Content[0], idx)
 	assert.Error(t, err)
 
 }
@@ -637,7 +637,7 @@ func TestExtractObjectRaw_Ref_AlmostBuildable(t *testing.T) {
 	var cNode yaml.Node
 	_ = yaml.Unmarshal([]byte(yml), &cNode)
 
-	_, err, _, _ := ExtractObjectRaw[*test_almostGood](cNode.Content[0], idx)
+	_, err, _, _ := ExtractObjectRaw[*test_almostGood](nil, cNode.Content[0], idx)
 	assert.Error(t, err)
 
 }

--- a/datamodel/low/reference.go
+++ b/datamodel/low/reference.go
@@ -38,7 +38,7 @@ type IsReferenced interface {
 //
 // Used by generic functions when automatically building out structs based on yaml.Node inputs.
 type Buildable[T any] interface {
-	Build(node *yaml.Node, idx *index.SpecIndex) error
+	Build(key, value *yaml.Node, idx *index.SpecIndex) error
 	*T
 }
 

--- a/datamodel/low/v2/definitions.go
+++ b/datamodel/low/v2/definitions.go
@@ -71,7 +71,7 @@ func (s *SecurityDefinitions) FindSecurityDefinition(securityDef string) *low.Va
 }
 
 // Build will extract all definitions into SchemaProxy instances.
-func (d *Definitions) Build(root *yaml.Node, idx *index.SpecIndex) error {
+func (d *Definitions) Build(_, root *yaml.Node, idx *index.SpecIndex) error {
 	root = utils.NodeAlias(root)
 	utils.CheckForMergeNodes(root)
 	errorChan := make(chan error)
@@ -87,7 +87,7 @@ func (d *Definitions) Build(root *yaml.Node, idx *index.SpecIndex) error {
 		var buildFunc = func(label *yaml.Node, value *yaml.Node, idx *index.SpecIndex,
 			r chan definitionResult[*base.SchemaProxy], e chan error) {
 
-			obj, err, _, rv := low.ExtractObjectRaw[*base.SchemaProxy](value, idx)
+			obj, err, _, rv := low.ExtractObjectRaw[*base.SchemaProxy](defLabel, value, idx)
 			if err != nil {
 				e <- err
 			}
@@ -133,7 +133,7 @@ func (d *Definitions) Hash() [32]byte {
 }
 
 // Build will extract all ParameterDefinitions into Parameter instances.
-func (pd *ParameterDefinitions) Build(root *yaml.Node, idx *index.SpecIndex) error {
+func (pd *ParameterDefinitions) Build(_, root *yaml.Node, idx *index.SpecIndex) error {
 	errorChan := make(chan error)
 	resultChan := make(chan definitionResult[*Parameter])
 	var defLabel *yaml.Node
@@ -147,7 +147,7 @@ func (pd *ParameterDefinitions) Build(root *yaml.Node, idx *index.SpecIndex) err
 		var buildFunc = func(label *yaml.Node, value *yaml.Node, idx *index.SpecIndex,
 			r chan definitionResult[*Parameter], e chan error) {
 
-			obj, err, _, rv := low.ExtractObjectRaw[*Parameter](value, idx)
+			obj, err, _, rv := low.ExtractObjectRaw[*Parameter](defLabel, value, idx)
 			if err != nil {
 				e <- err
 			}
@@ -182,7 +182,7 @@ type definitionResult[T any] struct {
 }
 
 // Build will extract all ResponsesDefinitions into Response instances.
-func (r *ResponsesDefinitions) Build(root *yaml.Node, idx *index.SpecIndex) error {
+func (r *ResponsesDefinitions) Build(_, root *yaml.Node, idx *index.SpecIndex) error {
 	errorChan := make(chan error)
 	resultChan := make(chan definitionResult[*Response])
 	var defLabel *yaml.Node
@@ -196,7 +196,7 @@ func (r *ResponsesDefinitions) Build(root *yaml.Node, idx *index.SpecIndex) erro
 		var buildFunc = func(label *yaml.Node, value *yaml.Node, idx *index.SpecIndex,
 			r chan definitionResult[*Response], e chan error) {
 
-			obj, err, _, rv := low.ExtractObjectRaw[*Response](value, idx)
+			obj, err, _, rv := low.ExtractObjectRaw[*Response](defLabel, value, idx)
 			if err != nil {
 				e <- err
 			}
@@ -225,7 +225,7 @@ func (r *ResponsesDefinitions) Build(root *yaml.Node, idx *index.SpecIndex) erro
 }
 
 // Build will extract all SecurityDefinitions into SecurityScheme instances.
-func (s *SecurityDefinitions) Build(root *yaml.Node, idx *index.SpecIndex) error {
+func (s *SecurityDefinitions) Build(_, root *yaml.Node, idx *index.SpecIndex) error {
 	errorChan := make(chan error)
 	resultChan := make(chan definitionResult[*SecurityScheme])
 	var defLabel *yaml.Node
@@ -239,7 +239,7 @@ func (s *SecurityDefinitions) Build(root *yaml.Node, idx *index.SpecIndex) error
 		var buildFunc = func(label *yaml.Node, value *yaml.Node, idx *index.SpecIndex,
 			r chan definitionResult[*SecurityScheme], e chan error) {
 
-			obj, err, _, rv := low.ExtractObjectRaw[*SecurityScheme](value, idx)
+			obj, err, _, rv := low.ExtractObjectRaw[*SecurityScheme](defLabel, value, idx)
 			if err != nil {
 				e <- err
 			}

--- a/datamodel/low/v2/definitions_test.go
+++ b/datamodel/low/v2/definitions_test.go
@@ -25,7 +25,7 @@ func TestDefinitions_Schemas_Build_Error(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 
 }
@@ -44,7 +44,7 @@ func TestDefinitions_Parameters_Build_Error(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 
 }
@@ -63,7 +63,7 @@ func TestDefinitions_Hash(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	_ = n.Build(idxNode.Content[0], idx)
+	_ = n.Build(nil, idxNode.Content[0], idx)
 	assert.Equal(t, "26d23786e6873e1a337f8e9be85f7de1490e4ff6cd303c3b15e593a25a6a149d",
 		low.GenerateHashString(&n))
 
@@ -83,7 +83,7 @@ func TestDefinitions_Responses_Build_Error(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 
 }
@@ -102,7 +102,7 @@ func TestDefinitions_Security_Build_Error(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 
 }

--- a/datamodel/low/v2/examples.go
+++ b/datamodel/low/v2/examples.go
@@ -27,7 +27,7 @@ func (e *Examples) FindExample(name string) *low.ValueReference[any] {
 }
 
 // Build will extract all examples and will attempt to unmarshal content into a map or slice based on type.
-func (e *Examples) Build(root *yaml.Node, _ *index.SpecIndex) error {
+func (e *Examples) Build(_, root *yaml.Node, _ *index.SpecIndex) error {
 	root = utils.NodeAlias(root)
 	utils.CheckForMergeNodes(root)
 	var keyNode, currNode *yaml.Node

--- a/datamodel/low/v2/examples_test.go
+++ b/datamodel/low/v2/examples_test.go
@@ -27,7 +27,7 @@ nothing: int`
 
 	var n Examples
 	_ = low.BuildModel(idxNode.Content[0], &n)
-	_ = n.Build(idxNode.Content[0], idx)
+	_ = n.Build(nil, idxNode.Content[0], idx)
 
 	yml2 := `anything:
   cake: burger
@@ -43,7 +43,7 @@ yes:
 
 	var n2 Examples
 	_ = low.BuildModel(idxNode2.Content[0], &n2)
-	_ = n2.Build(idxNode2.Content[0], idx2)
+	_ = n2.Build(nil, idxNode2.Content[0], idx2)
 
 	assert.Equal(t, n.Hash(), n2.Hash())
 

--- a/datamodel/low/v2/header.go
+++ b/datamodel/low/v2/header.go
@@ -51,7 +51,7 @@ func (h *Header) GetExtensions() map[low.KeyReference[string]]low.ValueReference
 }
 
 // Build will build out items, extensions and default value from the supplied node.
-func (h *Header) Build(root *yaml.Node, idx *index.SpecIndex) error {
+func (h *Header) Build(_, root *yaml.Node, idx *index.SpecIndex) error {
 	root = utils.NodeAlias(root)
 	utils.CheckForMergeNodes(root)
 	h.Extensions = low.ExtractExtensions(root)

--- a/datamodel/low/v2/header_test.go
+++ b/datamodel/low/v2/header_test.go
@@ -25,7 +25,7 @@ func TestHeader_Build(t *testing.T) {
 	err := low.BuildModel(idxNode.Content[0], &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 
 }
@@ -44,7 +44,7 @@ default:
 
 	var n Header
 	_ = low.BuildModel(idxNode.Content[0], &n)
-	_ = n.Build(idxNode.Content[0], idx)
+	_ = n.Build(nil, idxNode.Content[0], idx)
 
 	assert.NotNil(t, n.Default.Value)
 	assert.Len(t, n.Default.Value, 3)
@@ -65,7 +65,7 @@ func TestHeader_DefaultAsObject(t *testing.T) {
 
 	var n Header
 	_ = low.BuildModel(idxNode.Content[0], &n)
-	_ = n.Build(idxNode.Content[0], idx)
+	_ = n.Build(nil, idxNode.Content[0], idx)
 
 	assert.NotNil(t, n.Default.Value)
 }
@@ -80,7 +80,7 @@ func TestHeader_NoDefault(t *testing.T) {
 
 	var n Header
 	_ = low.BuildModel(idxNode.Content[0], &n)
-	_ = n.Build(idxNode.Content[0], idx)
+	_ = n.Build(nil, idxNode.Content[0], idx)
 
 	assert.Equal(t, 12, n.Minimum.Value)
 }
@@ -116,7 +116,7 @@ multipleOf: 12`
 
 	var n Header
 	_ = low.BuildModel(idxNode.Content[0], &n)
-	_ = n.Build(idxNode.Content[0], idx)
+	_ = n.Build(nil, idxNode.Content[0], idx)
 
 	yml2 := `description: head
 items:
@@ -148,7 +148,7 @@ pattern: wow
 
 	var n2 Header
 	_ = low.BuildModel(idxNode2.Content[0], &n2)
-	_ = n2.Build(idxNode2.Content[0], idx2)
+	_ = n2.Build(nil, idxNode2.Content[0], idx2)
 
 	// hash
 	assert.Equal(t, n.Hash(), n2.Hash())

--- a/datamodel/low/v2/items.go
+++ b/datamodel/low/v2/items.go
@@ -102,7 +102,7 @@ func (i *Items) Hash() [32]byte {
 }
 
 // Build will build out items and default value.
-func (i *Items) Build(root *yaml.Node, idx *index.SpecIndex) error {
+func (i *Items) Build(_, root *yaml.Node, idx *index.SpecIndex) error {
 	root = utils.NodeAlias(root)
 	utils.CheckForMergeNodes(root)
 	i.Extensions = low.ExtractExtensions(root)

--- a/datamodel/low/v2/items_test.go
+++ b/datamodel/low/v2/items_test.go
@@ -25,7 +25,7 @@ func TestItems_Build(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 }
 
@@ -42,7 +42,7 @@ default:
 
 	var n Items
 	_ = low.BuildModel(&idxNode, &n)
-	_ = n.Build(idxNode.Content[0], idx)
+	_ = n.Build(nil, idxNode.Content[0], idx)
 
 	assert.Len(t, n.Default.Value, 2)
 	assert.Len(t, n.GetExtensions(), 1)
@@ -60,7 +60,7 @@ func TestItems_DefaultAsMap(t *testing.T) {
 
 	var n Items
 	_ = low.BuildModel(&idxNode, &n)
-	_ = n.Build(idxNode.Content[0], idx)
+	_ = n.Build(nil, idxNode.Content[0], idx)
 
 	assert.Len(t, n.Default.Value, 2)
 
@@ -96,7 +96,7 @@ multipleOf: 12`
 
 	var n Items
 	_ = low.BuildModel(idxNode.Content[0], &n)
-	_ = n.Build(idxNode.Content[0], idx)
+	_ = n.Build(nil, idxNode.Content[0], idx)
 
 	yml2 := `items:
  type: int
@@ -127,7 +127,7 @@ pattern: wow
 
 	var n2 Items
 	_ = low.BuildModel(idxNode2.Content[0], &n2)
-	_ = n2.Build(idxNode2.Content[0], idx2)
+	_ = n2.Build(nil, idxNode2.Content[0], idx2)
 
 	// hash
 	assert.Equal(t, n.Hash(), n2.Hash())

--- a/datamodel/low/v2/operation.go
+++ b/datamodel/low/v2/operation.go
@@ -36,7 +36,7 @@ type Operation struct {
 }
 
 // Build will extract external docs, extensions, parameters, responses and security requirements.
-func (o *Operation) Build(root *yaml.Node, idx *index.SpecIndex) error {
+func (o *Operation) Build(_, root *yaml.Node, idx *index.SpecIndex) error {
 	root = utils.NodeAlias(root)
 	utils.CheckForMergeNodes(root)
 	o.Extensions = low.ExtractExtensions(root)

--- a/datamodel/low/v2/operation_test.go
+++ b/datamodel/low/v2/operation_test.go
@@ -26,7 +26,7 @@ func TestOperation_Build_ExternalDocs(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 
 }
@@ -45,7 +45,7 @@ func TestOperation_Build_Params(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 
 }
@@ -64,7 +64,7 @@ func TestOperation_Build_Responses(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 
 }
@@ -83,7 +83,7 @@ func TestOperation_Build_Security(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 
 }
@@ -126,7 +126,7 @@ x-smoke: not for a while`
 
 	var n Operation
 	_ = low.BuildModel(idxNode.Content[0], &n)
-	_ = n.Build(idxNode.Content[0], idx)
+	_ = n.Build(nil, idxNode.Content[0], idx)
 
 	yml2 := `summary: a nice day
 tags:
@@ -164,7 +164,7 @@ security:
 
 	var n2 Operation
 	_ = low.BuildModel(idxNode2.Content[0], &n2)
-	_ = n2.Build(idxNode2.Content[0], idx2)
+	_ = n2.Build(nil, idxNode2.Content[0], idx2)
 
 	// hash
 	assert.Equal(t, n.Hash(), n2.Hash())

--- a/datamodel/low/v2/parameter.go
+++ b/datamodel/low/v2/parameter.go
@@ -94,7 +94,7 @@ func (p *Parameter) GetExtensions() map[low.KeyReference[string]]low.ValueRefere
 }
 
 // Build will extract out extensions, schema, items and default value
-func (p *Parameter) Build(root *yaml.Node, idx *index.SpecIndex) error {
+func (p *Parameter) Build(_, root *yaml.Node, idx *index.SpecIndex) error {
 	root = utils.NodeAlias(root)
 	utils.CheckForMergeNodes(root)
 	p.Extensions = low.ExtractExtensions(root)

--- a/datamodel/low/v2/parameter_test.go
+++ b/datamodel/low/v2/parameter_test.go
@@ -25,7 +25,7 @@ func TestParameter_Build(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 
 }
@@ -44,7 +44,7 @@ func TestParameter_Build_Items(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 
 }
@@ -63,7 +63,7 @@ func TestParameter_DefaultSlice(t *testing.T) {
 	var n Parameter
 	_ = low.BuildModel(&idxNode, &n)
 
-	_ = n.Build(idxNode.Content[0], idx)
+	_ = n.Build(nil, idxNode.Content[0], idx)
 	assert.Len(t, n.Default.Value.([]any), 3)
 }
 
@@ -80,7 +80,7 @@ func TestParameter_DefaultMap(t *testing.T) {
 	var n Parameter
 	_ = low.BuildModel(&idxNode, &n)
 
-	_ = n.Build(idxNode.Content[0], idx)
+	_ = n.Build(nil, idxNode.Content[0], idx)
 	assert.Len(t, n.Default.Value.(map[string]any), 2)
 }
 
@@ -95,7 +95,7 @@ func TestParameter_NoDefaultNoError(t *testing.T) {
 	var n Parameter
 	_ = low.BuildModel(&idxNode, &n)
 
-	err := n.Build(idxNode.Content[0], idx)
+	err := n.Build(nil, idxNode.Content[0], idx)
 	assert.NoError(t, err)
 }
 
@@ -136,7 +136,7 @@ required: true`
 
 	var n Parameter
 	_ = low.BuildModel(idxNode.Content[0], &n)
-	_ = n.Build(idxNode.Content[0], idx)
+	_ = n.Build(nil, idxNode.Content[0], idx)
 
 	yml2 := `items:
  type: int
@@ -174,7 +174,7 @@ allowEmptyValue: true
 
 	var n2 Parameter
 	_ = low.BuildModel(idxNode2.Content[0], &n2)
-	_ = n2.Build(idxNode2.Content[0], idx2)
+	_ = n2.Build(nil, idxNode2.Content[0], idx2)
 
 	// hash
 	assert.Equal(t, n.Hash(), n2.Hash())

--- a/datamodel/low/v2/path_item.go
+++ b/datamodel/low/v2/path_item.go
@@ -157,7 +157,7 @@ func (p *PathItem) Build(_, root *yaml.Node, idx *index.SpecIndex) error {
 	opErrorChan := make(chan error)
 
 	var buildOpFunc = func(op low.NodeReference[*Operation], ch chan<- bool, errCh chan<- error) {
-		er := op.Value.Build(op.ValueNode, idx)
+		er := op.Value.Build(op.KeyNode, op.ValueNode, idx)
 		if er != nil {
 			errCh <- er
 		}

--- a/datamodel/low/v2/path_item.go
+++ b/datamodel/low/v2/path_item.go
@@ -47,7 +47,7 @@ func (p *PathItem) GetExtensions() map[low.KeyReference[string]]low.ValueReferen
 
 // Build will extract extensions, parameters and operations for all methods. Every method is handled
 // asynchronously, in order to keep things moving quickly for complex operations.
-func (p *PathItem) Build(root *yaml.Node, idx *index.SpecIndex) error {
+func (p *PathItem) Build(_, root *yaml.Node, idx *index.SpecIndex) error {
 	root = utils.NodeAlias(root)
 	utils.CheckForMergeNodes(root)
 	p.Extensions = low.ExtractExtensions(root)

--- a/datamodel/low/v2/path_item_test.go
+++ b/datamodel/low/v2/path_item_test.go
@@ -25,7 +25,7 @@ func TestPathItem_Build_Params(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 
 }
@@ -44,7 +44,7 @@ func TestPathItem_Build_MethodFail(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 
 }
@@ -76,7 +76,7 @@ x-winter: is coming`
 
 	var n PathItem
 	_ = low.BuildModel(idxNode.Content[0], &n)
-	_ = n.Build(idxNode.Content[0], idx)
+	_ = n.Build(nil, idxNode.Content[0], idx)
 
 	yml2 := `post:
   description: post me there
@@ -103,7 +103,7 @@ parameters:
 
 	var n2 PathItem
 	_ = low.BuildModel(idxNode2.Content[0], &n2)
-	_ = n2.Build(idxNode2.Content[0], idx2)
+	_ = n2.Build(nil, idxNode2.Content[0], idx2)
 
 	// hash
 	assert.Equal(t, n.Hash(), n2.Hash())

--- a/datamodel/low/v2/paths.go
+++ b/datamodel/low/v2/paths.go
@@ -51,7 +51,7 @@ func (p *Paths) FindExtension(ext string) *low.ValueReference[any] {
 }
 
 // Build will extract extensions and paths from node.
-func (p *Paths) Build(root *yaml.Node, idx *index.SpecIndex) error {
+func (p *Paths) Build(_, root *yaml.Node, idx *index.SpecIndex) error {
 	root = utils.NodeAlias(root)
 	utils.CheckForMergeNodes(root)
 	p.Extensions = low.ExtractExtensions(root)

--- a/datamodel/low/v2/paths.go
+++ b/datamodel/low/v2/paths.go
@@ -71,7 +71,7 @@ func (p *Paths) Build(_, root *yaml.Node, idx *index.SpecIndex) error {
 	var buildPathItem = func(cNode, pNode *yaml.Node, b chan<- pathBuildResult, e chan<- error) {
 		path := new(PathItem)
 		_ = low.BuildModel(pNode, path)
-		err := path.Build(pNode, idx)
+		err := path.Build(cNode, pNode, idx)
 		if err != nil {
 			e <- err
 			return

--- a/datamodel/low/v2/paths_test.go
+++ b/datamodel/low/v2/paths_test.go
@@ -25,7 +25,7 @@ func TestPaths_Build(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 
 }
@@ -45,7 +45,7 @@ func TestPaths_FindPathAndKey(t *testing.T) {
 
 	var n Paths
 	_ = low.BuildModel(idxNode.Content[0], &n)
-	_ = n.Build(idxNode.Content[0], idx)
+	_ = n.Build(nil, idxNode.Content[0], idx)
 	_, k := n.FindPathAndKey("/no/pizza")
 	assert.Equal(t, "because i'm fat", k.Value.Post.Value.Description.Value)
 
@@ -72,7 +72,7 @@ x-milk: creamy`
 
 	var n Paths
 	_ = low.BuildModel(idxNode.Content[0], &n)
-	_ = n.Build(idxNode.Content[0], idx)
+	_ = n.Build(nil, idxNode.Content[0], idx)
 
 	yml2 := `x-milk: creamy
 /spl/unk:
@@ -92,7 +92,7 @@ x-milk: creamy`
 
 	var n2 Paths
 	_ = low.BuildModel(idxNode2.Content[0], &n2)
-	_ = n2.Build(idxNode2.Content[0], idx2)
+	_ = n2.Build(nil, idxNode2.Content[0], idx2)
 
 	// hash
 	assert.Equal(t, n.Hash(), n2.Hash())

--- a/datamodel/low/v2/response.go
+++ b/datamodel/low/v2/response.go
@@ -43,7 +43,7 @@ func (r *Response) FindHeader(hType string) *low.ValueReference[*Header] {
 }
 
 // Build will extract schema, extensions, examples and headers from node
-func (r *Response) Build(root *yaml.Node, idx *index.SpecIndex) error {
+func (r *Response) Build(_, root *yaml.Node, idx *index.SpecIndex) error {
 	root = utils.NodeAlias(root)
 	utils.CheckForMergeNodes(root)
 	r.Extensions = low.ExtractExtensions(root)

--- a/datamodel/low/v2/response_test.go
+++ b/datamodel/low/v2/response_test.go
@@ -25,7 +25,7 @@ func TestResponse_Build_Schema(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 
 }
@@ -44,7 +44,7 @@ func TestResponse_Build_Examples(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 
 }
@@ -63,7 +63,7 @@ func TestResponse_Build_Headers(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 
 }
@@ -87,7 +87,7 @@ x-herbs: missing`
 
 	var n Response
 	_ = low.BuildModel(idxNode.Content[0], &n)
-	_ = n.Build(idxNode.Content[0], idx)
+	_ = n.Build(nil, idxNode.Content[0], idx)
 
 	yml2 := `description: your thing, sir.
 examples:
@@ -106,7 +106,7 @@ headers:
 
 	var n2 Response
 	_ = low.BuildModel(idxNode2.Content[0], &n2)
-	_ = n2.Build(idxNode2.Content[0], idx2)
+	_ = n2.Build(nil, idxNode2.Content[0], idx2)
 
 	// hash
 	assert.Equal(t, n.Hash(), n2.Hash())

--- a/datamodel/low/v2/responses.go
+++ b/datamodel/low/v2/responses.go
@@ -27,7 +27,7 @@ func (r *Responses) GetExtensions() map[low.KeyReference[string]]low.ValueRefere
 }
 
 // Build will extract default value and extensions from node.
-func (r *Responses) Build(root *yaml.Node, idx *index.SpecIndex) error {
+func (r *Responses) Build(_, root *yaml.Node, idx *index.SpecIndex) error {
 	root = utils.NodeAlias(root)
 	utils.CheckForMergeNodes(root)
 	r.Extensions = low.ExtractExtensions(root)

--- a/datamodel/low/v2/responses_test.go
+++ b/datamodel/low/v2/responses_test.go
@@ -24,7 +24,7 @@ func TestResponses_Build_Response(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 
 }
@@ -43,7 +43,7 @@ func TestResponses_Build_Response_Default(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 
 }
@@ -61,7 +61,7 @@ func TestResponses_Build_WrongType(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 
 }
@@ -88,7 +88,7 @@ x-tea: warm
 
 	var n Responses
 	_ = low.BuildModel(idxNode.Content[0], &n)
-	_ = n.Build(idxNode.Content[0], idx)
+	_ = n.Build(nil, idxNode.Content[0], idx)
 
 	yml2 := `401:
   description: and you are?
@@ -110,7 +110,7 @@ x-tea: warm`
 
 	var n2 Responses
 	_ = low.BuildModel(idxNode2.Content[0], &n2)
-	_ = n2.Build(idxNode2.Content[0], idx2)
+	_ = n2.Build(nil, idxNode2.Content[0], idx2)
 
 	// hash
 	assert.Equal(t, n.Hash(), n2.Hash())

--- a/datamodel/low/v2/scopes.go
+++ b/datamodel/low/v2/scopes.go
@@ -34,7 +34,7 @@ func (s *Scopes) FindScope(scope string) *low.ValueReference[string] {
 }
 
 // Build will extract scope values and extensions from node.
-func (s *Scopes) Build(root *yaml.Node, idx *index.SpecIndex) error {
+func (s *Scopes) Build(_, root *yaml.Node, idx *index.SpecIndex) error {
 	root = utils.NodeAlias(root)
 	utils.CheckForMergeNodes(root)
 	s.Extensions = low.ExtractExtensions(root)

--- a/datamodel/low/v2/scopes_test.go
+++ b/datamodel/low/v2/scopes_test.go
@@ -23,7 +23,7 @@ x-men: needs a reboot or a refresh`
 
 	var n Scopes
 	_ = low.BuildModel(idxNode.Content[0], &n)
-	_ = n.Build(idxNode.Content[0], idx)
+	_ = n.Build(nil, idxNode.Content[0], idx)
 
 	yml2 := `x-men: needs a reboot or a refresh
 pizza: beans
@@ -35,7 +35,7 @@ burgers: chips`
 
 	var n2 Scopes
 	_ = low.BuildModel(idxNode2.Content[0], &n2)
-	_ = n2.Build(idxNode2.Content[0], idx2)
+	_ = n2.Build(nil, idxNode2.Content[0], idx2)
 
 	// hash
 	assert.Equal(t, n.Hash(), n2.Hash())

--- a/datamodel/low/v2/security_scheme.go
+++ b/datamodel/low/v2/security_scheme.go
@@ -38,7 +38,7 @@ func (ss *SecurityScheme) GetExtensions() map[low.KeyReference[string]]low.Value
 }
 
 // Build will extract extensions and scopes from the node.
-func (ss *SecurityScheme) Build(root *yaml.Node, idx *index.SpecIndex) error {
+func (ss *SecurityScheme) Build(_, root *yaml.Node, idx *index.SpecIndex) error {
 	root = utils.NodeAlias(root)
 	utils.CheckForMergeNodes(root)
 	ss.Extensions = low.ExtractExtensions(root)

--- a/datamodel/low/v2/security_scheme_test.go
+++ b/datamodel/low/v2/security_scheme_test.go
@@ -25,7 +25,7 @@ func TestSecurityScheme_Build_Borked(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 
 }
@@ -45,7 +45,7 @@ func TestSecurityScheme_Build_Scopes(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.NoError(t, err)
 	assert.Len(t, n.Scopes.Value.Values, 2)
 
@@ -70,7 +70,7 @@ x-beer: not for a while`
 
 	var n SecurityScheme
 	_ = low.BuildModel(idxNode.Content[0], &n)
-	_ = n.Build(idxNode.Content[0], idx)
+	_ = n.Build(nil, idxNode.Content[0], idx)
 
 	yml2 := `in: my heart
 scopes:
@@ -90,7 +90,7 @@ authorizationUrl: https://pb33f.io
 
 	var n2 SecurityScheme
 	_ = low.BuildModel(idxNode2.Content[0], &n2)
-	_ = n2.Build(idxNode2.Content[0], idx2)
+	_ = n2.Build(nil, idxNode2.Content[0], idx2)
 
 	// hash
 	assert.Equal(t, n.Hash(), n2.Hash())

--- a/datamodel/low/v3/callback.go
+++ b/datamodel/low/v3/callback.go
@@ -39,7 +39,7 @@ func (cb *Callback) FindExpression(exp string) *low.ValueReference[*PathItem] {
 }
 
 // Build will extract extensions, expressions and PathItem objects for Callback
-func (cb *Callback) Build(root *yaml.Node, idx *index.SpecIndex) error {
+func (cb *Callback) Build(_, root *yaml.Node, idx *index.SpecIndex) error {
 	root = utils.NodeAlias(root)
 	utils.CheckForMergeNodes(root)
 	cb.Reference = new(low.Reference)

--- a/datamodel/low/v3/callback.go
+++ b/datamodel/low/v3/callback.go
@@ -57,7 +57,7 @@ func (cb *Callback) Build(_, root *yaml.Node, idx *index.SpecIndex) error {
 		if strings.HasPrefix(currentCB.Value, "x-") {
 			continue // ignore extension.
 		}
-		callback, eErr, _, rv := low.ExtractObjectRaw[*PathItem](callbackNode, idx)
+		callback, eErr, _, rv := low.ExtractObjectRaw[*PathItem](currentCB, callbackNode, idx)
 		if eErr != nil {
 			return eErr
 		}

--- a/datamodel/low/v3/callback_test.go
+++ b/datamodel/low/v3/callback_test.go
@@ -33,7 +33,7 @@ func TestCallback_Build_Success(t *testing.T) {
 	err := low.BuildModel(rootNode.Content[0], &n)
 	assert.NoError(t, err)
 
-	err = n.Build(rootNode.Content[0], nil)
+	err = n.Build(nil, rootNode.Content[0], nil)
 	assert.NoError(t, err)
 
 	assert.Len(t, n.Expression.Value, 1)
@@ -65,7 +65,7 @@ func TestCallback_Build_Error(t *testing.T) {
 	err := low.BuildModel(rootNode.Content[0], &n)
 	assert.NoError(t, err)
 
-	err = n.Build(rootNode.Content[0], idx)
+	err = n.Build(nil, rootNode.Content[0], idx)
 	assert.Error(t, err)
 
 }
@@ -100,7 +100,7 @@ func TestCallback_Build_Using_InlineRef(t *testing.T) {
 	err := low.BuildModel(rootNode.Content[0], &n)
 	assert.NoError(t, err)
 
-	err = n.Build(rootNode.Content[0], idx)
+	err = n.Build(nil, rootNode.Content[0], idx)
 	assert.NoError(t, err)
 	assert.Len(t, n.Expression.Value, 1)
 
@@ -128,7 +128,7 @@ x-weed: loved`
 
 	var n Callback
 	_ = low.BuildModel(idxNode.Content[0], &n)
-	_ = n.Build(idxNode.Content[0], idx)
+	_ = n.Build(nil, idxNode.Content[0], idx)
 
 	yml2 := `burgers:
   description: tasty!
@@ -145,7 +145,7 @@ beer:
 
 	var n2 Callback
 	_ = low.BuildModel(idxNode2.Content[0], &n2)
-	_ = n2.Build(idxNode2.Content[0], idx2)
+	_ = n2.Build(nil, idxNode2.Content[0], idx2)
 
 	// hash
 	assert.Equal(t, n.Hash(), n2.Hash())

--- a/datamodel/low/v3/components.go
+++ b/datamodel/low/v3/components.go
@@ -235,7 +235,8 @@ func extractComponentValues[T low.Buildable[N], N any](label string, root *yaml.
 
 		// build.
 		_ = low.BuildModel(value, n)
-		err = n.Build(value, idx)
+		// todo: label is a key or?
+		err = n.Build(label, value, idx)
 		if err != nil {
 			ec <- err
 			return

--- a/datamodel/low/v3/create_document.go
+++ b/datamodel/low/v3/create_document.go
@@ -117,7 +117,7 @@ func extractInfo(info *datamodel.SpecInfo, doc *Document, idx *index.SpecIndex) 
 	if vn != nil {
 		ir := base.Info{}
 		_ = low.BuildModel(vn, &ir)
-		_ = ir.Build(vn, idx)
+		_ = ir.Build(ln, vn, idx)
 		nr := low.NodeReference[*base.Info]{Value: &ir, ValueNode: vn, KeyNode: ln}
 		doc.Info = nr
 	}
@@ -172,7 +172,7 @@ func extractServers(info *datamodel.SpecInfo, doc *Document, idx *index.SpecInde
 				if utils.IsNodeMap(srvN) {
 					srvr := Server{}
 					_ = low.BuildModel(srvN, &srvr)
-					_ = srvr.Build(srvN, idx)
+					_ = srvr.Build(ln, srvN, idx)
 					servers = append(servers, low.ValueReference[*Server]{
 						Value:     &srvr,
 						ValueNode: srvN,
@@ -198,7 +198,7 @@ func extractTags(info *datamodel.SpecInfo, doc *Document, idx *index.SpecIndex) 
 				if utils.IsNodeMap(tagN) {
 					tag := base.Tag{}
 					_ = low.BuildModel(tagN, &tag)
-					if err := tag.Build(tagN, idx); err != nil {
+					if err := tag.Build(ln, tagN, idx); err != nil {
 						return err
 					}
 					tags = append(tags, low.ValueReference[*base.Tag]{
@@ -221,7 +221,7 @@ func extractPaths(info *datamodel.SpecInfo, doc *Document, idx *index.SpecIndex)
 	_, ln, vn := utils.FindKeyNodeFull(PathsLabel, info.RootNode.Content[0].Content)
 	if vn != nil {
 		ir := Paths{}
-		err := ir.Build(vn, idx)
+		err := ir.Build(ln, vn, idx)
 		if err != nil {
 			return err
 		}

--- a/datamodel/low/v3/encoding.go
+++ b/datamodel/low/v3/encoding.go
@@ -58,7 +58,7 @@ func (en *Encoding) Hash() [32]byte {
 }
 
 // Build will extract all Header objects from supplied node.
-func (en *Encoding) Build(root *yaml.Node, idx *index.SpecIndex) error {
+func (en *Encoding) Build(_, root *yaml.Node, idx *index.SpecIndex) error {
 	root = utils.NodeAlias(root)
 	utils.CheckForMergeNodes(root)
 	en.Reference = new(low.Reference)

--- a/datamodel/low/v3/encoding_test.go
+++ b/datamodel/low/v3/encoding_test.go
@@ -31,7 +31,7 @@ explode: true`
 	err := low.BuildModel(idxNode.Content[0], &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.NoError(t, err)
 	assert.Equal(t, "hot/cakes", n.ContentType.Value)
 	assert.Equal(t, true, n.AllowReserved.Value)
@@ -59,7 +59,7 @@ headers:
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 }
 
@@ -79,7 +79,7 @@ allowReserved: true`
 
 	var n Encoding
 	_ = low.BuildModel(idxNode.Content[0], &n)
-	_ = n.Build(idxNode.Content[0], idx)
+	_ = n.Build(nil, idxNode.Content[0], idx)
 
 	yml2 := `explode: true
 contentType: application/waffle
@@ -96,7 +96,7 @@ style: post modern
 
 	var n2 Encoding
 	_ = low.BuildModel(idxNode2.Content[0], &n2)
-	_ = n2.Build(idxNode2.Content[0], idx2)
+	_ = n2.Build(nil, idxNode2.Content[0], idx2)
 
 	// hash
 	assert.Equal(t, n.Hash(), n2.Hash())

--- a/datamodel/low/v3/header.go
+++ b/datamodel/low/v3/header.go
@@ -95,7 +95,7 @@ func (h *Header) Hash() [32]byte {
 }
 
 // Build will extract extensions, examples, schema and content/media types from node.
-func (h *Header) Build(root *yaml.Node, idx *index.SpecIndex) error {
+func (h *Header) Build(_, root *yaml.Node, idx *index.SpecIndex) error {
 	root = utils.NodeAlias(root)
 	utils.CheckForMergeNodes(root)
 	h.Reference = new(low.Reference)

--- a/datamodel/low/v3/header_test.go
+++ b/datamodel/low/v3/header_test.go
@@ -53,7 +53,7 @@ content:
 	err := low.BuildModel(idxNode.Content[0], &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.NoError(t, err)
 	assert.Equal(t, "michelle, meddy and maddy", n.Description.Value)
 	assert.True(t, n.AllowReserved.Value)
@@ -101,7 +101,7 @@ func TestHeader_Build_Success_Examples(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.NoError(t, err)
 
 	exp := n.FindExample("family").Value
@@ -129,7 +129,7 @@ func TestHeader_Build_Fail_Examples(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 }
 
@@ -145,7 +145,7 @@ func TestHeader_Build_Fail_Schema(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 }
 
@@ -162,7 +162,7 @@ func TestHeader_Build_Fail_Content(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 }
 
@@ -195,7 +195,7 @@ x-mango: chutney`
 
 	var n Header
 	_ = low.BuildModel(idxNode.Content[0], &n)
-	_ = n.Build(idxNode.Content[0], idx)
+	_ = n.Build(nil, idxNode.Content[0], idx)
 
 	yml2 := `x-mango: chutney
 required: true
@@ -224,7 +224,7 @@ schema:
 
 	var n2 Header
 	_ = low.BuildModel(idxNode2.Content[0], &n2)
-	_ = n2.Build(idxNode2.Content[0], idx2)
+	_ = n2.Build(nil, idxNode2.Content[0], idx2)
 
 	// hash
 	assert.Equal(t, n.Hash(), n2.Hash())

--- a/datamodel/low/v3/link.go
+++ b/datamodel/low/v3/link.go
@@ -53,7 +53,7 @@ func (l *Link) FindExtension(ext string) *low.ValueReference[any] {
 }
 
 // Build will extract extensions and servers from the node.
-func (l *Link) Build(root *yaml.Node, idx *index.SpecIndex) error {
+func (l *Link) Build(_, root *yaml.Node, idx *index.SpecIndex) error {
 	root = utils.NodeAlias(root)
 	utils.CheckForMergeNodes(root)
 	l.Reference = new(low.Reference)

--- a/datamodel/low/v3/link_test.go
+++ b/datamodel/low/v3/link_test.go
@@ -33,7 +33,7 @@ x-linky: slinky
 	err := low.BuildModel(idxNode.Content[0], &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.NoError(t, err)
 
 	assert.Equal(t, "#/someref", n.OperationRef.Value)
@@ -75,7 +75,7 @@ server:
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 
 }
@@ -99,7 +99,7 @@ x-mcdonalds: bigmac`
 
 	var n Link
 	_ = low.BuildModel(idxNode.Content[0], &n)
-	_ = n.Build(idxNode.Content[0], idx)
+	_ = n.Build(nil, idxNode.Content[0], idx)
 
 	yml2 := `parameters:
   bacon: eggs
@@ -118,7 +118,7 @@ server:
 
 	var n2 Link
 	_ = low.BuildModel(idxNode2.Content[0], &n2)
-	_ = n2.Build(idxNode2.Content[0], idx2)
+	_ = n2.Build(nil, idxNode2.Content[0], idx2)
 
 	// hash
 	assert.Equal(t, n.Hash(), n2.Hash())

--- a/datamodel/low/v3/media_type.go
+++ b/datamodel/low/v3/media_type.go
@@ -54,7 +54,7 @@ func (mt *MediaType) GetAllExamples() map[low.KeyReference[string]]low.ValueRefe
 }
 
 // Build will extract examples, extensions, schema and encoding from node.
-func (mt *MediaType) Build(root *yaml.Node, idx *index.SpecIndex) error {
+func (mt *MediaType) Build(_, root *yaml.Node, idx *index.SpecIndex) error {
 	root = utils.NodeAlias(root)
 	utils.CheckForMergeNodes(root)
 	mt.Reference = new(low.Reference)

--- a/datamodel/low/v3/media_type_test.go
+++ b/datamodel/low/v3/media_type_test.go
@@ -33,7 +33,7 @@ x-rock: and roll`
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.NoError(t, err)
 	assert.Equal(t, "and roll", n.FindExtension("x-rock").Value)
 	assert.Equal(t, "string", n.Schema.Value.Schema().Type.Value.A)
@@ -56,7 +56,7 @@ func TestMediaType_Build_Fail_Schema(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 }
 
@@ -73,7 +73,7 @@ func TestMediaType_Build_Fail_Examples(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 
 }
@@ -91,7 +91,7 @@ func TestMediaType_Build_Fail_Encoding(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 }
 
@@ -116,7 +116,7 @@ x-done: for the day!`
 
 	var n MediaType
 	_ = low.BuildModel(idxNode.Content[0], &n)
-	_ = n.Build(idxNode.Content[0], idx)
+	_ = n.Build(nil, idxNode.Content[0], idx)
 
 	yml2 := `encoding:
   meaty/chewy:
@@ -137,7 +137,7 @@ example: a thing`
 
 	var n2 MediaType
 	_ = low.BuildModel(idxNode2.Content[0], &n2)
-	_ = n2.Build(idxNode2.Content[0], idx2)
+	_ = n2.Build(nil, idxNode2.Content[0], idx2)
 
 	// hash
 	assert.Equal(t, n.Hash(), n2.Hash())

--- a/datamodel/low/v3/oauth_flows.go
+++ b/datamodel/low/v3/oauth_flows.go
@@ -36,7 +36,7 @@ func (o *OAuthFlows) FindExtension(ext string) *low.ValueReference[any] {
 }
 
 // Build will extract extensions and all OAuthFlow types from the supplied node.
-func (o *OAuthFlows) Build(root *yaml.Node, idx *index.SpecIndex) error {
+func (o *OAuthFlows) Build(_, root *yaml.Node, idx *index.SpecIndex) error {
 	root = utils.NodeAlias(root)
 	utils.CheckForMergeNodes(root)
 	o.Reference = new(low.Reference)
@@ -116,7 +116,7 @@ func (o *OAuthFlow) FindExtension(ext string) *low.ValueReference[any] {
 }
 
 // Build will extract extensions from the node.
-func (o *OAuthFlow) Build(root *yaml.Node, idx *index.SpecIndex) error {
+func (o *OAuthFlow) Build(_, root *yaml.Node, idx *index.SpecIndex) error {
 	o.Reference = new(low.Reference)
 	o.Extensions = low.ExtractExtensions(root)
 	return nil

--- a/datamodel/low/v3/oauth_flows_test.go
+++ b/datamodel/low/v3/oauth_flows_test.go
@@ -30,7 +30,7 @@ x-tasty: herbs
 	err := low.BuildModel(idxNode.Content[0], &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.NoError(t, err)
 	assert.Equal(t, "herbs", n.FindExtension("x-tasty").Value)
 	assert.Equal(t, "https://pb33f.io/auth", n.AuthorizationUrl.Value)
@@ -54,7 +54,7 @@ x-tasty: herbs`
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.NoError(t, err)
 	assert.Equal(t, "herbs", n.FindExtension("x-tasty").Value)
 	assert.Equal(t, "https://pb33f.io/auth", n.Implicit.Value.AuthorizationUrl.Value)
@@ -74,7 +74,7 @@ func TestOAuthFlow_Build_Implicit_Fail(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 }
 
@@ -91,7 +91,7 @@ func TestOAuthFlow_Build_Password(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.NoError(t, err)
 	assert.Equal(t, "https://pb33f.io/auth", n.Password.Value.AuthorizationUrl.Value)
 }
@@ -109,7 +109,7 @@ func TestOAuthFlow_Build_Password_Fail(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 }
 
@@ -126,7 +126,7 @@ func TestOAuthFlow_Build_ClientCredentials(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.NoError(t, err)
 	assert.Equal(t, "https://pb33f.io/auth", n.ClientCredentials.Value.AuthorizationUrl.Value)
 }
@@ -144,7 +144,7 @@ func TestOAuthFlow_Build_ClientCredentials_Fail(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 }
 
@@ -161,7 +161,7 @@ func TestOAuthFlow_Build_AuthCode(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.NoError(t, err)
 	assert.Equal(t, "https://pb33f.io/auth", n.AuthorizationCode.Value.AuthorizationUrl.Value)
 }
@@ -179,7 +179,7 @@ func TestOAuthFlow_Build_AuthCode_Fail(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 }
 
@@ -198,7 +198,7 @@ x-sleepy: tired`
 
 	var n OAuthFlow
 	_ = low.BuildModel(idxNode.Content[0], &n)
-	_ = n.Build(idxNode.Content[0], idx)
+	_ = n.Build(nil, idxNode.Content[0], idx)
 
 	yml2 := `refreshUrl: https://pb33f.io/refresh
 tokenUrl: https://pb33f.io/token
@@ -213,7 +213,7 @@ scopes:
 
 	var n2 OAuthFlow
 	_ = low.BuildModel(idxNode2.Content[0], &n2)
-	_ = n2.Build(idxNode2.Content[0], idx2)
+	_ = n2.Build(nil, idxNode2.Content[0], idx2)
 
 	// hash
 	assert.Equal(t, n.Hash(), n2.Hash())
@@ -239,7 +239,7 @@ x-code: cody
 
 	var n OAuthFlows
 	_ = low.BuildModel(idxNode.Content[0], &n)
-	_ = n.Build(idxNode.Content[0], idx)
+	_ = n.Build(nil, idxNode.Content[0], idx)
 
 	yml2 := `authorizationCode:
   authorizationUrl: https://pb33f.io/auth
@@ -258,7 +258,7 @@ password:
 
 	var n2 OAuthFlows
 	_ = low.BuildModel(idxNode2.Content[0], &n2)
-	_ = n2.Build(idxNode2.Content[0], idx2)
+	_ = n2.Build(nil, idxNode2.Content[0], idx2)
 
 	// hash
 	assert.Equal(t, n.Hash(), n2.Hash())

--- a/datamodel/low/v3/operation.go
+++ b/datamodel/low/v3/operation.go
@@ -55,7 +55,7 @@ func (o *Operation) FindSecurityRequirement(name string) []low.ValueReference[st
 }
 
 // Build will extract external docs, parameters, request body, responses, callbacks, security and servers.
-func (o *Operation) Build(root *yaml.Node, idx *index.SpecIndex) error {
+func (o *Operation) Build(_, root *yaml.Node, idx *index.SpecIndex) error {
 	root = utils.NodeAlias(root)
 	utils.CheckForMergeNodes(root)
 	o.Reference = new(low.Reference)

--- a/datamodel/low/v3/operation_test.go
+++ b/datamodel/low/v3/operation_test.go
@@ -50,7 +50,7 @@ servers:
 	err := low.BuildModel(idxNode.Content[0], &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.NoError(t, err)
 
 	assert.Len(t, n.Tags.Value, 2)
@@ -87,7 +87,7 @@ func TestOperation_Build_FailDocs(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 }
 
@@ -104,7 +104,7 @@ func TestOperation_Build_FailParams(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 }
 
@@ -121,7 +121,7 @@ func TestOperation_Build_FailRequestBody(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 }
 
@@ -138,7 +138,7 @@ func TestOperation_Build_FailResponses(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 }
 
@@ -155,7 +155,7 @@ func TestOperation_Build_FailCallbacks(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 }
 
@@ -172,7 +172,7 @@ func TestOperation_Build_FailSecurity(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 }
 
@@ -189,7 +189,7 @@ func TestOperation_Build_FailServers(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 }
 
@@ -229,7 +229,7 @@ x-mint: sweet`
 
 	var n Operation
 	_ = low.BuildModel(idxNode.Content[0], &n)
-	_ = n.Build(idxNode.Content[0], idx)
+	_ = n.Build(nil, idxNode.Content[0], idx)
 
 	yml2 := `tags:
   - nice
@@ -265,7 +265,7 @@ x-mint: sweet`
 
 	var n2 Operation
 	_ = low.BuildModel(idxNode2.Content[0], &n2)
-	_ = n2.Build(idxNode2.Content[0], idx2)
+	_ = n2.Build(nil, idxNode2.Content[0], idx2)
 
 	// hash
 	assert.Equal(t, n.Hash(), n2.Hash())
@@ -300,7 +300,7 @@ security: []`
 	err := low.BuildModel(idxNode.Content[0], &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.NoError(t, err)
 
 	assert.Len(t, n.Security.Value, 0)

--- a/datamodel/low/v3/parameter.go
+++ b/datamodel/low/v3/parameter.go
@@ -58,7 +58,7 @@ func (p *Parameter) GetExtensions() map[low.KeyReference[string]]low.ValueRefere
 }
 
 // Build will extract examples, extensions and content/media types.
-func (p *Parameter) Build(root *yaml.Node, idx *index.SpecIndex) error {
+func (p *Parameter) Build(_, root *yaml.Node, idx *index.SpecIndex) error {
 	root = utils.NodeAlias(root)
 	utils.CheckForMergeNodes(root)
 	p.Reference = new(low.Reference)

--- a/datamodel/low/v3/parameter_test.go
+++ b/datamodel/low/v3/parameter_test.go
@@ -55,7 +55,7 @@ content:
 	err := low.BuildModel(idxNode.Content[0], &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.NoError(t, err)
 	assert.Equal(t, "michelle, meddy and maddy", n.Description.Value)
 	assert.True(t, n.AllowReserved.Value)
@@ -105,7 +105,7 @@ func TestParameter_Build_Success_Examples(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.NoError(t, err)
 
 	exp := n.FindExample("family").Value
@@ -133,7 +133,7 @@ func TestParameter_Build_Fail_Examples(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 }
 
@@ -149,7 +149,7 @@ func TestParameter_Build_Fail_Schema(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 }
 
@@ -166,7 +166,7 @@ func TestParameter_Build_Fail_Content(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 }
 
@@ -216,7 +216,7 @@ content:
 
 	var n Parameter
 	_ = low.BuildModel(idxNode.Content[0], &n)
-	_ = n.Build(idxNode.Content[0], idx)
+	_ = n.Build(nil, idxNode.Content[0], idx)
 
 	yml2 := `description: michelle, meddy and maddy
 required: true
@@ -262,7 +262,7 @@ content:
 
 	var n2 Parameter
 	_ = low.BuildModel(idxNode2.Content[0], &n2)
-	_ = n2.Build(idxNode2.Content[0], idx2)
+	_ = n2.Build(nil, idxNode2.Content[0], idx2)
 
 	// hash
 	assert.Equal(t, n.Hash(), n2.Hash())

--- a/datamodel/low/v3/path_item.go
+++ b/datamodel/low/v3/path_item.go
@@ -142,7 +142,7 @@ func (p *PathItem) Build(_, root *yaml.Node, idx *index.SpecIndex) error {
 				if utils.IsNodeMap(srvN) {
 					srvr := new(Server)
 					_ = low.BuildModel(srvN, srvr)
-					srvr.Build(srvN, idx)
+					srvr.Build(ln, srvN, idx)
 					servers = append(servers, low.ValueReference[*Server]{
 						Value:     srvr,
 						ValueNode: srvN,
@@ -274,7 +274,7 @@ func (p *PathItem) Build(_, root *yaml.Node, idx *index.SpecIndex) error {
 	opErrorChan := make(chan error)
 
 	buildOpFunc := func(op low.NodeReference[*Operation], ch chan<- bool, errCh chan<- error, ref string) {
-		er := op.Value.Build(op.ValueNode, idx)
+		er := op.Value.Build(op.KeyNode, op.ValueNode, idx)
 		if ref != "" {
 			op.Value.Reference.Reference = ref
 		}

--- a/datamodel/low/v3/path_item.go
+++ b/datamodel/low/v3/path_item.go
@@ -108,7 +108,7 @@ func (p *PathItem) GetExtensions() map[low.KeyReference[string]]low.ValueReferen
 
 // Build extracts extensions, parameters, servers and each http method defined.
 // everything is extracted asynchronously for speed.
-func (p *PathItem) Build(root *yaml.Node, idx *index.SpecIndex) error {
+func (p *PathItem) Build(_, root *yaml.Node, idx *index.SpecIndex) error {
 	root = utils.NodeAlias(root)
 	utils.CheckForMergeNodes(root)
 	p.Reference = new(low.Reference)

--- a/datamodel/low/v3/path_item_test.go
+++ b/datamodel/low/v3/path_item_test.go
@@ -43,7 +43,7 @@ x-byebye: boebert`
 
 	var n PathItem
 	_ = low.BuildModel(idxNode.Content[0], &n)
-	_ = n.Build(idxNode.Content[0], idx)
+	_ = n.Build(nil, idxNode.Content[0], idx)
 
 	yml2 := `get:
   description: get me
@@ -75,7 +75,7 @@ summary: it's another path item`
 
 	var n2 PathItem
 	_ = low.BuildModel(idxNode2.Content[0], &n2)
-	_ = n2.Build(idxNode2.Content[0], idx2)
+	_ = n2.Build(nil, idxNode2.Content[0], idx2)
 
 	// hash
 	assert.Equal(t, n.Hash(), n2.Hash())

--- a/datamodel/low/v3/paths.go
+++ b/datamodel/low/v3/paths.go
@@ -58,7 +58,7 @@ func (p *Paths) GetExtensions() map[low.KeyReference[string]]low.ValueReference[
 }
 
 // Build will extract extensions and all PathItems. This happens asynchronously for speed.
-func (p *Paths) Build(root *yaml.Node, idx *index.SpecIndex) error {
+func (p *Paths) Build(_, root *yaml.Node, idx *index.SpecIndex) error {
 	root = utils.NodeAlias(root)
 	utils.CheckForMergeNodes(root)
 	p.Reference = new(low.Reference)

--- a/datamodel/low/v3/paths.go
+++ b/datamodel/low/v3/paths.go
@@ -102,7 +102,7 @@ func (p *Paths) Build(_, root *yaml.Node, idx *index.SpecIndex) error {
 
 		path := new(PathItem)
 		_ = low.BuildModel(pNode, path)
-		err := path.Build(pNode, idx)
+		err := path.Build(cNode, pNode, idx)
 		if err != nil {
 			e <- err
 			return

--- a/datamodel/low/v3/paths_test.go
+++ b/datamodel/low/v3/paths_test.go
@@ -47,7 +47,7 @@ x-milk: cold`
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.NoError(t, err)
 
 	path := n.FindPath("/some/path").Value
@@ -79,7 +79,7 @@ func TestPaths_Build_Fail(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 
 }
@@ -104,7 +104,7 @@ func TestPaths_Build_FailRef(t *testing.T) {
 	err := low.BuildModel(idxNode.Content[0], &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.NoError(t, err)
 
 	somePath := n.FindPath("/some/path").Value
@@ -139,7 +139,7 @@ func TestPaths_Build_FailRefDeadEnd(t *testing.T) {
 	err := low.BuildModel(idxNode.Content[0], &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 }
 
@@ -165,7 +165,7 @@ func TestPaths_Build_SuccessRef(t *testing.T) {
 	err := low.BuildModel(idxNode.Content[0], &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.NoError(t, err)
 
 	somePath := n.FindPath("/some/path").Value
@@ -194,7 +194,7 @@ func TestPaths_Build_BadParams(t *testing.T) {
 	err := low.BuildModel(idxNode.Content[0], &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 }
 
@@ -220,7 +220,7 @@ func TestPaths_Build_BadRef(t *testing.T) {
 	err := low.BuildModel(idxNode.Content[0], &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 }
 
@@ -250,7 +250,7 @@ func TestPathItem_Build_GoodRef(t *testing.T) {
 	err := low.BuildModel(idxNode.Content[0], &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.NoError(t, err)
 }
 
@@ -280,7 +280,7 @@ func TestPathItem_Build_BadRef(t *testing.T) {
 	err := low.BuildModel(idxNode.Content[0], &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 }
 
@@ -298,7 +298,7 @@ func TestPathNoOps(t *testing.T) {
 	err := low.BuildModel(idxNode.Content[0], &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.NoError(t, err)
 }
 
@@ -328,7 +328,7 @@ func TestPathItem_Build_Using_Ref(t *testing.T) {
 	err := low.BuildModel(rootNode.Content[0], &n)
 	assert.NoError(t, err)
 
-	err = n.Build(rootNode.Content[0], idx)
+	err = n.Build(nil, rootNode.Content[0], idx)
 	assert.NoError(t, err)
 
 	somePath := n.FindPath("/a/path")
@@ -371,7 +371,7 @@ func TestPath_Build_Using_CircularRef(t *testing.T) {
 	err := low.BuildModel(rootNode.Content[0], &n)
 	assert.NoError(t, err)
 
-	err = n.Build(rootNode.Content[0], idx)
+	err = n.Build(nil, rootNode.Content[0], idx)
 	assert.Error(t, err)
 
 }
@@ -408,7 +408,7 @@ func TestPath_Build_Using_CircularRefWithOp(t *testing.T) {
 	err := low.BuildModel(rootNode.Content[0], &n)
 	assert.NoError(t, err)
 
-	err = n.Build(rootNode.Content[0], idx)
+	err = n.Build(nil, rootNode.Content[0], idx)
 	assert.Error(t, err)
 
 }
@@ -428,7 +428,7 @@ func TestPaths_Build_BrokenOp(t *testing.T) {
 	err := low.BuildModel(idxNode.Content[0], &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 }
 
@@ -448,7 +448,7 @@ x-france: french`
 
 	var n Paths
 	_ = low.BuildModel(idxNode.Content[0], &n)
-	_ = n.Build(idxNode.Content[0], idx)
+	_ = n.Build(nil, idxNode.Content[0], idx)
 
 	yml2 := `/french/toast:
   description: toast
@@ -464,7 +464,7 @@ x-france: french`
 
 	var n2 Paths
 	_ = low.BuildModel(idxNode2.Content[0], &n2)
-	_ = n2.Build(idxNode2.Content[0], idx2)
+	_ = n2.Build(nil, idxNode2.Content[0], idx2)
 
 	// hash
 	assert.Equal(t, n.Hash(), n2.Hash())

--- a/datamodel/low/v3/request_body.go
+++ b/datamodel/low/v3/request_body.go
@@ -40,7 +40,7 @@ func (rb *RequestBody) FindContent(cType string) *low.ValueReference[*MediaType]
 }
 
 // Build will extract extensions and MediaType objects from the node.
-func (rb *RequestBody) Build(root *yaml.Node, idx *index.SpecIndex) error {
+func (rb *RequestBody) Build(_, root *yaml.Node, idx *index.SpecIndex) error {
 	root = utils.NodeAlias(root)
 	utils.CheckForMergeNodes(root)
 	rb.Reference = new(low.Reference)

--- a/datamodel/low/v3/request_body_test.go
+++ b/datamodel/low/v3/request_body_test.go
@@ -28,7 +28,7 @@ x-requesto: presto`
 	err := low.BuildModel(idxNode.Content[0], &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.NoError(t, err)
 	assert.Equal(t, "a nice request", n.Description.Value)
 	assert.True(t, n.Required.Value)
@@ -51,7 +51,7 @@ func TestRequestBody_Fail(t *testing.T) {
 	err := low.BuildModel(idxNode.Content[0], &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 }
 
@@ -75,7 +75,7 @@ x-toast: nice
 
 	var n RequestBody
 	_ = low.BuildModel(idxNode.Content[0], &n)
-	_ = n.Build(idxNode.Content[0], idx)
+	_ = n.Build(nil, idxNode.Content[0], idx)
 
 	yml2 := `description: nice toast
 content:
@@ -94,7 +94,7 @@ x-toast: nice`
 
 	var n2 RequestBody
 	_ = low.BuildModel(idxNode2.Content[0], &n2)
-	_ = n2.Build(idxNode2.Content[0], idx2)
+	_ = n2.Build(nil, idxNode2.Content[0], idx2)
 
 	// hash
 	assert.Equal(t, n.Hash(), n2.Hash())

--- a/datamodel/low/v3/response.go
+++ b/datamodel/low/v3/response.go
@@ -54,7 +54,7 @@ func (r *Response) FindLink(hType string) *low.ValueReference[*Link] {
 }
 
 // Build will extract headers, extensions, content and links from node.
-func (r *Response) Build(root *yaml.Node, idx *index.SpecIndex) error {
+func (r *Response) Build(_, root *yaml.Node, idx *index.SpecIndex) error {
 	root = utils.NodeAlias(root)
 	utils.CheckForMergeNodes(root)
 	r.Reference = new(low.Reference)

--- a/datamodel/low/v3/response_test.go
+++ b/datamodel/low/v3/response_test.go
@@ -39,7 +39,7 @@ default:
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.NoError(t, err)
 	assert.Equal(t, "default response", n.Default.Value.Description.Value)
 
@@ -92,7 +92,7 @@ x-shoes: old`
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 
 	// check hash
 	assert.Equal(t, "54ab66e6cb8bd226940f421c2387e45215b84c946182435dfe2a3036043fa07c",
@@ -116,7 +116,7 @@ func TestResponses_Build_FailCodes_WrongType(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 
 }
@@ -134,7 +134,7 @@ func TestResponses_Build_FailCodes(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 
 }
@@ -151,7 +151,7 @@ func TestResponses_Build_FailDefault(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 
 }
@@ -171,7 +171,7 @@ func TestResponses_Build_FailBadHeader(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 
 }
@@ -191,7 +191,7 @@ func TestResponses_Build_FailBadContent(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 
 }
@@ -211,7 +211,7 @@ func TestResponses_Build_FailBadLinks(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 
 }
@@ -232,7 +232,7 @@ func TestResponses_Build_AllowXPrefixHeader(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.NoError(t, err)
 
 	assert.Equal(t, "string",
@@ -267,7 +267,7 @@ links:
 
 	var n Response
 	_ = low.BuildModel(idxNode.Content[0], &n)
-	_ = n.Build(idxNode.Content[0], idx)
+	_ = n.Build(nil, idxNode.Content[0], idx)
 
 	yml2 := `description: nice toast
 x-ham: jam
@@ -294,7 +294,7 @@ links:
 
 	var n2 Response
 	_ = low.BuildModel(idxNode2.Content[0], &n2)
-	_ = n2.Build(idxNode2.Content[0], idx2)
+	_ = n2.Build(nil, idxNode2.Content[0], idx2)
 
 	// hash
 	assert.Equal(t, n.Hash(), n2.Hash())

--- a/datamodel/low/v3/responses.go
+++ b/datamodel/low/v3/responses.go
@@ -45,7 +45,7 @@ func (r *Responses) GetExtensions() map[low.KeyReference[string]]low.ValueRefere
 }
 
 // Build will extract default response and all Response objects for each code
-func (r *Responses) Build(root *yaml.Node, idx *index.SpecIndex) error {
+func (r *Responses) Build(_, root *yaml.Node, idx *index.SpecIndex) error {
 	root = utils.NodeAlias(root)
 	r.Reference = new(low.Reference)
 	r.Extensions = low.ExtractExtensions(root)

--- a/datamodel/low/v3/security_scheme.go
+++ b/datamodel/low/v3/security_scheme.go
@@ -48,7 +48,7 @@ func (ss *SecurityScheme) GetExtensions() map[low.KeyReference[string]]low.Value
 }
 
 // Build will extract OAuthFlows and extensions from the node.
-func (ss *SecurityScheme) Build(root *yaml.Node, idx *index.SpecIndex) error {
+func (ss *SecurityScheme) Build(_, root *yaml.Node, idx *index.SpecIndex) error {
 	root = utils.NodeAlias(root)
 	utils.CheckForMergeNodes(root)
 	ss.Reference = new(low.Reference)

--- a/datamodel/low/v3/security_scheme_test.go
+++ b/datamodel/low/v3/security_scheme_test.go
@@ -25,7 +25,7 @@ func TestSecurityRequirement_Build(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 
 	assert.NoError(t, err)
 	assert.Len(t, n.Requirements.Value, 1)
@@ -55,7 +55,7 @@ x-milk: please`
 	err := low.BuildModel(idxNode.Content[0], &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.NoError(t, err)
 
 	assert.Equal(t, "0b5ee36519fdfc6383c7befd92294d77b5799cd115911ff8c3e194f345a8c103",
@@ -86,6 +86,6 @@ func TestSecurityScheme_Build_Fail(t *testing.T) {
 	err := low.BuildModel(&idxNode, &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.Error(t, err)
 }

--- a/datamodel/low/v3/server.go
+++ b/datamodel/low/v3/server.go
@@ -34,7 +34,7 @@ func (s *Server) FindVariable(serverVar string) *low.ValueReference[*ServerVaria
 }
 
 // Build will extract server variables from the supplied node.
-func (s *Server) Build(root *yaml.Node, idx *index.SpecIndex) error {
+func (s *Server) Build(_, root *yaml.Node, idx *index.SpecIndex) error {
 	root = utils.NodeAlias(root)
 	utils.CheckForMergeNodes(root)
 	s.Reference = new(low.Reference)

--- a/datamodel/low/v3/server_test.go
+++ b/datamodel/low/v3/server_test.go
@@ -30,7 +30,7 @@ variables:
 	err := low.BuildModel(idxNode.Content[0], &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.NoError(t, err)
 
 	assert.Equal(t, "ec69dfcf68ad8988f3804e170ee6c4a7ad2e4ac51084796eea93168820827546",
@@ -63,7 +63,7 @@ description: high quality software for developers.`
 	err := low.BuildModel(idxNode.Content[0], &n)
 	assert.NoError(t, err)
 
-	err = n.Build(idxNode.Content[0], idx)
+	err = n.Build(nil, idxNode.Content[0], idx)
 	assert.NoError(t, err)
 	assert.Equal(t, "https://pb33f.io", n.URL.Value)
 	assert.Equal(t, "high quality software for developers.", n.Description.Value)

--- a/what-changed/model/callback_test.go
+++ b/what-changed/model/callback_test.go
@@ -36,8 +36,8 @@ func TestCompareCallback(t *testing.T) {
 	var rDoc v3.Callback
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareCallback(&lDoc, &rDoc)
@@ -82,8 +82,8 @@ func TestCompareCallback_Add(t *testing.T) {
 	var rDoc v3.Callback
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareCallback(&lDoc, &rDoc)
@@ -133,8 +133,8 @@ func TestCompareCallback_Modify(t *testing.T) {
 	var rDoc v3.Callback
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareCallback(&lDoc, &rDoc)
@@ -183,8 +183,8 @@ func TestCompareCallback_Remove(t *testing.T) {
 	var rDoc v3.Callback
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareCallback(&rDoc, &lDoc)

--- a/what-changed/model/components_test.go
+++ b/what-changed/model/components_test.go
@@ -39,8 +39,8 @@ thing2:
 	var rDoc v2.Definitions
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareComponents(&lDoc, &rDoc)
@@ -69,8 +69,8 @@ thing2:
 	var rDoc v2.Definitions
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareComponents(&lDoc, &rDoc)
@@ -108,8 +108,8 @@ thing3:
 	var rDoc v2.Definitions
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareComponents(&lDoc, &rDoc)
@@ -148,8 +148,8 @@ thing3:
 	var rDoc v2.Definitions
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareComponents(&rDoc, &lDoc)
@@ -187,8 +187,8 @@ param4:
 	var rDoc v2.ParameterDefinitions
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareComponents(&lDoc, &rDoc)
@@ -226,8 +226,8 @@ param4:
 	var rDoc v2.ParameterDefinitions
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareComponents(&rDoc, &lDoc)
@@ -261,8 +261,8 @@ resp3:
 	var rDoc v2.ResponsesDefinitions
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareComponents(&lDoc, &rDoc)
@@ -298,8 +298,8 @@ resp3:
 	var rDoc v2.ResponsesDefinitions
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareComponents(&rDoc, &lDoc)
@@ -331,8 +331,8 @@ scheme2:
 	var rDoc v2.SecurityDefinitions
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareComponents(&lDoc, &rDoc)

--- a/what-changed/model/contact_test.go
+++ b/what-changed/model/contact_test.go
@@ -27,8 +27,8 @@ url: https://pb33f.io`
 	var rDoc lowbase.Contact
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareContact(&lDoc, &rDoc)
@@ -54,8 +54,8 @@ url: https://pb33f.io`
 	var rDoc lowbase.Contact
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareContact(&lDoc, &rDoc)
@@ -80,8 +80,8 @@ name: buckaroo`
 	var rDoc lowbase.Contact
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareContact(&lDoc, &rDoc)
@@ -106,8 +106,8 @@ name: buckaroo`
 	var rDoc lowbase.Contact
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareContact(&lDoc, &rDoc)
@@ -131,8 +131,8 @@ email: buckaroo@pb33f.io`
 	var rDoc lowbase.Contact
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareContact(&lDoc, &rDoc)
@@ -157,8 +157,8 @@ email: buckaroo@pb33f.io`
 	var rDoc lowbase.Contact
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareContact(&lDoc, &rDoc)
@@ -183,8 +183,8 @@ email: dave@quobix.com`
 	var rDoc lowbase.Contact
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareContact(&lDoc, &rDoc)
@@ -210,8 +210,8 @@ email: dave@quobix.com`
 	var rDoc lowbase.Contact
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareContact(&lDoc, &rDoc)
@@ -235,8 +235,8 @@ url: https://pb33f.io`
 	var rDoc lowbase.Contact
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareContact(&lDoc, &rDoc)

--- a/what-changed/model/encoding_test.go
+++ b/what-changed/model/encoding_test.go
@@ -38,8 +38,8 @@ allowReserved: true`
 	var rDoc v3.Encoding
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareEncoding(&lDoc, &rDoc)
@@ -73,8 +73,8 @@ allowReserved: true`
 	var rDoc v3.Encoding
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareEncoding(&lDoc, &rDoc)
@@ -108,8 +108,8 @@ allowReserved: true`
 	var rDoc v3.Encoding
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareEncoding(&lDoc, &rDoc)
@@ -144,8 +144,8 @@ allowReserved: true`
 	var rDoc v3.Encoding
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareEncoding(&rDoc, &lDoc)

--- a/what-changed/model/example_test.go
+++ b/what-changed/model/example_test.go
@@ -28,8 +28,8 @@ func TestCompareExamples_SummaryModified(t *testing.T) {
 	var rDoc base.Example
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	extChanges := CompareExamples(&lDoc, &rDoc)
 
@@ -61,8 +61,8 @@ func TestCompareExamples_Map(t *testing.T) {
 	var rDoc base.Example
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	extChanges := CompareExamples(&lDoc, &rDoc)
 
@@ -90,8 +90,8 @@ func TestCompareExamples_MapAdded(t *testing.T) {
 	var rDoc base.Example
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	extChanges := CompareExamples(&lDoc, &rDoc)
 
@@ -119,8 +119,8 @@ func TestCompareExamples_MapRemoved(t *testing.T) {
 	var rDoc base.Example
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	extChanges := CompareExamples(&rDoc, &lDoc)
 
@@ -144,8 +144,8 @@ description: cure all`
 	var rDoc base.Example
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	extChanges := CompareExamples(&lDoc, &rDoc)
 
@@ -171,8 +171,8 @@ x-herbs: cure all`
 	var rDoc base.Example
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	extChanges := CompareExamples(&lDoc, &rDoc)
 
@@ -197,8 +197,8 @@ func TestCompareExamples_Identical(t *testing.T) {
 	var rDoc base.Example
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	extChanges := CompareExamples(&lDoc, &rDoc)
 	assert.Nil(t, extChanges)
@@ -220,8 +220,8 @@ func TestCompareExamples_Date(t *testing.T) {
 	var rDoc base.Example
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	changes := CompareExamples(&lDoc, &rDoc)
 

--- a/what-changed/model/examples_test.go
+++ b/what-changed/model/examples_test.go
@@ -26,8 +26,8 @@ func TestCompareExamplesV2(t *testing.T) {
 	var rDoc v2.Examples
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	extChanges := CompareExamplesV2(&lDoc, &rDoc)
 	assert.Equal(t, extChanges.TotalChanges(), 1)
@@ -54,8 +54,8 @@ yummy: coffee`
 	var rDoc v2.Examples
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	extChanges := CompareExamplesV2(&lDoc, &rDoc)
 	assert.Equal(t, extChanges.TotalChanges(), 1)
@@ -79,8 +79,8 @@ yummy: coffee`
 	var rDoc v2.Examples
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	extChanges := CompareExamplesV2(&rDoc, &lDoc)
 	assert.Equal(t, extChanges.TotalChanges(), 1)
@@ -103,8 +103,8 @@ func TestCompareExamplesV2_Identical(t *testing.T) {
 	var rDoc v2.Examples
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	extChanges := CompareExamplesV2(&rDoc, &lDoc)
 	assert.Nil(t, extChanges)

--- a/what-changed/model/external_docs_test.go
+++ b/what-changed/model/external_docs_test.go
@@ -31,8 +31,8 @@ x-testing: hiya!`
 	var rDoc lowbase.ExternalDoc
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareExternalDocs(&lDoc, &rDoc)
@@ -88,8 +88,8 @@ url: https://quobix.com`
 	var rDoc lowbase.ExternalDoc
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareExternalDocs(&lDoc, &rDoc)
@@ -139,8 +139,8 @@ x-testing: hello`
 	var rDoc lowbase.ExternalDoc
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareExternalDocs(&lDoc, &rDoc)
@@ -165,8 +165,8 @@ x-testing: hello`
 	var rDoc lowbase.ExternalDoc
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareExternalDocs(&lDoc, &rDoc)
@@ -191,8 +191,8 @@ url: https://pb33f.io`
 	var rDoc lowbase.ExternalDoc
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareExternalDocs(&lDoc, &rDoc)
@@ -217,8 +217,8 @@ description: something`
 	var rDoc lowbase.ExternalDoc
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareExternalDocs(&lDoc, &rDoc)
@@ -243,8 +243,8 @@ url: https://pb33f.io`
 	var rDoc lowbase.ExternalDoc
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare
 	extChanges := CompareExternalDocs(&lDoc, &rDoc)

--- a/what-changed/model/header_test.go
+++ b/what-changed/model/header_test.go
@@ -73,8 +73,8 @@ func TestCompareHeaders_v2_identical(t *testing.T) {
 	var rDoc v2.Header
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareHeadersV2(&lDoc, &rDoc)
@@ -116,8 +116,8 @@ x-beer: really yummy`
 	var rDoc v2.Header
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareHeadersV2(&lDoc, &rDoc)
@@ -160,8 +160,8 @@ x-beer: yummy`
 	var rDoc v2.Header
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareHeadersV2(&rDoc, &lDoc)
@@ -205,8 +205,8 @@ x-beer: yummy`
 	var rDoc v2.Header
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareHeadersV2(&lDoc, &rDoc)
@@ -232,8 +232,8 @@ func TestCompareHeaders_v2_ItemsModified(t *testing.T) {
 	var rDoc v2.Header
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareHeadersV2(&lDoc, &rDoc)
@@ -255,8 +255,8 @@ func TestCompareHeaders_v3_identical(t *testing.T) {
 	var rDoc v3.Header
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareHeadersV3(&lDoc, &rDoc)
@@ -297,8 +297,8 @@ x-beer: yummy`
 	var rDoc v3.Header
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareHeadersV3(&lDoc, &rDoc)

--- a/what-changed/model/info_test.go
+++ b/what-changed/model/info_test.go
@@ -42,8 +42,8 @@ license:
 	var rDoc base.Info
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareInfo(&lDoc, &rDoc)
@@ -83,8 +83,8 @@ license:
 	var rDoc base.Info
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareInfo(&lDoc, &rDoc)
@@ -123,8 +123,8 @@ license:
 	var rDoc base.Info
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareInfo(&lDoc, &rDoc)
@@ -161,8 +161,8 @@ contact:
 	var rDoc base.Info
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareInfo(&lDoc, &rDoc)
@@ -199,8 +199,8 @@ license:
 	var rDoc base.Info
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareInfo(&lDoc, &rDoc)
@@ -239,8 +239,8 @@ license:
 	var rDoc base.Info
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareInfo(&lDoc, &rDoc)
@@ -276,8 +276,8 @@ license:
 	var rDoc base.Info
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareInfo(&lDoc, &rDoc)
@@ -313,8 +313,8 @@ license:
 	var rDoc base.Info
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareInfo(&lDoc, &rDoc)
@@ -353,8 +353,8 @@ license:
 	var rDoc base.Info
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareInfo(&lDoc, &rDoc)
@@ -394,8 +394,8 @@ license:
 	var rDoc base.Info
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareInfo(&lDoc, &rDoc)

--- a/what-changed/model/items_test.go
+++ b/what-changed/model/items_test.go
@@ -27,8 +27,8 @@ func TestCompareItems(t *testing.T) {
 	var rDoc v2.Items
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	changes := CompareItems(&lDoc, &rDoc)
@@ -58,8 +58,8 @@ items:
 	var rDoc v2.Items
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	changes := CompareItems(&lDoc, &rDoc)
@@ -88,8 +88,8 @@ items:
 	var rDoc v2.Items
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	changes := CompareItems(&lDoc, &rDoc)
@@ -118,8 +118,8 @@ items:
 	var rDoc v2.Items
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	changes := CompareItems(&rDoc, &lDoc)

--- a/what-changed/model/license_test.go
+++ b/what-changed/model/license_test.go
@@ -27,8 +27,8 @@ url: https://pb33f.io`
 	var rDoc lowbase.License
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareLicense(&lDoc, &rDoc)
@@ -55,8 +55,8 @@ url: https://pb33f.io`
 	var rDoc lowbase.License
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareLicense(&lDoc, &rDoc)
@@ -82,8 +82,8 @@ name: buckaroo`
 	var rDoc lowbase.License
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareLicense(&lDoc, &rDoc)
@@ -109,8 +109,8 @@ name: buckaroo`
 	var rDoc lowbase.License
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareLicense(&lDoc, &rDoc)
@@ -135,8 +135,8 @@ func TestCompareLicense_URLModified(t *testing.T) {
 	var rDoc lowbase.License
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareLicense(&lDoc, &rDoc)
@@ -162,8 +162,8 @@ url: https://pb33f.io`
 	var rDoc lowbase.License
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareLicense(&lDoc, &rDoc)
@@ -190,8 +190,8 @@ url: https://pb33f.io`
 	var rDoc lowbase.License
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareLicense(&lDoc, &rDoc)

--- a/what-changed/model/link_test.go
+++ b/what-changed/model/link_test.go
@@ -32,8 +32,8 @@ parameters:
 	var rDoc v3.Link
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareLinks(&lDoc, &rDoc)
@@ -70,8 +70,8 @@ x-cake: very tasty`
 	var rDoc v3.Link
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareLinks(&lDoc, &rDoc)
@@ -109,8 +109,8 @@ parameters:
 	var rDoc v3.Link
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareLinks(&lDoc, &rDoc)
@@ -145,8 +145,8 @@ parameters:
 	var rDoc v3.Link
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareLinks(&lDoc, &rDoc)
@@ -181,8 +181,8 @@ parameters:
 	var rDoc v3.Link
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareLinks(&rDoc, &lDoc)
@@ -219,8 +219,8 @@ parameters:
 	var rDoc v3.Link
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareLinks(&lDoc, &rDoc)
@@ -261,8 +261,8 @@ parameters:
 	var rDoc v3.Link
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareLinks(&lDoc, &rDoc)
@@ -302,8 +302,8 @@ parameters:
 	var rDoc v3.Link
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareLinks(&rDoc, &lDoc)

--- a/what-changed/model/media_type_test.go
+++ b/what-changed/model/media_type_test.go
@@ -40,8 +40,8 @@ encoding:
 	var rDoc v3.MediaType
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareMediaTypes(&lDoc, &rDoc)
@@ -77,8 +77,8 @@ encoding:
 	var rDoc v3.MediaType
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareMediaTypes(&lDoc, &rDoc)
@@ -112,8 +112,8 @@ example:
 	var rDoc v3.MediaType
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareMediaTypes(&lDoc, &rDoc)
@@ -145,8 +145,8 @@ example:
 	var rDoc v3.MediaType
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareMediaTypes(&lDoc, &rDoc)
@@ -178,8 +178,8 @@ example:
 	var rDoc v3.MediaType
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareMediaTypes(&rDoc, &lDoc)
@@ -218,8 +218,8 @@ encoding:
 	var rDoc v3.MediaType
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareMediaTypes(&lDoc, &rDoc)
@@ -258,8 +258,8 @@ encoding:
 	var rDoc v3.MediaType
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareMediaTypes(&rDoc, &lDoc)
@@ -304,8 +304,8 @@ x-tea: cup`
 	var rDoc v3.MediaType
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareMediaTypes(&lDoc, &rDoc)

--- a/what-changed/model/oauth_flows_test.go
+++ b/what-changed/model/oauth_flows_test.go
@@ -34,8 +34,8 @@ scopes:
 	var rDoc v3.OAuthFlow
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare
 	extChanges := CompareOAuthFlow(&lDoc, &rDoc)
@@ -68,8 +68,8 @@ x-burgers: crispy`
 	var rDoc v3.OAuthFlow
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare
 	extChanges := CompareOAuthFlow(&lDoc, &rDoc)
@@ -104,8 +104,8 @@ x-burgers: nice`
 	var rDoc v3.OAuthFlow
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare
 	extChanges := CompareOAuthFlow(&lDoc, &rDoc)
@@ -142,8 +142,8 @@ x-burgers: nice`
 	var rDoc v3.OAuthFlow
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare
 	extChanges := CompareOAuthFlow(&rDoc, &lDoc)
@@ -179,8 +179,8 @@ x-burgers: nice`
 	var rDoc v3.OAuthFlow
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare
 	extChanges := CompareOAuthFlow(&lDoc, &rDoc)
@@ -223,8 +223,8 @@ x-coke: cola`
 	var rDoc v3.OAuthFlows
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare
 	extChanges := CompareOAuthFlows(&lDoc, &rDoc)
@@ -253,8 +253,8 @@ x-coke: cola`
 	var rDoc v3.OAuthFlows
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare
 	extChanges := CompareOAuthFlows(&lDoc, &rDoc)
@@ -285,8 +285,8 @@ x-coke: cola`
 	var rDoc v3.OAuthFlows
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare
 	extChanges := CompareOAuthFlows(&rDoc, &lDoc)
@@ -325,8 +325,8 @@ x-coke: cherry`
 	var rDoc v3.OAuthFlows
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare
 	extChanges := CompareOAuthFlows(&lDoc, &rDoc)

--- a/what-changed/model/operation_test.go
+++ b/what-changed/model/operation_test.go
@@ -43,8 +43,8 @@ parameters:
 	var rDoc v2.Operation
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareOperations(&lDoc, &rDoc)
@@ -96,8 +96,8 @@ parameters:
 	var rDoc v2.Operation
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareOperations(&lDoc, &rDoc)
@@ -147,8 +147,8 @@ parameters:
 	var rDoc v2.Operation
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareOperations(&lDoc, &rDoc)
@@ -201,8 +201,8 @@ parameters:
 	var rDoc v2.Operation
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareOperations(&rDoc, &lDoc)
@@ -261,8 +261,8 @@ parameters:
 	var rDoc v2.Operation
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareOperations(&lDoc, &rDoc)
@@ -319,8 +319,8 @@ parameters:
 	var rDoc v2.Operation
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareOperations(&rDoc, &lDoc)
@@ -377,8 +377,8 @@ parameters:
 	var rDoc v2.Operation
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareOperations(&lDoc, &rDoc)
@@ -435,8 +435,8 @@ parameters:
 	var rDoc v2.Operation
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareOperations(&lDoc, &rDoc)
@@ -472,8 +472,8 @@ schemes:
 	var rDoc v2.Operation
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareOperations(&lDoc, &rDoc)
@@ -506,8 +506,8 @@ responses:
 	var rDoc v2.Operation
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareOperations(&lDoc, &rDoc)
@@ -548,8 +548,8 @@ responses:
 	var rDoc v2.Operation
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareOperations(&lDoc, &rDoc)
@@ -578,8 +578,8 @@ responses:
 	var rDoc v2.Operation
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareOperations(&lDoc, &rDoc)
@@ -610,8 +610,8 @@ responses:
 	var rDoc v2.Operation
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareOperations(&rDoc, &lDoc)
@@ -646,8 +646,8 @@ security:
 	var rDoc v2.Operation
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareOperations(&lDoc, &rDoc)
@@ -683,8 +683,8 @@ security:
 	var rDoc v2.Operation
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareOperations(&rDoc, &lDoc)
@@ -722,8 +722,8 @@ security:
 	var rDoc v2.Operation
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareOperations(&lDoc, &rDoc)
@@ -761,8 +761,8 @@ security:
 	var rDoc v2.Operation
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareOperations(&rDoc, &lDoc)
@@ -812,8 +812,8 @@ parameters:
 	var rDoc v3.Operation
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareOperations(&lDoc, &rDoc)
@@ -841,8 +841,8 @@ func TestCompareOperations_V3_ModifyParam(t *testing.T) {
 	var rDoc v3.Operation
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareOperations(&lDoc, &rDoc)
@@ -875,8 +875,8 @@ func TestCompareOperations_V3_AddParam(t *testing.T) {
 	var rDoc v3.Operation
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareOperations(&lDoc, &rDoc)
@@ -909,8 +909,8 @@ func TestCompareOperations_V3_RemoveParam(t *testing.T) {
 	var rDoc v3.Operation
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareOperations(&rDoc, &lDoc)
@@ -939,8 +939,8 @@ parameters:
 	var rDoc v3.Operation
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareOperations(&lDoc, &rDoc)
@@ -969,8 +969,8 @@ parameters:
 	var rDoc v3.Operation
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareOperations(&rDoc, &lDoc)
@@ -1000,8 +1000,8 @@ func TestCompareOperations_V3_ModifyServers(t *testing.T) {
 	var rDoc v3.Operation
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareOperations(&lDoc, &rDoc)
@@ -1034,8 +1034,8 @@ func TestCompareOperations_V3_ModifyCallback(t *testing.T) {
 	var rDoc v3.Operation
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareOperations(&lDoc, &rDoc)
@@ -1075,8 +1075,8 @@ func TestCompareOperations_V3_AddCallback(t *testing.T) {
 	var rDoc v3.Operation
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareOperations(&lDoc, &rDoc)
@@ -1110,8 +1110,8 @@ callbacks:
 	var rDoc v3.Operation
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareOperations(&lDoc, &rDoc)
@@ -1145,8 +1145,8 @@ callbacks:
 	var rDoc v3.Operation
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareOperations(&rDoc, &lDoc)
@@ -1183,8 +1183,8 @@ func TestCompareOperations_V3_RemoveCallback(t *testing.T) {
 	var rDoc v3.Operation
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareOperations(&rDoc, &lDoc)
@@ -1212,8 +1212,8 @@ func TestCompareOperations_V3_AddServer(t *testing.T) {
 	var rDoc v3.Operation
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareOperations(&lDoc, &rDoc)
@@ -1241,8 +1241,8 @@ func TestCompareOperations_V3_RemoveServer(t *testing.T) {
 	var rDoc v3.Operation
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareOperations(&rDoc, &lDoc)
@@ -1270,8 +1270,8 @@ servers:
 	var rDoc v3.Operation
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareOperations(&lDoc, &rDoc)
@@ -1299,8 +1299,8 @@ servers:
 	var rDoc v3.Operation
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareOperations(&rDoc, &lDoc)
@@ -1332,8 +1332,8 @@ security:
 	var rDoc v3.Operation
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareOperations(&lDoc, &rDoc)
@@ -1361,8 +1361,8 @@ security:
 	var rDoc v3.Operation
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareOperations(&lDoc, &rDoc)
@@ -1390,8 +1390,8 @@ security: []`
 	var rDoc v3.Operation
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareOperations(&lDoc, &rDoc)
@@ -1418,8 +1418,8 @@ func TestCompareOperations_V3_ModifyRequestBody(t *testing.T) {
 	var rDoc v3.Operation
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareOperations(&lDoc, &rDoc)
@@ -1446,8 +1446,8 @@ requestBody:
 	var rDoc v3.Operation
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareOperations(&lDoc, &rDoc)
@@ -1472,8 +1472,8 @@ func TestCompareOperations_V3_ModifyExtension(t *testing.T) {
 	var rDoc v3.Operation
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareOperations(&lDoc, &rDoc)
@@ -1500,8 +1500,8 @@ requestBody:
 	var rDoc v3.Operation
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareOperations(&rDoc, &lDoc)

--- a/what-changed/model/parameter_test.go
+++ b/what-changed/model/parameter_test.go
@@ -26,8 +26,8 @@ func TestCompareParameters(t *testing.T) {
 	var rDoc v3.Parameter
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareParameters(&lDoc, &rDoc)
@@ -48,8 +48,8 @@ func TestCompareParameters_V3(t *testing.T) {
 	var rDoc v3.Parameter
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareParametersV3(&lDoc, &rDoc)
@@ -72,8 +72,8 @@ func TestCompareParameters_V3_Schema(t *testing.T) {
 	var rDoc v3.Parameter
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareParameters(&lDoc, &rDoc)
@@ -100,8 +100,8 @@ schema:
 	var rDoc v3.Parameter
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareParameters(&lDoc, &rDoc)
@@ -128,8 +128,8 @@ schema:
 	var rDoc v3.Parameter
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareParameters(&rDoc, &lDoc)
@@ -154,8 +154,8 @@ func TestCompareParameters_V3_Extensions(t *testing.T) {
 	var rDoc v3.Parameter
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareParameters(&lDoc, &rDoc)
@@ -181,8 +181,8 @@ func TestCompareParameters_V3_ExampleChange(t *testing.T) {
 	var rDoc v3.Parameter
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareParameters(&lDoc, &rDoc)
@@ -205,8 +205,8 @@ func TestCompareParameters_V3_ExampleEqual(t *testing.T) {
 	var rDoc v3.Parameter
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareParameters(&lDoc, &rDoc)
@@ -228,8 +228,8 @@ example: a string`
 	var rDoc v3.Parameter
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare
 	extChanges := CompareParameters(&lDoc, &rDoc)
@@ -254,8 +254,8 @@ example: a string`
 	var rDoc v3.Parameter
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare
 	extChanges := CompareParameters(&rDoc, &lDoc)
@@ -283,8 +283,8 @@ func TestCompareParameters_V3_ExamplesChanged(t *testing.T) {
 	var rDoc v3.Parameter
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare
 	extChanges := CompareParameters(&lDoc, &rDoc)
@@ -315,8 +315,8 @@ func TestCompareParameters_V3_ExamplesAdded(t *testing.T) {
 	var rDoc v3.Parameter
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare
 	extChanges := CompareParameters(&lDoc, &rDoc)
@@ -347,8 +347,8 @@ func TestCompareParameters_V3_ExamplesRemoved(t *testing.T) {
 	var rDoc v3.Parameter
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare
 	extChanges := CompareParameters(&rDoc, &lDoc)
@@ -379,8 +379,8 @@ func TestCompareParameters_V3_ContentChanged(t *testing.T) {
 	var rDoc v3.Parameter
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare
 	extChanges := CompareParameters(&lDoc, &rDoc)
@@ -415,8 +415,8 @@ func TestCompareParameters_V3_ContentAdded(t *testing.T) {
 	var rDoc v3.Parameter
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare
 	extChanges := CompareParameters(&lDoc, &rDoc)
@@ -440,8 +440,8 @@ func TestCompareParameters_V2_DefaultChange(t *testing.T) {
 	var rDoc v2.Parameter
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareParameters(&lDoc, &rDoc)
@@ -465,8 +465,8 @@ default: wat?`
 	var rDoc v2.Parameter
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareParameters(&lDoc, &rDoc)
@@ -491,8 +491,8 @@ func TestCompareParameters_V2_EnumChange(t *testing.T) {
 	var rDoc v2.Parameter
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareParameters(&lDoc, &rDoc)
@@ -519,8 +519,8 @@ func TestCompareParameters_V2_EnumEqual_Reorder(t *testing.T) {
 	var rDoc v2.Parameter
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareParameters(&lDoc, &rDoc)
@@ -542,8 +542,8 @@ example: a string`
 	var rDoc v3.Parameter
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare
 	extChanges := CompareParameters(&rDoc, &lDoc)
@@ -567,8 +567,8 @@ func TestCompareParameters_V2_Equal(t *testing.T) {
 	var rDoc v2.Parameter
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareParameters(&lDoc, &rDoc)
@@ -589,8 +589,8 @@ func TestCompareParameters_V2(t *testing.T) {
 	var rDoc v2.Parameter
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareParameters(&lDoc, &rDoc)
@@ -613,8 +613,8 @@ func TestCompareParameters_V2_ItemsChange(t *testing.T) {
 	var rDoc v2.Parameter
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareParameters(&lDoc, &rDoc)
@@ -641,8 +641,8 @@ items:
 	var rDoc v2.Parameter
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareParameters(&lDoc, &rDoc)
@@ -668,8 +668,8 @@ items:
 	var rDoc v2.Parameter
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareParameters(&rDoc, &lDoc)
@@ -693,8 +693,8 @@ func TestCompareParameters_V2_Extensions(t *testing.T) {
 	var rDoc v2.Parameter
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareParameters(&lDoc, &rDoc)

--- a/what-changed/model/path_item_test.go
+++ b/what-changed/model/path_item_test.go
@@ -44,8 +44,8 @@ x-thing: thang.`
 	var rDoc v2.PathItem
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := ComparePathItems(&lDoc, &rDoc)
@@ -99,8 +99,8 @@ x-thing: ding-a-ling`
 	var rDoc v2.PathItem
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := ComparePathItems(&lDoc, &rDoc)
@@ -136,8 +136,8 @@ parameters:
 	var rDoc v2.PathItem
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := ComparePathItems(&lDoc, &rDoc)
@@ -177,8 +177,8 @@ parameters:
 	var rDoc v2.PathItem
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := ComparePathItems(&lDoc, &rDoc)
@@ -217,8 +217,8 @@ parameters:
 	var rDoc v2.PathItem
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := ComparePathItems(&rDoc, &lDoc)
@@ -252,8 +252,8 @@ parameters:
 	var rDoc v2.PathItem
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := ComparePathItems(&lDoc, &rDoc)
@@ -288,8 +288,8 @@ parameters:
 	var rDoc v2.PathItem
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := ComparePathItems(&lDoc, &rDoc)
@@ -329,8 +329,8 @@ parameters:
 	var rDoc v2.PathItem
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := ComparePathItems(&lDoc, &rDoc)
@@ -369,8 +369,8 @@ parameters:
 	var rDoc v2.PathItem
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := ComparePathItems(&rDoc, &lDoc)
@@ -416,8 +416,8 @@ x-thing: thang.`
 	var rDoc v3.PathItem
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := ComparePathItems(&lDoc, &rDoc)
@@ -484,8 +484,8 @@ x-thing: dang.`
 	var rDoc v3.PathItem
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := ComparePathItems(&lDoc, &rDoc)
@@ -511,8 +511,8 @@ parameters:
 	var rDoc v3.PathItem
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := ComparePathItems(&lDoc, &rDoc)
@@ -540,8 +540,8 @@ parameters:
 	var rDoc v3.PathItem
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := ComparePathItemsV3(&rDoc, &lDoc)
@@ -583,8 +583,8 @@ trace:
 	var rDoc v3.PathItem
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := ComparePathItems(&lDoc, &rDoc)
@@ -624,8 +624,8 @@ trace:
 	var rDoc v3.PathItem
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := ComparePathItems(&rDoc, &lDoc)
@@ -657,8 +657,8 @@ func TestComparePathItem_V3_ChangeParam(t *testing.T) {
 	var rDoc v3.PathItem
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := ComparePathItems(&lDoc, &rDoc)

--- a/what-changed/model/paths_test.go
+++ b/what-changed/model/paths_test.go
@@ -36,8 +36,8 @@ func TestComparePaths_v2(t *testing.T) {
 	var rDoc v2.Paths
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := ComparePaths(&rDoc, &lDoc)
@@ -78,8 +78,8 @@ x-windows: washed
 	var rDoc v2.Paths
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := ComparePaths(&lDoc, &rDoc)
@@ -118,8 +118,8 @@ x-windows: dirty
 	var rDoc v2.Paths
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := ComparePaths(&lDoc, &rDoc)
@@ -160,8 +160,8 @@ x-windows: dirty
 	var rDoc v2.Paths
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := ComparePaths(&rDoc, &lDoc)
@@ -195,8 +195,8 @@ func TestComparePaths_v3(t *testing.T) {
 	var rDoc v3.Paths
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := ComparePaths(&rDoc, &lDoc)
@@ -237,8 +237,8 @@ x-windows: washed
 	var rDoc v3.Paths
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := ComparePaths(&lDoc, &rDoc)
@@ -284,8 +284,8 @@ x-windows: dirty`
 	var rDoc v3.Paths
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := ComparePaths(&lDoc, &rDoc)
@@ -333,8 +333,8 @@ x-windows: dirty`
 	var rDoc v3.Paths
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := ComparePaths(&rDoc, &lDoc)

--- a/what-changed/model/request_body_test.go
+++ b/what-changed/model/request_body_test.go
@@ -36,8 +36,8 @@ content:
 	var rDoc v3.RequestBody
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareRequestBodies(&lDoc, &rDoc)
@@ -71,8 +71,8 @@ content:
 	var rDoc v3.RequestBody
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareRequestBodies(&lDoc, &rDoc)

--- a/what-changed/model/response_test.go
+++ b/what-changed/model/response_test.go
@@ -36,8 +36,8 @@ x-toot: poot`
 	var rDoc v2.Response
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	extChanges := CompareResponse(&lDoc, &rDoc)
 	assert.Nil(t, extChanges)
@@ -74,8 +74,8 @@ x-toot: poot`
 	var rDoc v2.Response
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	extChanges := CompareResponse(&lDoc, &rDoc)
 	assert.Equal(t, 5, extChanges.TotalChanges())
@@ -108,8 +108,8 @@ examples:
 	var rDoc v2.Response
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	extChanges := CompareResponse(&lDoc, &rDoc)
 	assert.Equal(t, 2, extChanges.TotalChanges())
@@ -142,8 +142,8 @@ examples:
 	var rDoc v2.Response
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	extChanges := CompareResponse(&rDoc, &lDoc)
 	assert.Equal(t, 2, extChanges.TotalChanges())
@@ -176,8 +176,8 @@ x-toot: poot`
 	var rDoc v3.Response
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	extChanges := CompareResponse(&lDoc, &rDoc)
 	assert.Nil(t, extChanges)
@@ -222,8 +222,8 @@ x-toot: pooty`
 	var rDoc v3.Response
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	extChanges := CompareResponse(&lDoc, &rDoc)
 

--- a/what-changed/model/responses_test.go
+++ b/what-changed/model/responses_test.go
@@ -38,8 +38,8 @@ default:
 	var rDoc v2.Responses
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	extChanges := CompareResponses(&lDoc, &rDoc)
 	assert.Nil(t, extChanges)
@@ -76,8 +76,8 @@ x-ting: tang`
 	var rDoc v2.Responses
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	extChanges := CompareResponses(&lDoc, &rDoc)
 	assert.Equal(t, 2, extChanges.TotalChanges())
@@ -117,8 +117,8 @@ x-apple: pie`
 	var rDoc v2.Responses
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	extChanges := CompareResponses(&rDoc, &lDoc)
 	assert.Equal(t, 2, extChanges.TotalChanges())
@@ -153,8 +153,8 @@ func TestCompareResponses_V2_RemoveSchema(t *testing.T) {
 	var rDoc v2.Responses
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	extChanges := CompareResponses(&lDoc, &rDoc)
 	assert.Equal(t, 1, extChanges.TotalChanges())
@@ -187,8 +187,8 @@ default:
 	var rDoc v2.Responses
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	extChanges := CompareResponses(&lDoc, &rDoc)
 	assert.Equal(t, 1, extChanges.TotalChanges())
@@ -221,8 +221,8 @@ default:
 	var rDoc v2.Responses
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	extChanges := CompareResponses(&rDoc, &lDoc)
 	assert.Equal(t, 1, extChanges.TotalChanges())
@@ -259,8 +259,8 @@ default:
 	var rDoc v2.Responses
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	extChanges := CompareResponses(&lDoc, &rDoc)
 	assert.Equal(t, 2, extChanges.TotalChanges())
@@ -289,8 +289,8 @@ default:
 	var rDoc v3.Responses
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	extChanges := CompareResponses(&lDoc, &rDoc)
 	assert.Nil(t, extChanges)
@@ -323,8 +323,8 @@ x-coffee: yum
 	var rDoc v3.Responses
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	extChanges := CompareResponses(&lDoc, &rDoc)
 	assert.Equal(t, 4, extChanges.TotalChanges())
@@ -357,8 +357,8 @@ default:
 	var rDoc v3.Responses
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	extChanges := CompareResponses(&lDoc, &rDoc)
 	assert.Equal(t, 1, extChanges.TotalChanges())
@@ -392,8 +392,8 @@ default:
 	var rDoc v3.Responses
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	extChanges := CompareResponses(&rDoc, &lDoc)
 	assert.Equal(t, 1, extChanges.TotalChanges())
@@ -429,8 +429,8 @@ default:
 	var rDoc v3.Responses
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	extChanges := CompareResponses(&lDoc, &rDoc)
 	assert.Equal(t, 1, extChanges.TotalChanges())
@@ -462,8 +462,8 @@ func TestCompareResponses_V3_AddRemoveMediaType(t *testing.T) {
 	var rDoc v3.Responses
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	extChanges := CompareResponses(&lDoc, &rDoc)
 	assert.Equal(t, 2, extChanges.TotalChanges())

--- a/what-changed/model/scopes_test.go
+++ b/what-changed/model/scopes_test.go
@@ -29,8 +29,8 @@ x-nugget: chicken`
 	var rDoc v2.Scopes
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareScopes(&lDoc, &rDoc)
@@ -55,8 +55,8 @@ x-nugget: chicken`
 	var rDoc v2.Scopes
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareScopes(&lDoc, &rDoc)
@@ -84,8 +84,8 @@ x-nugget: chicken`
 	var rDoc v2.Scopes
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareScopes(&lDoc, &rDoc)
@@ -114,8 +114,8 @@ x-nugget: soup`
 	var rDoc v2.Scopes
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareScopes(&rDoc, &lDoc)

--- a/what-changed/model/security_requirement_test.go
+++ b/what-changed/model/security_requirement_test.go
@@ -30,8 +30,8 @@ func TestCompareSecurityRequirement_V2(t *testing.T) {
 	var rDoc base.SecurityRequirement
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare
 	extChanges := CompareSecurityRequirement(&lDoc, &rDoc)
@@ -63,8 +63,8 @@ biscuit:
 	var rDoc base.SecurityRequirement
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare
 	extChanges := CompareSecurityRequirement(&lDoc, &rDoc)
@@ -96,8 +96,8 @@ biscuit:
 	var rDoc base.SecurityRequirement
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare
 	extChanges := CompareSecurityRequirement(&rDoc, &lDoc)
@@ -129,8 +129,8 @@ milk:
 	var rDoc base.SecurityRequirement
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare
 	extChanges := CompareSecurityRequirement(&lDoc, &rDoc)
@@ -166,8 +166,8 @@ milk:
 	var rDoc base.SecurityRequirement
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare
 	extChanges := CompareSecurityRequirement(&lDoc, &rDoc)
@@ -201,8 +201,8 @@ biscuit:
 	var rDoc base.SecurityRequirement
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare
 	extChanges := CompareSecurityRequirement(&lDoc, &rDoc)
@@ -239,8 +239,8 @@ biscuit:
 	var rDoc base.SecurityRequirement
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare
 	extChanges := CompareSecurityRequirement(&lDoc, &rDoc)
@@ -273,8 +273,8 @@ biscuit:
 	var rDoc base.SecurityRequirement
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare
 	extChanges := CompareSecurityRequirement(&lDoc, &rDoc)
@@ -307,8 +307,8 @@ biscuit:
 	var rDoc base.SecurityRequirement
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare
 	extChanges := CompareSecurityRequirement(&lDoc, &rDoc)
@@ -339,8 +339,8 @@ biscuit:
 	var rDoc base.SecurityRequirement
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare
 	extChanges := CompareSecurityRequirement(&rDoc, &lDoc)
@@ -375,8 +375,8 @@ biscuit:
 	var rDoc base.SecurityRequirement
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare
 	extChanges := CompareSecurityRequirement(&lDoc, &rDoc)

--- a/what-changed/model/security_scheme_test.go
+++ b/what-changed/model/security_scheme_test.go
@@ -37,8 +37,8 @@ x-beer: tasty`
 	var rDoc v2.SecurityScheme
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare
 	extChanges := CompareSecuritySchemes(&lDoc, &rDoc)
@@ -66,8 +66,8 @@ x-beer: very tasty`
 	var rDoc v2.SecurityScheme
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare
 	extChanges := CompareSecuritySchemes(&lDoc, &rDoc)
@@ -98,8 +98,8 @@ scopes:
 	var rDoc v2.SecurityScheme
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare
 	extChanges := CompareSecuritySchemes(&lDoc, &rDoc)
@@ -128,8 +128,8 @@ scopes:
 	var rDoc v2.SecurityScheme
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare
 	extChanges := CompareSecuritySchemes(&rDoc, &lDoc)
@@ -158,8 +158,8 @@ func TestCompareSecuritySchemes_v2_ModifyScope(t *testing.T) {
 	var rDoc v2.SecurityScheme
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare
 	extChanges := CompareSecuritySchemes(&lDoc, &rDoc)
@@ -193,8 +193,8 @@ description: a thing`
 	var rDoc v3.SecurityScheme
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare
 	extChanges := CompareSecuritySchemes(&lDoc, &rDoc)
@@ -224,8 +224,8 @@ x-beer: cool`
 	var rDoc v3.SecurityScheme
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare
 	extChanges := CompareSecuritySchemes(&lDoc, &rDoc)
@@ -257,8 +257,8 @@ flows:
 	var rDoc v3.SecurityScheme
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare
 	extChanges := CompareSecuritySchemes(&lDoc, &rDoc)
@@ -286,8 +286,8 @@ flows:
 	var rDoc v3.SecurityScheme
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare
 	extChanges := CompareSecuritySchemes(&rDoc, &lDoc)
@@ -318,8 +318,8 @@ flows:
 	var rDoc v3.SecurityScheme
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare
 	extChanges := CompareSecuritySchemes(&lDoc, &rDoc)

--- a/what-changed/model/server_test.go
+++ b/what-changed/model/server_test.go
@@ -40,8 +40,8 @@ variables:
 	var rDoc v3.Server
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareServers(&lDoc, &rDoc)
@@ -77,8 +77,8 @@ variables:
 	var rDoc v3.Server
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareServers(&lDoc, &rDoc)
@@ -115,8 +115,8 @@ variables:
 	var rDoc v3.Server
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareServers(&lDoc, &rDoc)
@@ -155,8 +155,8 @@ variables:
 	var rDoc v3.Server
 	_ = low.BuildModel(lNode.Content[0], &lDoc)
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
-	_ = lDoc.Build(lNode.Content[0], nil)
-	_ = rDoc.Build(rNode.Content[0], nil)
+	_ = lDoc.Build(nil, lNode.Content[0], nil)
+	_ = rDoc.Build(nil, rNode.Content[0], nil)
 
 	// compare.
 	extChanges := CompareServers(&rDoc, &lDoc)


### PR DESCRIPTION
Hi Dave,
We came to a point where we need to get access to a key node for the objects. As I figured the key node is present in the low proxy, but there are no methods to access it. When I've added a method, i noticed that key node (kn) is always empty.

I made an attempt to fix it. Please let me know what do you think?  Or is there any better way to get access to a key node.

Main changes are:
```go
// On Buildable key was added
Build(key, value *yaml.Node, idx *index.SpecIndex) error
```

```go
// On low proxy

// GetKeyNode will return the yaml.Node pointer that is a key for value node.
func (sp *SchemaProxy) GetKeyNode() *yaml.Node {
	return sp.kn
}
```