### PR TITLE
fix: add missing const value to schema

### DIFF
--- a/datamodel/high/base/schema.go
+++ b/datamodel/high/base/schema.go
@@ -92,6 +92,7 @@ type Schema struct {
 	AdditionalProperties any                     `json:"additionalProperties,omitempty" yaml:"additionalProperties,renderZero,omitempty"`
 	Description          string                  `json:"description,omitempty" yaml:"description,omitempty"`
 	Default              any                     `json:"default,omitempty" yaml:"default,renderZero,omitempty"`
+	Const                any                     `json:"const,omitempty" yaml:"const,renderZero,omitempty"`
 	Nullable             *bool                   `json:"nullable,omitempty" yaml:"nullable,omitempty"`
 	ReadOnly             bool                    `json:"readOnly,omitempty" yaml:"readOnly,omitempty"`   // https://github.com/pb33f/libopenapi/issues/30
 	WriteOnly            bool                    `json:"writeOnly,omitempty" yaml:"writeOnly,omitempty"` // https://github.com/pb33f/libopenapi/issues/30
@@ -232,7 +233,6 @@ func NewSchema(schema *base.Schema) *Schema {
 	}
 
 	if !schema.UnevaluatedProperties.IsEmpty() {
-
 	}
 
 	s.Pattern = schema.Pattern.Value
@@ -263,6 +263,7 @@ func NewSchema(schema *base.Schema) *Schema {
 	}
 	s.Description = schema.Description.Value
 	s.Default = schema.Default.Value
+	s.Const = schema.Const.Value
 	if !schema.Nullable.IsEmpty() {
 		s.Nullable = &schema.Nullable.Value
 	}

--- a/datamodel/low/base/schema_test.go
+++ b/datamodel/low/base/schema_test.go
@@ -405,7 +405,8 @@ contentEncoding: fish64
 contentMediaType: fish/paste
 items: true
 examples:
-  - testing`
+  - testing
+const: tasty`
 
 	var rootNode yaml.Node
 	mErr := yaml.Unmarshal([]byte(testSpec), &rootNode)
@@ -432,6 +433,7 @@ examples:
 	assert.Equal(t, "fish/paste", sch.ContentMediaType.Value)
 	assert.True(t, sch.Items.Value.IsB())
 	assert.True(t, sch.Items.Value.B)
+	assert.Equal(t, "tasty", sch.Const.Value)
 }
 
 func TestSchema_Build_PropsLookup(t *testing.T) {

--- a/datamodel/low/base/schema_test.go
+++ b/datamodel/low/base/schema_test.go
@@ -415,23 +415,23 @@ examples:
 	mbErr := low.BuildModel(rootNode.Content[0], &sch)
 	assert.NoError(t, mbErr)
 
-    schErr := sch.Build(rootNode.Content[0], nil)
-    assert.NoError(t, schErr)
-    assert.Equal(t, "something object", sch.Description.Value)
-    assert.Len(t, sch.Type.Value.B, 2)
-    assert.True(t, sch.Type.Value.IsB())
-    assert.Equal(t, "object", sch.Type.Value.B[0].Value)
-    assert.True(t, sch.ExclusiveMinimum.Value.IsB())
-    assert.False(t, sch.ExclusiveMinimum.Value.IsA())
-    assert.True(t, sch.ExclusiveMaximum.Value.IsB())
-    assert.Equal(t, float64(12), sch.ExclusiveMinimum.Value.B)
-    assert.Equal(t, float64(13), sch.ExclusiveMaximum.Value.B)
-    assert.Len(t, sch.Examples.Value, 1)
-    assert.Equal(t, "testing", sch.Examples.Value[0].Value)
-    assert.Equal(t, "fish64", sch.ContentEncoding.Value)
-    assert.Equal(t, "fish/paste", sch.ContentMediaType.Value)
-    assert.True(t, sch.Items.Value.IsB())
-    assert.True(t, sch.Items.Value.B)
+	schErr := sch.Build(rootNode.Content[0], nil)
+	assert.NoError(t, schErr)
+	assert.Equal(t, "something object", sch.Description.Value)
+	assert.Len(t, sch.Type.Value.B, 2)
+	assert.True(t, sch.Type.Value.IsB())
+	assert.Equal(t, "object", sch.Type.Value.B[0].Value)
+	assert.True(t, sch.ExclusiveMinimum.Value.IsB())
+	assert.False(t, sch.ExclusiveMinimum.Value.IsA())
+	assert.True(t, sch.ExclusiveMaximum.Value.IsB())
+	assert.Equal(t, float64(12), sch.ExclusiveMinimum.Value.B)
+	assert.Equal(t, float64(13), sch.ExclusiveMaximum.Value.B)
+	assert.Len(t, sch.Examples.Value, 1)
+	assert.Equal(t, "testing", sch.Examples.Value[0].Value)
+	assert.Equal(t, "fish64", sch.ContentEncoding.Value)
+	assert.Equal(t, "fish/paste", sch.ContentMediaType.Value)
+	assert.True(t, sch.Items.Value.IsB())
+	assert.True(t, sch.Items.Value.B)
 }
 
 func TestSchema_Build_PropsLookup(t *testing.T) {
@@ -986,6 +986,22 @@ schema:
 	assert.Equal(t, 5, sch.Default.Value)
 }
 
