### PR TITLE
Added support for configurable levels of circular reference checking …

### DIFF
--- a/datamodel/document_config.go
+++ b/datamodel/document_config.go
@@ -40,6 +40,18 @@ type DocumentConfiguration struct {
 	// BypassDocumentCheck will bypass the document check. This is disabled by default. This will allow any document to
 	// passed in and used. Only enable this when parsing non openapi documents.
 	BypassDocumentCheck bool
+
+	// IgnorePolymorphicCircularReferences will skip over checking for circular references in polymorphic schemas.
+	// A polymorphic schema is any schema that is composed other schemas using references via `oneOf`, `anyOf` of `allOf`.
+	// This is disabled by default, which means polymorphic circular references will be checked.
+	IgnorePolymorphicCircularReferences bool
+
+	// IgnoreArrayCircularReferences will skip over checking for circular references in arrays. Sometimes a circular
+	// reference is required to describe a data-shape correctly. Often those shapes are valid circles if the
+	// type of the schema implementing the loop is an array. An empty array would technically break the loop.
+	// So if libopenapi is returning circular references for this use case, then this option should be enabled.
+	// this is disabled by default, which means array circular references will be checked.
+	IgnoreArrayCircularReferences bool
 }
 
 func NewOpenDocumentConfiguration() *DocumentConfiguration {

--- a/datamodel/low/v3/create_document.go
+++ b/datamodel/low/v3/create_document.go
@@ -63,6 +63,16 @@ func createDocument(info *datamodel.SpecInfo, config *datamodel.DocumentConfigur
 
 	// create resolver and check for circular references.
 	resolve := resolver.NewResolver(idx)
+
+	// if configured, ignore circular references in arrays and polymorphic schemas
+	if config.IgnoreArrayCircularReferences {
+		resolve.IgnoreArrayCircularReferences()
+	}
+	if config.IgnorePolymorphicCircularReferences {
+		resolve.IgnorePolymorphicCircularReferences()
+	}
+
+	// check for circular references.
 	resolvingErrors := resolve.CheckForCircularReferences()
 
 	if len(resolvingErrors) > 0 {

--- a/index/circular_reference_result.go
+++ b/index/circular_reference_result.go
@@ -8,8 +8,10 @@ type CircularReferenceResult struct {
 	Start               *Reference
 	LoopIndex           int
 	LoopPoint           *Reference
-	IsPolymorphicResult bool // if this result comes from a polymorphic loop.
-	IsInfiniteLoop      bool // if all the definitions in the reference loop are marked as required, this is an infinite circular reference, thus is not allowed.
+	IsArrayResult       bool   // if this result comes from an array loop.
+	PolymorphicType     string // which type of polymorphic loop is this? (oneOf, anyOf, allOf)
+	IsPolymorphicResult bool   // if this result comes from a polymorphic loop.
+	IsInfiniteLoop      bool   // if all the definitions in the reference loop are marked as required, this is an infinite circular reference, thus is not allowed.
 }
 
 func (c *CircularReferenceResult) GenerateJourneyPath() string {

--- a/index/index_model.go
+++ b/index/index_model.go
@@ -105,6 +105,12 @@ type SpecIndexConfig struct {
 	// Use the `BuildIndex()` method on the index to build it out once resolved/ready.
 	AvoidBuildIndex bool
 
+	// If set to true, the index will ignore circular references in polymorphic schemas.
+	IgnorePolymorphicCircularReferences bool // ignore circular references in polymorphic schemas.
+
+	// If set to true, the index will ignore circular references in arrays.
+	IgnoreArrayCircularReferences bool // ignore circular references in arrays.
+
 	// private fields
 	seenRemoteSources *syncmap.Map
 	remoteLock        *sync.Mutex

--- a/index/index_model.go
+++ b/index/index_model.go
@@ -105,12 +105,6 @@ type SpecIndexConfig struct {
 	// Use the `BuildIndex()` method on the index to build it out once resolved/ready.
 	AvoidBuildIndex bool
 
-	// If set to true, the index will ignore circular references in polymorphic schemas.
-	IgnorePolymorphicCircularReferences bool // ignore circular references in polymorphic schemas.
-
-	// If set to true, the index will ignore circular references in arrays.
-	IgnoreArrayCircularReferences bool // ignore circular references in arrays.
-
 	// private fields
 	seenRemoteSources *syncmap.Map
 	remoteLock        *sync.Mutex

--- a/index/index_model.go
+++ b/index/index_model.go
@@ -28,6 +28,7 @@ type Reference struct {
 	Name                  string
 	Node                  *yaml.Node
 	ParentNode            *yaml.Node
+	ParentNodeSchemaType  string // used to determine if the parent node is an array or not.
 	Resolved              bool
 	Circular              bool
 	Seen                  bool

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -3,7 +3,8 @@ package resolver
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"net/url"
+	"os"
 	"testing"
 
 	"github.com/pb33f/libopenapi/index"
@@ -16,24 +17,24 @@ func TestNewResolver(t *testing.T) {
 }
 
 func Benchmark_ResolveDocumentStripe(b *testing.B) {
-	stripe, _ := ioutil.ReadFile("../test_specs/stripe.yaml")
+	stripe, _ := os.ReadFile("../test_specs/stripe.yaml")
 	for n := 0; n < b.N; n++ {
 		var rootNode yaml.Node
-		yaml.Unmarshal(stripe, &rootNode)
-		index := index.NewSpecIndex(&rootNode)
-		resolver := NewResolver(index)
+		_ = yaml.Unmarshal(stripe, &rootNode)
+		idx := index.NewSpecIndexWithConfig(&rootNode, index.CreateClosedAPIIndexConfig())
+		resolver := NewResolver(idx)
 		resolver.Resolve()
 	}
 }
 
 func TestResolver_ResolveComponents_CircularSpec(t *testing.T) {
-	circular, _ := ioutil.ReadFile("../test_specs/circular-tests.yaml")
+	circular, _ := os.ReadFile("../test_specs/circular-tests.yaml")
 	var rootNode yaml.Node
-	yaml.Unmarshal(circular, &rootNode)
+	_ = yaml.Unmarshal(circular, &rootNode)
 
-	index := index.NewSpecIndex(&rootNode)
+	idx := index.NewSpecIndexWithConfig(&rootNode, index.CreateClosedAPIIndexConfig())
 
-	resolver := NewResolver(index)
+	resolver := NewResolver(idx)
 	assert.NotNil(t, resolver)
 
 	circ := resolver.Resolve()
@@ -44,13 +45,13 @@ func TestResolver_ResolveComponents_CircularSpec(t *testing.T) {
 }
 
 func TestResolver_CheckForCircularReferences(t *testing.T) {
-	circular, _ := ioutil.ReadFile("../test_specs/circular-tests.yaml")
+	circular, _ := os.ReadFile("../test_specs/circular-tests.yaml")
 	var rootNode yaml.Node
-	yaml.Unmarshal(circular, &rootNode)
+	_ = yaml.Unmarshal(circular, &rootNode)
 
-	index := index.NewSpecIndex(&rootNode)
+	idx := index.NewSpecIndexWithConfig(&rootNode, index.CreateClosedAPIIndexConfig())
 
-	resolver := NewResolver(index)
+	resolver := NewResolver(idx)
 	assert.NotNil(t, resolver)
 
 	circ := resolver.CheckForCircularReferences()
@@ -80,11 +81,11 @@ components:
         - "name"
         - "children"`)
 	var rootNode yaml.Node
-	yaml.Unmarshal(circular, &rootNode)
+	_ = yaml.Unmarshal(circular, &rootNode)
 
-	index := index.NewSpecIndex(&rootNode)
+	idx := index.NewSpecIndexWithConfig(&rootNode, index.CreateClosedAPIIndexConfig())
 
-	resolver := NewResolver(index)
+	resolver := NewResolver(idx)
 	assert.NotNil(t, resolver)
 
 	circ := resolver.CheckForCircularReferences()
@@ -115,11 +116,11 @@ components:
         - "name"
         - "children"`)
 	var rootNode yaml.Node
-	yaml.Unmarshal(circular, &rootNode)
+	_ = yaml.Unmarshal(circular, &rootNode)
 
-	index := index.NewSpecIndex(&rootNode)
+	idx := index.NewSpecIndexWithConfig(&rootNode, index.CreateClosedAPIIndexConfig())
 
-	resolver := NewResolver(index)
+	resolver := NewResolver(idx)
 	assert.NotNil(t, resolver)
 
 	resolver.IgnoreArrayCircularReferences()
@@ -151,11 +152,11 @@ components:
         - "name"
         - "children"`)
 	var rootNode yaml.Node
-	yaml.Unmarshal(circular, &rootNode)
+	_ = yaml.Unmarshal(circular, &rootNode)
 
-	index := index.NewSpecIndex(&rootNode)
+	idx := index.NewSpecIndexWithConfig(&rootNode, index.CreateClosedAPIIndexConfig())
 
-	resolver := NewResolver(index)
+	resolver := NewResolver(idx)
 	assert.NotNil(t, resolver)
 
 	resolver.IgnorePolymorphicCircularReferences()
@@ -187,11 +188,11 @@ components:
         - "name"
         - "children"`)
 	var rootNode yaml.Node
-	yaml.Unmarshal(circular, &rootNode)
+	_ = yaml.Unmarshal(circular, &rootNode)
 
-	index := index.NewSpecIndex(&rootNode)
+	idx := index.NewSpecIndexWithConfig(&rootNode, index.CreateClosedAPIIndexConfig())
 
-	resolver := NewResolver(index)
+	resolver := NewResolver(idx)
 	assert.NotNil(t, resolver)
 
 	resolver.IgnorePolymorphicCircularReferences()
@@ -223,11 +224,11 @@ components:
         - "name"
         - "children"`)
 	var rootNode yaml.Node
-	yaml.Unmarshal(circular, &rootNode)
+	_ = yaml.Unmarshal(circular, &rootNode)
 
-	index := index.NewSpecIndex(&rootNode)
+	idx := index.NewSpecIndexWithConfig(&rootNode, index.CreateClosedAPIIndexConfig())
 
-	resolver := NewResolver(index)
+	resolver := NewResolver(idx)
 	assert.NotNil(t, resolver)
 
 	resolver.IgnorePolymorphicCircularReferences()
@@ -259,11 +260,11 @@ components:
         - "name"
         - "children"`)
 	var rootNode yaml.Node
-	yaml.Unmarshal(circular, &rootNode)
+	_ = yaml.Unmarshal(circular, &rootNode)
 
-	index := index.NewSpecIndex(&rootNode)
+	idx := index.NewSpecIndexWithConfig(&rootNode, index.CreateClosedAPIIndexConfig())
 
-	resolver := NewResolver(index)
+	resolver := NewResolver(idx)
 	assert.NotNil(t, resolver)
 
 	circ := resolver.CheckForCircularReferences()
@@ -293,11 +294,11 @@ components:
         - "name"
         - "children"`)
 	var rootNode yaml.Node
-	yaml.Unmarshal(circular, &rootNode)
+	_ = yaml.Unmarshal(circular, &rootNode)
 
-	index := index.NewSpecIndex(&rootNode)
+	idx := index.NewSpecIndexWithConfig(&rootNode, index.CreateClosedAPIIndexConfig())
 
-	resolver := NewResolver(index)
+	resolver := NewResolver(idx)
 	assert.NotNil(t, resolver)
 
 	circ := resolver.CheckForCircularReferences()
@@ -310,39 +311,39 @@ components:
 	assert.NoError(t, err)
 }
 
-//func TestResolver_CheckForCircularReferences_DigitalOcean(t *testing.T) {
-//	circular, _ := ioutil.ReadFile("../test_specs/digitalocean.yaml")
-//	var rootNode yaml.Node
-//	yaml.Unmarshal(circular, &rootNode)
-//
-//	baseURL, _ := url.Parse("https://raw.githubusercontent.com/digitalocean/openapi/main/specification")
-//
-//	index := index.NewSpecIndexWithConfig(&rootNode, &index.SpecIndexConfig{
-//		AllowRemoteLookup: true,
-//		AllowFileLookup:   true,
-//		BaseURL:           baseURL,
-//	})
-//
-//	resolver := NewResolver(index)
-//	assert.NotNil(t, resolver)
-//
-//	circ := resolver.CheckForCircularReferences()
-//	assert.Len(t, circ, 0)
-//	assert.Len(t, resolver.GetResolvingErrors(), 0)
-//	assert.Len(t, resolver.GetCircularErrors(), 0)
-//
-//	_, err := yaml.Marshal(resolver.resolvedRoot)
-//	assert.NoError(t, err)
-//}
+func TestResolver_CheckForCircularReferences_DigitalOcean(t *testing.T) {
+	circular, _ := os.ReadFile("../test_specs/digitalocean.yaml")
+	var rootNode yaml.Node
+	_ = yaml.Unmarshal(circular, &rootNode)
+
+	baseURL, _ := url.Parse("https://raw.githubusercontent.com/digitalocean/openapi/main/specification")
+
+	idx := index.NewSpecIndexWithConfig(&rootNode, &index.SpecIndexConfig{
+		AllowRemoteLookup: true,
+		AllowFileLookup:   true,
+		BaseURL:           baseURL,
+	})
+
+	resolver := NewResolver(idx)
+	assert.NotNil(t, resolver)
+
+	circ := resolver.CheckForCircularReferences()
+	assert.Len(t, circ, 0)
+	assert.Len(t, resolver.GetResolvingErrors(), 0)
+	assert.Len(t, resolver.GetCircularErrors(), 0)
+
+	_, err := yaml.Marshal(resolver.resolvedRoot)
+	assert.NoError(t, err)
+}
 
 func TestResolver_CircularReferencesRequiredValid(t *testing.T) {
-	circular, _ := ioutil.ReadFile("../test_specs/swagger-valid-recursive-model.yaml")
+	circular, _ := os.ReadFile("../test_specs/swagger-valid-recursive-model.yaml")
 	var rootNode yaml.Node
-	yaml.Unmarshal(circular, &rootNode)
+	_ = yaml.Unmarshal(circular, &rootNode)
 
-	index := index.NewSpecIndex(&rootNode)
+	idx := index.NewSpecIndexWithConfig(&rootNode, index.CreateClosedAPIIndexConfig())
 
-	resolver := NewResolver(index)
+	resolver := NewResolver(idx)
 	assert.NotNil(t, resolver)
 
 	circ := resolver.CheckForCircularReferences()
@@ -353,13 +354,13 @@ func TestResolver_CircularReferencesRequiredValid(t *testing.T) {
 }
 
 func TestResolver_CircularReferencesRequiredInvalid(t *testing.T) {
-	circular, _ := ioutil.ReadFile("../test_specs/swagger-invalid-recursive-model.yaml")
+	circular, _ := os.ReadFile("../test_specs/swagger-invalid-recursive-model.yaml")
 	var rootNode yaml.Node
-	yaml.Unmarshal(circular, &rootNode)
+	_ = yaml.Unmarshal(circular, &rootNode)
 
-	index := index.NewSpecIndex(&rootNode)
+	idx := index.NewSpecIndexWithConfig(&rootNode, index.CreateClosedAPIIndexConfig())
 
-	resolver := NewResolver(index)
+	resolver := NewResolver(idx)
 	assert.NotNil(t, resolver)
 
 	circ := resolver.CheckForCircularReferences()
@@ -374,19 +375,19 @@ func TestResolver_DeepJourney(t *testing.T) {
 	for f := 0; f < 200; f++ {
 		journey = append(journey, nil)
 	}
-	index := index.NewSpecIndex(nil)
-	resolver := NewResolver(index)
+	idx := index.NewSpecIndexWithConfig(nil, nil)
+	resolver := NewResolver(idx)
 	assert.Nil(t, resolver.extractRelatives(nil, nil, nil, journey, false))
 }
 
 func TestResolver_ResolveComponents_Stripe(t *testing.T) {
-	stripe, _ := ioutil.ReadFile("../test_specs/stripe.yaml")
+	stripe, _ := os.ReadFile("../test_specs/stripe.yaml")
 	var rootNode yaml.Node
-	yaml.Unmarshal(stripe, &rootNode)
+	_ = yaml.Unmarshal(stripe, &rootNode)
 
-	index := index.NewSpecIndex(&rootNode)
+	idx := index.NewSpecIndexWithConfig(&rootNode, index.CreateClosedAPIIndexConfig())
 
-	resolver := NewResolver(index)
+	resolver := NewResolver(idx)
 	assert.NotNil(t, resolver)
 
 	circ := resolver.Resolve()
@@ -397,13 +398,13 @@ func TestResolver_ResolveComponents_Stripe(t *testing.T) {
 }
 
 func TestResolver_ResolveComponents_BurgerShop(t *testing.T) {
-	mixedref, _ := ioutil.ReadFile("../test_specs/burgershop.openapi.yaml")
+	mixedref, _ := os.ReadFile("../test_specs/burgershop.openapi.yaml")
 	var rootNode yaml.Node
-	yaml.Unmarshal(mixedref, &rootNode)
+	_ = yaml.Unmarshal(mixedref, &rootNode)
 
-	index := index.NewSpecIndex(&rootNode)
+	idx := index.NewSpecIndexWithConfig(&rootNode, index.CreateClosedAPIIndexConfig())
 
-	resolver := NewResolver(index)
+	resolver := NewResolver(idx)
 	assert.NotNil(t, resolver)
 
 	circ := resolver.Resolve()
@@ -432,11 +433,11 @@ components:
       description: tea`
 
 	var rootNode yaml.Node
-	yaml.Unmarshal([]byte(yml), &rootNode)
+	_ = yaml.Unmarshal([]byte(yml), &rootNode)
 
-	index := index.NewSpecIndex(&rootNode)
+	idx := index.NewSpecIndexWithConfig(&rootNode, index.CreateClosedAPIIndexConfig())
 
-	resolver := NewResolver(index)
+	resolver := NewResolver(idx)
 	assert.NotNil(t, resolver)
 
 	circ := resolver.CheckForCircularReferences()
@@ -459,18 +460,18 @@ components:
       description: tea`
 
 	var rootNode yaml.Node
-	yaml.Unmarshal([]byte(yml), &rootNode)
+	_ = yaml.Unmarshal([]byte(yml), &rootNode)
 
-	index := index.NewSpecIndex(&rootNode)
+	idx := index.NewSpecIndexWithConfig(&rootNode, index.CreateClosedAPIIndexConfig())
 
-	resolver := NewResolver(index)
+	resolver := NewResolver(idx)
 	assert.NotNil(t, resolver)
 
 	_ = resolver.CheckForCircularReferences()
 	resolver.circularReferences[0].IsInfiniteLoop = true // override
-	assert.Len(t, index.GetCircularReferences(), 1)
+	assert.Len(t, idx.GetCircularReferences(), 1)
 	assert.Len(t, resolver.GetPolymorphicCircularErrors(), 1)
-	assert.Equal(t, 2, index.GetCircularReferences()[0].LoopIndex)
+	assert.Equal(t, 2, idx.GetCircularReferences()[0].LoopIndex)
 
 }
 
@@ -495,11 +496,11 @@ components:
           $ref: 'go home, I am drunk'`
 
 	var rootNode yaml.Node
-	yaml.Unmarshal([]byte(yml), &rootNode)
+	_ = yaml.Unmarshal([]byte(yml), &rootNode)
 
-	index := index.NewSpecIndex(&rootNode)
+	idx := index.NewSpecIndexWithConfig(&rootNode, index.CreateClosedAPIIndexConfig())
 
-	resolver := NewResolver(index)
+	resolver := NewResolver(idx)
 	assert.NotNil(t, resolver)
 
 	err := resolver.Resolve()
@@ -508,9 +509,9 @@ components:
 }
 
 func TestResolver_ResolveComponents_MixedRef(t *testing.T) {
-	mixedref, _ := ioutil.ReadFile("../test_specs/mixedref-burgershop.openapi.yaml")
+	mixedref, _ := os.ReadFile("../test_specs/mixedref-burgershop.openapi.yaml")
 	var rootNode yaml.Node
-	yaml.Unmarshal(mixedref, &rootNode)
+	_ = yaml.Unmarshal(mixedref, &rootNode)
 
 	b := index.CreateOpenAPIIndexConfig()
 	idx := index.NewSpecIndexWithConfig(&rootNode, b)
@@ -529,13 +530,13 @@ func TestResolver_ResolveComponents_MixedRef(t *testing.T) {
 }
 
 func TestResolver_ResolveComponents_k8s(t *testing.T) {
-	k8s, _ := ioutil.ReadFile("../test_specs/k8s.json")
+	k8s, _ := os.ReadFile("../test_specs/k8s.json")
 	var rootNode yaml.Node
 	yaml.Unmarshal(k8s, &rootNode)
 
-	index := index.NewSpecIndex(&rootNode)
+	idx := index.NewSpecIndexWithConfig(&rootNode, index.CreateClosedAPIIndexConfig())
 
-	resolver := NewResolver(index)
+	resolver := NewResolver(idx)
 	assert.NotNil(t, resolver)
 
 	circ := resolver.Resolve()
@@ -548,17 +549,17 @@ func ExampleNewResolver() {
 	var rootNode yaml.Node
 
 	//  load in the Stripe OpenAPI spec (lots of polymorphic complexity in here)
-	stripeBytes, _ := ioutil.ReadFile("../test_specs/stripe.yaml")
+	stripeBytes, _ := os.ReadFile("../test_specs/stripe.yaml")
 
 	// unmarshal bytes into our rootNode.
 	_ = yaml.Unmarshal(stripeBytes, &rootNode)
 
 	// create a new spec index (resolver depends on it)
 	indexConfig := index.CreateClosedAPIIndexConfig()
-	index := index.NewSpecIndexWithConfig(&rootNode, indexConfig)
+	idx := index.NewSpecIndexWithConfig(&rootNode, indexConfig)
 
 	// create a new resolver using the index.
-	resolver := NewResolver(index)
+	resolver := NewResolver(idx)
 
 	// resolve the document, if there are circular reference errors, they are returned/
 	// WARNING: this is a destructive action and the rootNode will be PERMANENTLY altered and cannot be unresolved
@@ -574,7 +575,7 @@ func ExampleNewResolver() {
 
 func ExampleResolvingError() {
 	re := ResolvingError{
-		ErrorRef: errors.New("Je suis une erreur"),
+		ErrorRef: errors.New("je suis une erreur"),
 		Node: &yaml.Node{
 			Line:   5,
 			Column: 21,

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -532,7 +532,7 @@ func TestResolver_ResolveComponents_MixedRef(t *testing.T) {
 func TestResolver_ResolveComponents_k8s(t *testing.T) {
 	k8s, _ := os.ReadFile("../test_specs/k8s.json")
 	var rootNode yaml.Node
-	yaml.Unmarshal(k8s, &rootNode)
+	_ = yaml.Unmarshal(k8s, &rootNode)
 
 	idx := index.NewSpecIndexWithConfig(&rootNode, index.CreateClosedAPIIndexConfig())
 

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -585,5 +585,5 @@ func ExampleResolvingError() {
 	}
 
 	fmt.Printf("%s", re.Error())
-	// Output: Je suis une erreur: #/definitions/JeSuisUneErreur [5:21]
+	// Output: je suis une erreur: #/definitions/JeSuisUneErreur [5:21]
 }

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -375,7 +375,7 @@ func TestResolver_DeepJourney(t *testing.T) {
 	for f := 0; f < 200; f++ {
 		journey = append(journey, nil)
 	}
-	idx := index.NewSpecIndexWithConfig(nil, nil)
+	idx := index.NewSpecIndexWithConfig(nil, index.CreateClosedAPIIndexConfig())
 	resolver := NewResolver(idx)
 	assert.Nil(t, resolver.extractRelatives(nil, nil, nil, journey, false))
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -236,6 +236,9 @@ func FindKeyNodeTop(key string, nodes []*yaml.Node) (keyNode *yaml.Node, valueNo
 		}
 
 		if strings.EqualFold(key, v.Value) {
+			if i+1 >= len(nodes) {
+				return v, nodes[i]
+			}
 			return v, nodes[i+1] // next node is what we need.
 		}
 	}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -293,6 +293,17 @@ func TestFindKeyNodeTop(t *testing.T) {
 	assert.Equal(t, 3, k.Line)
 }
 
+func TestFindKeyNodeTopSingleNode(t *testing.T) {
+	a := &yaml.Node{
+		Value: "chicken",
+	}
+
+	c, k := FindKeyNodeTop("chicken", []*yaml.Node{a})
+	assert.Equal(t, "chicken", c.Value)
+	assert.Equal(t, "chicken", k.Value)
+
+}
+
 func TestFindKeyNodeTop_NotFound(t *testing.T) {
 	nodes, _ := FindNodes(getPetstore(), "$")
 	k, v := FindKeyNodeTop("i am a giant potato", nodes[0].Content)


### PR DESCRIPTION
Circular references mean different things to different consumers. They may or may not be valid use cases. So after much discussion, I've decided to allow engineers to override my opinions on circular references. 

Polymorphic based references, or array based references may or may not be valid circles, an empty array can break the loop for example. This isn't clear in the spec as there can be no way of knowing. The default position of `libopenapi` is to **not** ignore polymorphic (`anyOf`, `oneOf`, `allOf`) loops, or array based loops. 

Now this can be configured, Choose to ignore polymorphic loops, or array loops, or both. 

To configure the resolver directly, there are two new methods available:

`IgnorePolymorphicCircularReferences()` and `IgnoreArrayCircularReferences()`

The same properties exist on the `datamodel.DocumentConfiguration` struct that allows them to be ignored when building a document. For example:

```go
var d = `openapi: 3.1.0
components:
  schemas:
    ProductCategory:
      type: "object"
      properties:
        name:
          type: "string"
        children:
          type: "object"
          anyOf:
            - $ref: "#/components/schemas/ProductCategory"
          description: "Array of sub-categories in the same format."
      required:
        - "name"
        - "children"`

	config := datamodel.NewClosedDocumentConfiguration()
        
        // ignore polymorphic circular references.
	config.IgnorePolymorphicCircularReferences = true

	doc, err := NewDocumentWithConfiguration([]byte(d), config)
	if err != nil {
		panic(err)
	}

	m, errs := doc.BuildV3Model()

	assert.Len(t, errs, 0)
	assert.Len(t, m.Index.GetCircularReferences(), 0)
```

The second update in this release is that the `datamodel.CircularReferenceResult` contains more detail on
what type of circular reference was located. This is valuable to determine if you should programmatically ignore the loop.

```go
type CircularReferenceResult struct {
	Journey             []*Reference
	Start               *Reference
	LoopIndex           int
	LoopPoint           *Reference
	IsArrayResult       bool   // if this result comes from an array loop.
	PolymorphicType     string // which type of polymorphic loop is this? (oneOf, anyOf, allOf)
	IsPolymorphicResult bool   // if this result comes from a polymorphic loop.
	IsInfiniteLoop      bool   // if all the definitions in the reference loop are marked as required, this is an infinite circular reference, thus is not allowed.
}
```

The `IsArrayResult` will be true if the loop has come through an array

The `PolymorphicTypeResult` will be `oneOf`, `anyOf` or `allOf` depending on which type was used and the
`isPolymorphicResult` value will also be true, as before.

The docs have been updated for some more detail if required:

https://pb33f.io/libopenapi/circular-references/#circular-reference-results

- #113 
- #130