### PR TITLE
chore: replace use of deprecated ioutil with os

### DIFF
--- a/datamodel/high/v2/swagger_test.go
+++ b/datamodel/high/v2/swagger_test.go
@@ -4,18 +4,19 @@
 package v2
 
 import (
+	"os"
+
 	"github.com/pb33f/libopenapi/datamodel"
 	v2 "github.com/pb33f/libopenapi/datamodel/low/v2"
 	"github.com/stretchr/testify/assert"
 
-	"io/ioutil"
 	"testing"
 )
 
 var doc *v2.Swagger
 
 func initTest() {
-	data, _ := ioutil.ReadFile("../../../test_specs/petstorev2-complete.yaml")
+	data, _ := os.ReadFile("../../../test_specs/petstorev2-complete.yaml")
 	info, _ := datamodel.ExtractSpecInfo(data)
 	var err []error
 	doc, err = v2.CreateDocument(info)

--- a/datamodel/high/v3/media_type_test.go
+++ b/datamodel/high/v3/media_type_test.go
@@ -4,7 +4,7 @@
 package v3
 
 import (
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -18,7 +18,7 @@ import (
 
 func TestMediaType_MarshalYAMLInline(t *testing.T) {
 	// load the petstore spec
-	data, _ := ioutil.ReadFile("../../../test_specs/petstorev3.json")
+	data, _ := os.ReadFile("../../../test_specs/petstorev3.json")
 	info, _ := datamodel.ExtractSpecInfo(data)
 	var err []error
 	lowDoc, err = v3.CreateDocumentFromConfig(info, &datamodel.DocumentConfiguration{})
@@ -108,7 +108,7 @@ example: testing a nice mutation`
 
 func TestMediaType_MarshalYAML(t *testing.T) {
 	// load the petstore spec
-	data, _ := ioutil.ReadFile("../../../test_specs/petstorev3.json")
+	data, _ := os.ReadFile("../../../test_specs/petstorev3.json")
 	info, _ := datamodel.ExtractSpecInfo(data)
 	var err []error
 	lowDoc, err = v3.CreateDocumentFromConfig(info, &datamodel.DocumentConfiguration{})

--- a/datamodel/high/v3/package_test.go
+++ b/datamodel/high/v3/package_test.go
@@ -5,15 +5,16 @@ package v3
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/pb33f/libopenapi/datamodel"
 	lowv3 "github.com/pb33f/libopenapi/datamodel/low/v3"
-	"io/ioutil"
 )
 
 // An example of how to create a new high-level OpenAPI 3+ document from an OpenAPI specification.
 func Example_createHighLevelOpenAPIDocument() {
 	// Load in an OpenAPI 3+ specification as a byte slice.
-	data, _ := ioutil.ReadFile("../../../test_specs/petstorev3.json")
+	data, _ := os.ReadFile("../../../test_specs/petstorev3.json")
 
 	// Create a new *datamodel.SpecInfo from bytes.
 	info, _ := datamodel.ExtractSpecInfo(data)

--- a/datamodel/low/v2/package_test.go
+++ b/datamodel/low/v2/package_test.go
@@ -5,8 +5,9 @@ package v2
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/pb33f/libopenapi/datamodel"
-	"io/ioutil"
 )
 
 // How to create a low-level Swagger / OpenAPI 2 Document from a specification
@@ -15,7 +16,7 @@ func Example_createLowLevelSwaggerDocument() {
 	// How to create a low-level OpenAPI 2 Document
 
 	// load petstore into bytes
-	petstoreBytes, _ := ioutil.ReadFile("../../../test_specs/petstorev2.json")
+	petstoreBytes, _ := os.ReadFile("../../../test_specs/petstorev2.json")
 
 	// read in specification
 	info, _ := datamodel.ExtractSpecInfo(petstoreBytes)
@@ -43,7 +44,7 @@ func ExampleCreateDocument() {
 	// How to create a low-level OpenAPI 2 Document
 
 	// load petstore into bytes
-	petstoreBytes, _ := ioutil.ReadFile("../../../test_specs/petstorev2.json")
+	petstoreBytes, _ := os.ReadFile("../../../test_specs/petstorev2.json")
 
 	// read in specification
 	info, _ := datamodel.ExtractSpecInfo(petstoreBytes)

--- a/datamodel/low/v2/swagger_test.go
+++ b/datamodel/low/v2/swagger_test.go
@@ -5,10 +5,11 @@ package v2
 
 import (
 	"fmt"
+	"os"
+	"testing"
+
 	"github.com/pb33f/libopenapi/datamodel"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
-	"testing"
 )
 
 var doc *Swagger
@@ -17,7 +18,7 @@ func initTest() {
 	if doc != nil {
 		return
 	}
-	data, _ := ioutil.ReadFile("../../../test_specs/petstorev2-complete.yaml")
+	data, _ := os.ReadFile("../../../test_specs/petstorev2-complete.yaml")
 	info, _ := datamodel.ExtractSpecInfo(data)
 	var err []error
 	doc, err = CreateDocumentFromConfig(info, &datamodel.DocumentConfiguration{
@@ -38,7 +39,7 @@ func initTest() {
 }
 
 func BenchmarkCreateDocument(b *testing.B) {
-	data, _ := ioutil.ReadFile("../../../test_specs/petstorev2-complete.yaml")
+	data, _ := os.ReadFile("../../../test_specs/petstorev2-complete.yaml")
 	info, _ := datamodel.ExtractSpecInfo(data)
 	for i := 0; i < b.N; i++ {
 		doc, _ = CreateDocumentFromConfig(info, &datamodel.DocumentConfiguration{
@@ -344,7 +345,7 @@ func TestCreateDocument_InfoBad(t *testing.T) {
 
 func TestCircularReferenceError(t *testing.T) {
 
-	data, _ := ioutil.ReadFile("../../../test_specs/swagger-circular-tests.yaml")
+	data, _ := os.ReadFile("../../../test_specs/swagger-circular-tests.yaml")
 	info, _ := datamodel.ExtractSpecInfo(data)
 	circDoc, err := CreateDocument(info)
 	assert.NotNil(t, circDoc)

--- a/datamodel/low/v3/examples_test.go
+++ b/datamodel/low/v3/examples_test.go
@@ -5,8 +5,9 @@ package v3
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/pb33f/libopenapi/datamodel"
-	"io/ioutil"
 )
 
 // How to create a low-level OpenAPI 3+ Document from an OpenAPI specification
@@ -14,7 +15,7 @@ func Example_createLowLevelOpenAPIDocument() {
 	// How to create a low-level OpenAPI 3 Document
 
 	// load petstore into bytes
-	petstoreBytes, _ := ioutil.ReadFile("../../../test_specs/petstorev3.json")
+	petstoreBytes, _ := os.ReadFile("../../../test_specs/petstorev3.json")
 
 	// read in specification
 	info, _ := datamodel.ExtractSpecInfo(petstoreBytes)

--- a/datamodel/spec_info_test.go
+++ b/datamodel/spec_info_test.go
@@ -5,7 +5,7 @@ package datamodel
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/pb33f/libopenapi/utils"
@@ -290,7 +290,7 @@ func TestExtractSpecInfo_BadVersion_AsyncAPI(t *testing.T) {
 func ExampleExtractSpecInfo() {
 
 	// load bytes from openapi spec file.
-	bytes, _ := ioutil.ReadFile("../test_specs/petstorev3.json")
+	bytes, _ := os.ReadFile("../test_specs/petstorev3.json")
 
 	// create a new *SpecInfo instance from loaded bytes
 	specInfo, err := ExtractSpecInfo(bytes)

--- a/index/spec_index_test.go
+++ b/index/spec_index_test.go
@@ -5,7 +5,6 @@ package index
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/url"
 	"os"
@@ -18,7 +17,7 @@ import (
 )
 
 func TestSpecIndex_ExtractRefsStripe(t *testing.T) {
-	stripe, _ := ioutil.ReadFile("../test_specs/stripe.yaml")
+	stripe, _ := os.ReadFile("../test_specs/stripe.yaml")
 	var rootNode yaml.Node
 	_ = yaml.Unmarshal(stripe, &rootNode)
 
@@ -65,7 +64,7 @@ func TestSpecIndex_ExtractRefsStripe(t *testing.T) {
 }
 
 func TestSpecIndex_Asana(t *testing.T) {
-	asana, _ := ioutil.ReadFile("../test_specs/asana.yaml")
+	asana, _ := os.ReadFile("../test_specs/asana.yaml")
 	var rootNode yaml.Node
 	_ = yaml.Unmarshal(asana, &rootNode)
 
@@ -112,7 +111,7 @@ func TestSpecIndex_DigitalOcean_FullCheckoutLocalResolve(t *testing.T) {
 		log.Fatalf("cmd.Run() failed with %s\n", err)
 	}
 	spec, _ := filepath.Abs(filepath.Join(tmp, "specification", "DigitalOcean-public.v2.yaml"))
-	doLocal, _ := ioutil.ReadFile(spec)
+	doLocal, _ := os.ReadFile(spec)
 	var rootNode yaml.Node
 	_ = yaml.Unmarshal(doLocal, &rootNode)
 
@@ -141,7 +140,7 @@ func TestSpecIndex_DigitalOcean_FullCheckoutLocalResolve(t *testing.T) {
 }
 
 func TestSpecIndex_DigitalOcean_LookupsNotAllowed(t *testing.T) {
-	asana, _ := ioutil.ReadFile("../test_specs/digitalocean.yaml")
+	asana, _ := os.ReadFile("../test_specs/digitalocean.yaml")
 	var rootNode yaml.Node
 	_ = yaml.Unmarshal(asana, &rootNode)
 
@@ -156,7 +155,7 @@ func TestSpecIndex_DigitalOcean_LookupsNotAllowed(t *testing.T) {
 }
 
 func TestSpecIndex_BaseURLError(t *testing.T) {
-	asana, _ := ioutil.ReadFile("../test_specs/digitalocean.yaml")
+	asana, _ := os.ReadFile("../test_specs/digitalocean.yaml")
 	var rootNode yaml.Node
 	_ = yaml.Unmarshal(asana, &rootNode)
 
@@ -173,7 +172,7 @@ func TestSpecIndex_BaseURLError(t *testing.T) {
 }
 
 func TestSpecIndex_k8s(t *testing.T) {
-	asana, _ := ioutil.ReadFile("../test_specs/k8s.json")
+	asana, _ := os.ReadFile("../test_specs/k8s.json")
 	var rootNode yaml.Node
 	_ = yaml.Unmarshal(asana, &rootNode)
 
@@ -198,7 +197,7 @@ func TestSpecIndex_k8s(t *testing.T) {
 }
 
 func TestSpecIndex_PetstoreV2(t *testing.T) {
-	asana, _ := ioutil.ReadFile("../test_specs/petstorev2.json")
+	asana, _ := os.ReadFile("../test_specs/petstorev2.json")
 	var rootNode yaml.Node
 	_ = yaml.Unmarshal(asana, &rootNode)
 
@@ -222,7 +221,7 @@ func TestSpecIndex_PetstoreV2(t *testing.T) {
 }
 
 func TestSpecIndex_XSOAR(t *testing.T) {
-	xsoar, _ := ioutil.ReadFile("../test_specs/xsoar.json")
+	xsoar, _ := os.ReadFile("../test_specs/xsoar.json")
 	var rootNode yaml.Node
 	_ = yaml.Unmarshal(xsoar, &rootNode)
 
@@ -240,7 +239,7 @@ func TestSpecIndex_XSOAR(t *testing.T) {
 }
 
 func TestSpecIndex_PetstoreV3(t *testing.T) {
-	petstore, _ := ioutil.ReadFile("../test_specs/petstorev3.json")
+	petstore, _ := os.ReadFile("../test_specs/petstorev3.json")
 	var rootNode yaml.Node
 	_ = yaml.Unmarshal(petstore, &rootNode)
 
@@ -268,7 +267,7 @@ func TestSpecIndex_PetstoreV3(t *testing.T) {
 var mappedRefs = 15
 
 func TestSpecIndex_BurgerShop(t *testing.T) {
-	burgershop, _ := ioutil.ReadFile("../test_specs/burgershop.openapi.yaml")
+	burgershop, _ := os.ReadFile("../test_specs/burgershop.openapi.yaml")
 	var rootNode yaml.Node
 	_ = yaml.Unmarshal(burgershop, &rootNode)
 
@@ -366,7 +365,7 @@ paths:
 }
 
 func TestSpecIndex_BurgerShop_AllTheComponents(t *testing.T) {
-	burgershop, _ := ioutil.ReadFile("../test_specs/all-the-components.yaml")
+	burgershop, _ := os.ReadFile("../test_specs/all-the-components.yaml")
 	var rootNode yaml.Node
 	_ = yaml.Unmarshal(burgershop, &rootNode)
 
@@ -435,7 +434,7 @@ func TestSpecIndex_NoRoot(t *testing.T) {
 }
 
 func TestSpecIndex_BurgerShopMixedRef(t *testing.T) {
-	spec, _ := ioutil.ReadFile("../test_specs/mixedref-burgershop.openapi.yaml")
+	spec, _ := os.ReadFile("../test_specs/mixedref-burgershop.openapi.yaml")
 	var rootNode yaml.Node
 	_ = yaml.Unmarshal(spec, &rootNode)
 
@@ -463,7 +462,7 @@ func TestSpecIndex_BurgerShopMixedRef(t *testing.T) {
 }
 
 func TestSpecIndex_TestEmptyBrokenReferences(t *testing.T) {
-	asana, _ := ioutil.ReadFile("../test_specs/badref-burgershop.openapi.yaml")
+	asana, _ := os.ReadFile("../test_specs/badref-burgershop.openapi.yaml")
 	var rootNode yaml.Node
 	_ = yaml.Unmarshal(asana, &rootNode)
 
@@ -669,7 +668,7 @@ func TestSpecIndex_lookupFileReference_NoComponent(t *testing.T) {
 	index := new(SpecIndex)
 	index.config = &SpecIndexConfig{BasePath: cwd}
 
-	_ = ioutil.WriteFile("coffee-time.yaml", []byte("time: for coffee"), 0o664)
+	_ = os.WriteFile("coffee-time.yaml", []byte("time: for coffee"), 0o664)
 	defer os.Remove("coffee-time.yaml")
 
 	index.seenRemoteSources = make(map[string]*yaml.Node)
@@ -715,7 +714,7 @@ paths:
 }
 
 func TestSpecIndex_CheckIndexDiscoversNoComponentLocalFileReference(t *testing.T) {
-	_ = ioutil.WriteFile("coffee-time.yaml", []byte("name: time for coffee"), 0o664)
+	_ = os.WriteFile("coffee-time.yaml", []byte("name: time for coffee"), 0o664)
 	defer os.Remove("coffee-time.yaml")
 
 	yml := `openapi: 3.0.3
@@ -765,7 +764,7 @@ func TestSpecIndex_lookupFileReference_BadFile(t *testing.T) {
 }
 
 func TestSpecIndex_lookupFileReference_BadFileDataRead(t *testing.T) {
-	_ = ioutil.WriteFile("chickers.yaml", []byte("broke: the: thing: [again]"), 0o664)
+	_ = os.WriteFile("chickers.yaml", []byte("broke: the: thing: [again]"), 0o664)
 	defer os.Remove("chickers.yaml")
 	var root yaml.Node
 	index := NewSpecIndexWithConfig(&root, CreateOpenAPIIndexConfig())
@@ -774,7 +773,7 @@ func TestSpecIndex_lookupFileReference_BadFileDataRead(t *testing.T) {
 }
 
 func TestSpecIndex_lookupFileReference_MultiRes(t *testing.T) {
-	_ = ioutil.WriteFile("embie.yaml", []byte("naughty:\n - puppy: dog\n - puppy: naughty\npuppy:\n - naughty: puppy"), 0o664)
+	_ = os.WriteFile("embie.yaml", []byte("naughty:\n - puppy: dog\n - puppy: naughty\npuppy:\n - naughty: puppy"), 0o664)
 	defer os.Remove("embie.yaml")
 
 	index := NewSpecIndexWithConfig(nil, CreateOpenAPIIndexConfig())
@@ -786,7 +785,7 @@ func TestSpecIndex_lookupFileReference_MultiRes(t *testing.T) {
 }
 
 func TestSpecIndex_lookupFileReference(t *testing.T) {
-	_ = ioutil.WriteFile("fox.yaml", []byte("good:\n - puppy: dog\n - puppy: forever-more"), 0o664)
+	_ = os.WriteFile("fox.yaml", []byte("good:\n - puppy: dog\n - puppy: forever-more"), 0o664)
 	defer os.Remove("fox.yaml")
 
 	index := NewSpecIndexWithConfig(nil, CreateOpenAPIIndexConfig())
@@ -798,7 +797,7 @@ func TestSpecIndex_lookupFileReference(t *testing.T) {
 }
 
 func TestSpecIndex_parameterReferencesHavePaths(t *testing.T) {
-	_ = ioutil.WriteFile("paramour.yaml", []byte(`components:
+	_ = os.WriteFile("paramour.yaml", []byte(`components:
   parameters:
     param3:
       name: param3

--- a/what-changed/reports/summary_test.go
+++ b/what-changed/reports/summary_test.go
@@ -4,17 +4,18 @@
 package reports
 
 import (
+	"os"
+	"testing"
+
 	"github.com/pb33f/libopenapi"
 	v3 "github.com/pb33f/libopenapi/datamodel/low/v3"
 	"github.com/pb33f/libopenapi/what-changed/model"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
-	"testing"
 )
 
 func createDiff() *model.DocumentChanges {
-	burgerShopOriginal, _ := ioutil.ReadFile("../../test_specs/burgershop.openapi.yaml")
-	burgerShopUpdated, _ := ioutil.ReadFile("../../test_specs/burgershop.openapi-modified.yaml")
+	burgerShopOriginal, _ := os.ReadFile("../../test_specs/burgershop.openapi.yaml")
+	burgerShopUpdated, _ := os.ReadFile("../../test_specs/burgershop.openapi-modified.yaml")
 	originalDoc, _ := libopenapi.NewDocument(burgerShopOriginal)
 	updatedDoc, _ := libopenapi.NewDocument(burgerShopUpdated)
 	documentChanges, _ := libopenapi.CompareDocuments(originalDoc, updatedDoc)

--- a/what-changed/what_changed_test.go
+++ b/what-changed/what_changed_test.go
@@ -5,18 +5,19 @@ package what_changed
 
 import (
 	"fmt"
+	"os"
+	"testing"
+
 	"github.com/pb33f/libopenapi/datamodel"
 	v2 "github.com/pb33f/libopenapi/datamodel/low/v2"
 	v3 "github.com/pb33f/libopenapi/datamodel/low/v3"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
-	"testing"
 )
 
 func TestCompareOpenAPIDocuments(t *testing.T) {
 
-	original, _ := ioutil.ReadFile("../test_specs/burgershop.openapi.yaml")
-	modified, _ := ioutil.ReadFile("../test_specs/burgershop.openapi-modified.yaml")
+	original, _ := os.ReadFile("../test_specs/burgershop.openapi.yaml")
+	modified, _ := os.ReadFile("../test_specs/burgershop.openapi-modified.yaml")
 	infoOrig, _ := datamodel.ExtractSpecInfo(original)
 	infoMod, _ := datamodel.ExtractSpecInfo(modified)
 
@@ -27,13 +28,13 @@ func TestCompareOpenAPIDocuments(t *testing.T) {
 	assert.Equal(t, 75, changes.TotalChanges())
 	assert.Equal(t, 19, changes.TotalBreakingChanges())
 	//out, _ := json.MarshalIndent(changes, "", "  ")
-	//_ = ioutil.WriteFile("outputv3.json", out, 0776)
+	//_ = os.WriteFile("outputv3.json", out, 0776)
 }
 
 func TestCompareSwaggerDocuments(t *testing.T) {
 
-	original, _ := ioutil.ReadFile("../test_specs/petstorev2-complete.yaml")
-	modified, _ := ioutil.ReadFile("../test_specs/petstorev2-complete-modified.yaml")
+	original, _ := os.ReadFile("../test_specs/petstorev2-complete.yaml")
+	modified, _ := os.ReadFile("../test_specs/petstorev2-complete-modified.yaml")
 	infoOrig, _ := datamodel.ExtractSpecInfo(original)
 	infoMod, _ := datamodel.ExtractSpecInfo(modified)
 
@@ -45,14 +46,14 @@ func TestCompareSwaggerDocuments(t *testing.T) {
 	assert.Equal(t, 27, changes.TotalBreakingChanges())
 
 	//out, _ := json.MarshalIndent(changes, "", "  ")
-	//_ = ioutil.WriteFile("output.json", out, 0776)
+	//_ = os.WriteFile("output.json", out, 0776)
 
 }
 
 func Benchmark_CompareOpenAPIDocuments(b *testing.B) {
 
-	original, _ := ioutil.ReadFile("../test_specs/burgershop.openapi.yaml")
-	modified, _ := ioutil.ReadFile("../test_specs/burgershop.openapi-modified.yaml")
+	original, _ := os.ReadFile("../test_specs/burgershop.openapi.yaml")
+	modified, _ := os.ReadFile("../test_specs/burgershop.openapi-modified.yaml")
 
 	infoOrig, _ := datamodel.ExtractSpecInfo(original)
 	infoMod, _ := datamodel.ExtractSpecInfo(modified)
@@ -66,8 +67,8 @@ func Benchmark_CompareOpenAPIDocuments(b *testing.B) {
 
 func Benchmark_CompareSwaggerDocuments(b *testing.B) {
 
-	original, _ := ioutil.ReadFile("../test_specs/petstorev2-complete.yaml")
-	modified, _ := ioutil.ReadFile("../test_specs/petstorev2-complete-modified.yaml")
+	original, _ := os.ReadFile("../test_specs/petstorev2-complete.yaml")
+	modified, _ := os.ReadFile("../test_specs/petstorev2-complete-modified.yaml")
 	infoOrig, _ := datamodel.ExtractSpecInfo(original)
 	infoMod, _ := datamodel.ExtractSpecInfo(modified)
 
@@ -81,8 +82,8 @@ func Benchmark_CompareSwaggerDocuments(b *testing.B) {
 
 func Benchmark_CompareOpenAPIDocuments_NoChange(b *testing.B) {
 
-	original, _ := ioutil.ReadFile("../test_specs/burgershop.openapi.yaml")
-	modified, _ := ioutil.ReadFile("../test_specs/burgershop.openapi.yaml")
+	original, _ := os.ReadFile("../test_specs/burgershop.openapi.yaml")
+	modified, _ := os.ReadFile("../test_specs/burgershop.openapi.yaml")
 
 	infoOrig, _ := datamodel.ExtractSpecInfo(original)
 	infoMod, _ := datamodel.ExtractSpecInfo(modified)
@@ -96,8 +97,8 @@ func Benchmark_CompareOpenAPIDocuments_NoChange(b *testing.B) {
 
 func Benchmark_CompareK8s(b *testing.B) {
 
-	original, _ := ioutil.ReadFile("../test_specs/k8s.json")
-	modified, _ := ioutil.ReadFile("../test_specs/k8s.json")
+	original, _ := os.ReadFile("../test_specs/k8s.json")
+	modified, _ := os.ReadFile("../test_specs/k8s.json")
 
 	infoOrig, _ := datamodel.ExtractSpecInfo(original)
 	infoMod, _ := datamodel.ExtractSpecInfo(modified)
@@ -111,8 +112,8 @@ func Benchmark_CompareK8s(b *testing.B) {
 
 func Benchmark_CompareStripe(b *testing.B) {
 
-	original, _ := ioutil.ReadFile("../test_specs/stripe.yaml")
-	modified, _ := ioutil.ReadFile("../test_specs/stripe.yaml")
+	original, _ := os.ReadFile("../test_specs/stripe.yaml")
+	modified, _ := os.ReadFile("../test_specs/stripe.yaml")
 
 	infoOrig, _ := datamodel.ExtractSpecInfo(original)
 	infoMod, _ := datamodel.ExtractSpecInfo(modified)
@@ -127,10 +128,10 @@ func Benchmark_CompareStripe(b *testing.B) {
 func ExampleCompareOpenAPIDocuments() {
 
 	// Read in a 'left' (original) OpenAPI specification
-	original, _ := ioutil.ReadFile("../test_specs/burgershop.openapi.yaml")
+	original, _ := os.ReadFile("../test_specs/burgershop.openapi.yaml")
 
 	// Read in a 'right' (modified) OpenAPI specification
-	modified, _ := ioutil.ReadFile("../test_specs/burgershop.openapi-modified.yaml")
+	modified, _ := os.ReadFile("../test_specs/burgershop.openapi-modified.yaml")
 
 	// Extract SpecInfo from bytes
 	infoOriginal, _ := datamodel.ExtractSpecInfo(original)


### PR DESCRIPTION
There are no functional changes because ioutil.ReadFile and ioutil.WriteFile simply call os.ReadFile and os.WriteFile respectively.