### PR TITLE
Properties named ‘enum’ were being indexed as enums

### DIFF
--- a/index/extract_refs.go
+++ b/index/extract_refs.go
@@ -329,11 +329,12 @@ func (index *SpecIndex) ExtractRefs(node, parent *yaml.Node, seenPath []string, 
 				// capture enums
 				if n.Value == "enum" {
 
-					lastItem := seenPath[len(seenPath)-1]
-					if lastItem == "properties" {
-						continue
+					if len(seenPath) > 0 {
+						lastItem := seenPath[len(seenPath)-1]
+						if lastItem == "properties" {
+							continue
+						}
 					}
-
 					// all enums need to have a type, extract the type from the node where the enum was found.
 					_, enumKeyValueNode := utils.FindKeyNodeTop("type", node.Content)
 

--- a/index/extract_refs.go
+++ b/index/extract_refs.go
@@ -329,6 +329,11 @@ func (index *SpecIndex) ExtractRefs(node, parent *yaml.Node, seenPath []string, 
 				// capture enums
 				if n.Value == "enum" {
 
+					lastItem := seenPath[len(seenPath)-1]
+					if lastItem == "properties" {
+						continue
+					}
+
 					// all enums need to have a type, extract the type from the node where the enum was found.
 					_, enumKeyValueNode := utils.FindKeyNodeTop("type", node.Content)
 

--- a/index/extract_refs_test.go
+++ b/index/extract_refs_test.go
@@ -134,3 +134,41 @@ components:
 	assert.Len(t, idx.allMappedRefs, 1)
 	assert.Equal(t, "Cake[Burger]", idx.allMappedRefs["#/components/schemas/Cake[Burger]"].Name)
 }
+
+// https://github.com/daveshanley/vacuum/issues/339
+func TestSpecIndex_ExtractRefs_CheckEnumNotPropertyCalledEnum(t *testing.T) {
+
+	yml := `openapi: 3.0.0
+components:
+  schemas:
+    SimpleFieldSchema:
+      description: Schema of a field as described in  JSON Schema draft 2019-09
+      type: object
+      required:
+        - type
+        - description
+      properties:
+        type:
+          type: string
+          enum:
+            - string
+            - number
+        description:
+          type: string
+          description: A description of the property
+        enum:
+          type: array
+          description: A array of describing the possible values
+          items:
+            type: string
+          example:
+            - yo
+            - hello
+   `
+	var rootNode yaml.Node
+	_ = yaml.Unmarshal([]byte(yml), &rootNode)
+	c := CreateOpenAPIIndexConfig()
+	idx := NewSpecIndexWithConfig(&rootNode, c)
+	assert.Len(t, idx.allEnums, 1)
+
+}


### PR DESCRIPTION
An edge case reported in https://github.com/daveshanley/vacuum/issues/339 shows up when enums are being indexed when they are actually a property of a schema called ‘enum’.

This has been fixed.