+func TestExtractSchema_ConstPrimitive(t *testing.T) {
+	yml := `
+schema: 
+  type: object
+  const: 5`
+
+	var idxNode yaml.Node
+	_ = yaml.Unmarshal([]byte(yml), &idxNode)
+
+	res, err := ExtractSchema(idxNode.Content[0], nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, res.Value)
+	sch := res.Value.Schema()
+	assert.Equal(t, 5, sch.Const.Value)
+}
+
 func TestExtractSchema_Ref(t *testing.T) {
 	yml := `components:
   schemas:
@@ -1156,7 +1172,6 @@ func TestExtractSchema_AdditionalPropertiesAsSchema(t *testing.T) {
 
 	assert.NotNil(t, res.Value.Schema().AdditionalProperties.Value.(*SchemaProxy).Schema())
 	assert.Nil(t, err)
-
 }
 
 func TestExtractSchema_AdditionalPropertiesAsSchemaSlice(t *testing.T) {
@@ -1180,7 +1195,6 @@ func TestExtractSchema_AdditionalPropertiesAsSchemaSlice(t *testing.T) {
 
 	assert.NotNil(t, res.Value.Schema().AdditionalProperties.Value.([]low.ValueReference[interface{}]))
 	assert.Nil(t, err)
-
 }
 
 func TestExtractSchema_DoNothing(t *testing.T) {
@@ -1599,7 +1613,6 @@ func TestSchema_UnevaluatedPropertiesAsBool_DefinedAsTrue(t *testing.T) {
 
 	assert.Equal(t, "571bd1853c22393131e2dcadce86894da714ec14968895c8b7ed18154b2be8cd",
 		low.GenerateHashString(res.Value.Schema().UnevaluatedProperties.Value))
-
 }
 
 func TestSchema_UnevaluatedPropertiesAsBool_DefinedAsFalse(t *testing.T) {
@@ -1622,7 +1635,6 @@ func TestSchema_UnevaluatedPropertiesAsBool_DefinedAsFalse(t *testing.T) {
 
 	assert.True(t, res.Value.Schema().UnevaluatedProperties.Value.IsB())
 	assert.False(t, *res.Value.Schema().UnevaluatedProperties.Value.B)
-
 }
 
 func TestSchema_UnevaluatedPropertiesAsBool_Undefined(t *testing.T) {
@@ -1644,5 +1656,4 @@ func TestSchema_UnevaluatedPropertiesAsBool_Undefined(t *testing.T) {
 	res, _ := ExtractSchema(idxNode.Content[0], idx)
 
 	assert.Nil(t, res.Value.Schema().UnevaluatedProperties.Value)
-
 }

--- a/datamodel/low/v3/constants.go
+++ b/datamodel/low/v3/constants.go
@@ -33,6 +33,7 @@ const (
 	TraceLabel                 = "trace"
 	LinksLabel                 = "links"
 	DefaultLabel               = "default"
+	ConstLabel                 = "const"
 	SecurityLabel              = "security"
 	SecuritySchemesLabel       = "securitySchemes"
 	OAuthFlowsLabel            = "flows"


### PR DESCRIPTION
Libopenapi was missing the ability to access the [const field](https://json-schema.org/understanding-json-schema/reference/generic.html#constant-values) of a schema.

This adds that