### PR TITLE
fix!: fixed handling of additionalProperties to handle the bool/json-schema nature better

### DIFF
--- a/datamodel/high/base/schema.go
+++ b/datamodel/high/base/schema.go
@@ -63,7 +63,7 @@ type Schema struct {
 
 	// in 3.1 UnevaluatedProperties can be a Schema or a boolean
 	// https://github.com/pb33f/libopenapi/issues/118
-	UnevaluatedProperties *DynamicValue[*SchemaProxy, *bool] `json:"unevaluatedProperties,omitempty" yaml:"unevaluatedProperties,omitempty"`
+	UnevaluatedProperties *DynamicValue[*SchemaProxy, bool] `json:"unevaluatedProperties,omitempty" yaml:"unevaluatedProperties,omitempty"`
 
 	// in 3.1 Items can be a Schema or a boolean
 	Items *DynamicValue[*SchemaProxy, bool] `json:"items,omitempty" yaml:"items,omitempty"`
@@ -72,35 +72,35 @@ type Schema struct {
 	Anchor string `json:"$anchor,omitempty" yaml:"$anchor,omitempty"`
 
 	// Compatible with all versions
-	Not                  *SchemaProxy            `json:"not,omitempty" yaml:"not,omitempty"`
-	Properties           map[string]*SchemaProxy `json:"properties,omitempty" yaml:"properties,omitempty"`
-	Title                string                  `json:"title,omitempty" yaml:"title,omitempty"`
-	MultipleOf           *float64                `json:"multipleOf,omitempty" yaml:"multipleOf,omitempty"`
-	Maximum              *float64                `json:"maximum,omitempty" yaml:"maximum,omitempty"`
-	Minimum              *float64                `json:"minimum,omitempty" yaml:"minimum,omitempty"`
-	MaxLength            *int64                  `json:"maxLength,omitempty" yaml:"maxLength,omitempty"`
-	MinLength            *int64                  `json:"minLength,omitempty" yaml:"minLength,omitempty"`
-	Pattern              string                  `json:"pattern,omitempty" yaml:"pattern,omitempty"`
-	Format               string                  `json:"format,omitempty" yaml:"format,omitempty"`
-	MaxItems             *int64                  `json:"maxItems,omitempty" yaml:"maxItems,omitempty"`
-	MinItems             *int64                  `json:"minItems,omitempty" yaml:"minItems,omitempty"`
-	UniqueItems          *bool                   `json:"uniqueItems,omitempty" yaml:"uniqueItems,omitempty"`
-	MaxProperties        *int64                  `json:"maxProperties,omitempty" yaml:"maxProperties,omitempty"`
-	MinProperties        *int64                  `json:"minProperties,omitempty" yaml:"minProperties,omitempty"`
-	Required             []string                `json:"required,omitempty" yaml:"required,omitempty"`
-	Enum                 []any                   `json:"enum,omitempty" yaml:"enum,omitempty"`
-	AdditionalProperties any                     `json:"additionalProperties,omitempty" yaml:"additionalProperties,renderZero,omitempty"`
-	Description          string                  `json:"description,omitempty" yaml:"description,omitempty"`
-	Default              any                     `json:"default,omitempty" yaml:"default,renderZero,omitempty"`
-	Const                any                     `json:"const,omitempty" yaml:"const,renderZero,omitempty"`
-	Nullable             *bool                   `json:"nullable,omitempty" yaml:"nullable,omitempty"`
-	ReadOnly             bool                    `json:"readOnly,omitempty" yaml:"readOnly,omitempty"`   // https://github.com/pb33f/libopenapi/issues/30
-	WriteOnly            bool                    `json:"writeOnly,omitempty" yaml:"writeOnly,omitempty"` // https://github.com/pb33f/libopenapi/issues/30
-	XML                  *XML                    `json:"xml,omitempty" yaml:"xml,omitempty"`
-	ExternalDocs         *ExternalDoc            `json:"externalDocs,omitempty" yaml:"externalDocs,omitempty"`
-	Example              any                     `json:"example,omitempty" yaml:"example,omitempty"`
-	Deprecated           *bool                   `json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
-	Extensions           map[string]any          `json:"-" yaml:"-"`
+	Not                  *SchemaProxy                      `json:"not,omitempty" yaml:"not,omitempty"`
+	Properties           map[string]*SchemaProxy           `json:"properties,omitempty" yaml:"properties,omitempty"`
+	Title                string                            `json:"title,omitempty" yaml:"title,omitempty"`
+	MultipleOf           *float64                          `json:"multipleOf,omitempty" yaml:"multipleOf,omitempty"`
+	Maximum              *float64                          `json:"maximum,omitempty" yaml:"maximum,omitempty"`
+	Minimum              *float64                          `json:"minimum,omitempty" yaml:"minimum,omitempty"`
+	MaxLength            *int64                            `json:"maxLength,omitempty" yaml:"maxLength,omitempty"`
+	MinLength            *int64                            `json:"minLength,omitempty" yaml:"minLength,omitempty"`
+	Pattern              string                            `json:"pattern,omitempty" yaml:"pattern,omitempty"`
+	Format               string                            `json:"format,omitempty" yaml:"format,omitempty"`
+	MaxItems             *int64                            `json:"maxItems,omitempty" yaml:"maxItems,omitempty"`
+	MinItems             *int64                            `json:"minItems,omitempty" yaml:"minItems,omitempty"`
+	UniqueItems          *bool                             `json:"uniqueItems,omitempty" yaml:"uniqueItems,omitempty"`
+	MaxProperties        *int64                            `json:"maxProperties,omitempty" yaml:"maxProperties,omitempty"`
+	MinProperties        *int64                            `json:"minProperties,omitempty" yaml:"minProperties,omitempty"`
+	Required             []string                          `json:"required,omitempty" yaml:"required,omitempty"`
+	Enum                 []any                             `json:"enum,omitempty" yaml:"enum,omitempty"`
+	AdditionalProperties *DynamicValue[*SchemaProxy, bool] `json:"additionalProperties,omitempty" yaml:"additionalProperties,renderZero,omitempty"`
+	Description          string                            `json:"description,omitempty" yaml:"description,omitempty"`
+	Default              any                               `json:"default,omitempty" yaml:"default,renderZero,omitempty"`
+	Const                any                               `json:"const,omitempty" yaml:"const,renderZero,omitempty"`
+	Nullable             *bool                             `json:"nullable,omitempty" yaml:"nullable,omitempty"`
+	ReadOnly             bool                              `json:"readOnly,omitempty" yaml:"readOnly,omitempty"`   // https://github.com/pb33f/libopenapi/issues/30
+	WriteOnly            bool                              `json:"writeOnly,omitempty" yaml:"writeOnly,omitempty"` // https://github.com/pb33f/libopenapi/issues/30
+	XML                  *XML                              `json:"xml,omitempty" yaml:"xml,omitempty"`
+	ExternalDocs         *ExternalDoc                      `json:"externalDocs,omitempty" yaml:"externalDocs,omitempty"`
+	Example              any                               `json:"example,omitempty" yaml:"example,omitempty"`
+	Deprecated           *bool                             `json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
+	Extensions           map[string]any                    `json:"-" yaml:"-"`
 	low                  *base.Schema
 
 	// Parent Proxy refers back to the low level SchemaProxy that is proxying this schema.
@@ -211,29 +211,22 @@ func NewSchema(schema *base.Schema) *Schema {
 			Value:     schema.UnevaluatedItems.Value,
 		})
 	}
-	// check if unevaluated properties is a schema
-	if !schema.UnevaluatedProperties.IsEmpty() && schema.UnevaluatedProperties.Value.IsA() {
-		s.UnevaluatedProperties = &DynamicValue[*SchemaProxy, *bool]{
-			A: NewSchemaProxy(
-				&lowmodel.NodeReference[*base.SchemaProxy]{
+
+	var unevaluatedProperties *DynamicValue[*SchemaProxy, bool]
+	if !schema.UnevaluatedProperties.IsEmpty() {
+		if schema.UnevaluatedProperties.Value.IsA() {
+			unevaluatedProperties = &DynamicValue[*SchemaProxy, bool]{
+				A: NewSchemaProxy(&lowmodel.NodeReference[*base.SchemaProxy]{
 					ValueNode: schema.UnevaluatedProperties.ValueNode,
 					Value:     schema.UnevaluatedProperties.Value.A,
-				},
-			),
-			N: 0,
+					KeyNode:   schema.UnevaluatedProperties.KeyNode,
+				}),
+			}
+		} else {
+			unevaluatedProperties = &DynamicValue[*SchemaProxy, bool]{N: 1, B: schema.UnevaluatedProperties.Value.B}
 		}
 	}
-
-	// check if unevaluated properties is a bool
-	if !schema.UnevaluatedProperties.IsEmpty() && schema.UnevaluatedProperties.Value.IsB() {
-		s.UnevaluatedProperties = &DynamicValue[*SchemaProxy, *bool]{
-			B: schema.UnevaluatedProperties.Value.B,
-			N: 1,
-		}
-	}
-
-	if !schema.UnevaluatedProperties.IsEmpty() {
-	}
+	s.UnevaluatedProperties = unevaluatedProperties
 
 	s.Pattern = schema.Pattern.Value
 	s.Format = schema.Format.Value
@@ -248,19 +241,23 @@ func NewSchema(schema *base.Schema) *Schema {
 			s.Type = append(s.Type, schema.Type.Value.B[i].Value)
 		}
 	}
-	if schema.AdditionalProperties.Value != nil {
-		if addPropSchema, ok := schema.AdditionalProperties.Value.(*base.SchemaProxy); ok {
-			s.AdditionalProperties = NewSchemaProxy(&lowmodel.NodeReference[*base.SchemaProxy]{
-				KeyNode:   schema.AdditionalProperties.KeyNode,
-				ValueNode: schema.AdditionalProperties.ValueNode,
-				Value:     addPropSchema,
-			})
-		} else {
-			// TODO: check for slice and map types and unpack correctly.
 
-			s.AdditionalProperties = schema.AdditionalProperties.Value
+	var additionalProperties *DynamicValue[*SchemaProxy, bool]
+	if !schema.AdditionalProperties.IsEmpty() {
+		if schema.AdditionalProperties.Value.IsA() {
+			additionalProperties = &DynamicValue[*SchemaProxy, bool]{
+				A: NewSchemaProxy(&lowmodel.NodeReference[*base.SchemaProxy]{
+					ValueNode: schema.AdditionalProperties.ValueNode,
+					Value:     schema.AdditionalProperties.Value.A,
+					KeyNode:   schema.AdditionalProperties.KeyNode,
+				}),
+			}
+		} else {
+			additionalProperties = &DynamicValue[*SchemaProxy, bool]{N: 1, B: schema.AdditionalProperties.Value.B}
 		}
 	}
+	s.AdditionalProperties = additionalProperties
+
 	s.Description = schema.Description.Value
 	s.Default = schema.Default.Value
 	s.Const = schema.Const.Value
@@ -423,7 +420,8 @@ func NewSchema(schema *base.Schema) *Schema {
 					Value:     schema.Items.Value.A,
 					KeyNode:   schema.Items.KeyNode,
 				},
-				)}
+				),
+			}
 		} else {
 			items = &DynamicValue[*SchemaProxy, bool]{N: 1, B: schema.Items.Value.B}
 		}

--- a/datamodel/high/v3/document_test.go
+++ b/datamodel/high/v3/document_test.go
@@ -220,7 +220,7 @@ func TestNewDocument_Components_Schemas(t *testing.T) {
 
 	d := h.Components.Schemas["Drink"]
 	assert.Len(t, d.Schema().Required, 2)
-	assert.True(t, d.Schema().AdditionalProperties.(bool))
+	assert.True(t, d.Schema().AdditionalProperties.B)
 	assert.Equal(t, "drinkType", d.Schema().Discriminator.PropertyName)
 	assert.Equal(t, "some value", d.Schema().Discriminator.Mapping["drink"])
 	assert.Equal(t, 516, d.Schema().Discriminator.GoLow().PropertyName.ValueNode.Line)
@@ -377,7 +377,6 @@ func testBurgerShop(t *testing.T, h *Document, checkLines bool) {
 		assert.Equal(t, 310, okResp.Links["LocateBurger"].GoLow().OperationId.ValueNode.Line)
 		assert.Equal(t, 118, burgersOp.Post.Security[0].GoLow().Requirements.ValueNode.Line)
 	}
-
 }
 
 func TestStripeAsDoc(t *testing.T) {
@@ -435,7 +434,6 @@ func TestDigitalOceanAsDocFromSHA(t *testing.T) {
 	d := NewDocument(lowDoc)
 	assert.NotNil(t, d)
 	assert.Equal(t, 183, len(d.Paths.PathItems))
-
 }
 
 func TestPetstoreAsDoc(t *testing.T) {
@@ -463,7 +461,6 @@ func TestCircularReferencesDoc(t *testing.T) {
 }
 
 func TestDocument_MarshalYAML(t *testing.T) {
-
 	// create a new document
 	initTest()
 	h := NewDocument(lowDoc)
@@ -477,11 +474,9 @@ func TestDocument_MarshalYAML(t *testing.T) {
 
 	highDoc := NewDocument(lDoc)
 	testBurgerShop(t, highDoc, false)
-
 }
 
 func TestDocument_MarshalIndention(t *testing.T) {
-
 	data, _ := os.ReadFile("../../../test_specs/single-definition.yaml")
 	info, _ := datamodel.ExtractSpecInfo(data)
 
@@ -495,11 +490,9 @@ func TestDocument_MarshalIndention(t *testing.T) {
 	rendered = highDoc.RenderWithIndention(4)
 
 	assert.NotEqual(t, string(data), strings.TrimSpace(string(rendered)))
-
 }
 
 func TestDocument_MarshalIndention_Error(t *testing.T) {
-
 	data, _ := os.ReadFile("../../../test_specs/single-definition.yaml")
 	info, _ := datamodel.ExtractSpecInfo(data)
 
@@ -513,11 +506,9 @@ func TestDocument_MarshalIndention_Error(t *testing.T) {
 	rendered = highDoc.RenderWithIndention(4)
 
 	assert.NotEqual(t, string(data), strings.TrimSpace(string(rendered)))
-
 }
 
 func TestDocument_MarshalJSON(t *testing.T) {
-
 	data, _ := os.ReadFile("../../../test_specs/petstorev3.json")
 	info, _ := datamodel.ExtractSpecInfo(data)
 
@@ -537,7 +528,6 @@ func TestDocument_MarshalJSON(t *testing.T) {
 }
 
 func TestDocument_MarshalYAMLInline(t *testing.T) {
-
 	// create a new document
 	initTest()
 	h := NewDocument(lowDoc)
@@ -551,11 +541,9 @@ func TestDocument_MarshalYAMLInline(t *testing.T) {
 
 	highDoc := NewDocument(lDoc)
 	testBurgerShop(t, highDoc, false)
-
 }
 
 func TestDocument_MarshalYAML_TestRefs(t *testing.T) {
-
 	// create a new document
 	yml := `openapi: 3.1.0
 paths:
@@ -633,7 +621,6 @@ components:
 }
 
 func TestDocument_MarshalYAML_TestParamRefs(t *testing.T) {
-
 	// create a new document
 	yml := `openapi: 3.1.0
 paths:
@@ -686,7 +673,6 @@ components:
 }
 
 func TestDocument_MarshalYAML_TestModifySchemas(t *testing.T) {
-
 	// create a new document
 	yml := `openapi: 3.1.0
 components:

--- a/datamodel/low/base/schema_test.go
+++ b/datamodel/low/base/schema_test.go
@@ -169,7 +169,7 @@ func Test_Schema(t *testing.T) {
 	schErr := sch.Build(rootNode.Content[0], nil)
 	assert.NoError(t, schErr)
 	assert.Equal(t, "something object", sch.Description.Value)
-	assert.True(t, sch.AdditionalProperties.Value.(bool))
+	assert.True(t, sch.AdditionalProperties.Value.B)
 
 	assert.Len(t, sch.Properties.Value, 2)
 	v := sch.FindProperty("somethingB")
@@ -1172,30 +1172,7 @@ func TestExtractSchema_AdditionalPropertiesAsSchema(t *testing.T) {
 
 	res, err := ExtractSchema(idxNode.Content[0], idx)
 
-	assert.NotNil(t, res.Value.Schema().AdditionalProperties.Value.(*SchemaProxy).Schema())
-	assert.Nil(t, err)
-}
-
-func TestExtractSchema_AdditionalPropertiesAsSchemaSlice(t *testing.T) {
-	yml := `components:
-  schemas:
-    Something:
-      additionalProperties:
-        - nice: rice`
-
-	var iNode yaml.Node
-	mErr := yaml.Unmarshal([]byte(yml), &iNode)
-	assert.NoError(t, mErr)
-	idx := index.NewSpecIndex(&iNode)
-
-	yml = `$ref: '#/components/schemas/Something'`
-
-	var idxNode yaml.Node
-	_ = yaml.Unmarshal([]byte(yml), &idxNode)
-
-	res, err := ExtractSchema(idxNode.Content[0], idx)
-
-	assert.NotNil(t, res.Value.Schema().AdditionalProperties.Value.([]low.ValueReference[interface{}]))
+	assert.NotNil(t, res.Value.Schema().AdditionalProperties.Value.A.Schema())
 	assert.Nil(t, err)
 }
 
@@ -1244,7 +1221,7 @@ func TestExtractSchema_AdditionalProperties_Ref(t *testing.T) {
 	_ = yaml.Unmarshal([]byte(yml), &idxNode)
 
 	res, err := ExtractSchema(idxNode.Content[0], idx)
-	assert.NotNil(t, res.Value.Schema().AdditionalProperties.Value.(*SchemaProxy).Schema())
+	assert.NotNil(t, res.Value.Schema().AdditionalProperties.Value.A.Schema())
 	assert.Nil(t, err)
 }
 
@@ -1378,7 +1355,7 @@ func TestSchema_Hash_Equal(t *testing.T) {
   uniqueItems: 1
   maxProperties: 10
   minProperties: 1
-  additionalProperties: anything
+  additionalProperties: true
   description: milky
   contentEncoding: rubber shoes
   contentMediaType: paper tiger
@@ -1420,7 +1397,7 @@ func TestSchema_Hash_Equal(t *testing.T) {
   uniqueItems: 1
   maxProperties: 10
   minProperties: 1
-  additionalProperties: anything
+  additionalProperties: true
   description: milky
   contentEncoding: rubber shoes
   contentMediaType: paper tiger
@@ -1611,7 +1588,7 @@ func TestSchema_UnevaluatedPropertiesAsBool_DefinedAsTrue(t *testing.T) {
 	res, _ := ExtractSchema(idxNode.Content[0], idx)
 
 	assert.True(t, res.Value.Schema().UnevaluatedProperties.Value.IsB())
-	assert.True(t, *res.Value.Schema().UnevaluatedProperties.Value.B)
+	assert.True(t, res.Value.Schema().UnevaluatedProperties.Value.B)
 
 	assert.Equal(t, "571bd1853c22393131e2dcadce86894da714ec14968895c8b7ed18154b2be8cd",
 		low.GenerateHashString(res.Value.Schema().UnevaluatedProperties.Value))
@@ -1636,7 +1613,7 @@ func TestSchema_UnevaluatedPropertiesAsBool_DefinedAsFalse(t *testing.T) {
 	res, _ := ExtractSchema(idxNode.Content[0], idx)
 
 	assert.True(t, res.Value.Schema().UnevaluatedProperties.Value.IsB())
-	assert.False(t, *res.Value.Schema().UnevaluatedProperties.Value.B)
+	assert.False(t, res.Value.Schema().UnevaluatedProperties.Value.B)
 }
 
 func TestSchema_UnevaluatedPropertiesAsBool_Undefined(t *testing.T) {

--- a/datamodel/low/v3/create_document_test.go
+++ b/datamodel/low/v3/create_document_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/pb33f/libopenapi/datamodel"
-	"github.com/pb33f/libopenapi/datamodel/low/base"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -52,7 +51,6 @@ func BenchmarkCreateDocument_Circular(b *testing.B) {
 }
 
 func BenchmarkCreateDocument_k8s(b *testing.B) {
-
 	data, _ := os.ReadFile("../../../test_specs/k8s.json")
 	info, _ := datamodel.ExtractSpecInfo(data)
 
@@ -69,7 +67,6 @@ func BenchmarkCreateDocument_k8s(b *testing.B) {
 }
 
 func TestCircularReferenceError(t *testing.T) {
-
 	data, _ := os.ReadFile("../../../test_specs/circular-tests.yaml")
 	info, _ := datamodel.ExtractSpecInfo(data)
 	circDoc, err := CreateDocumentFromConfig(info, &datamodel.DocumentConfiguration{
@@ -81,7 +78,6 @@ func TestCircularReferenceError(t *testing.T) {
 }
 
 func TestCircularReference_IgnoreArray(t *testing.T) {
-
 	spec := `openapi: 3.1.0
 components:
   schemas:
@@ -110,7 +106,6 @@ components:
 }
 
 func TestCircularReference_IgnorePoly(t *testing.T) {
-
 	spec := `openapi: 3.1.0
 components:
   schemas:
@@ -168,7 +163,6 @@ func BenchmarkCreateDocument_Petstore(b *testing.B) {
 }
 
 func TestCreateDocumentStripe(t *testing.T) {
-
 	data, _ := os.ReadFile("../../../test_specs/stripe.yaml")
 	info, _ := datamodel.ExtractSpecInfo(data)
 	d, err := CreateDocumentFromConfig(info, &datamodel.DocumentConfiguration{
@@ -303,7 +297,6 @@ func TestCreateDocument_Tags(t *testing.T) {
 			// this is why we will need a higher level API to this model, this looks cool and all, but dude.
 			assert.Equal(t, "now?", extension.Value.(map[string]interface{})["ok"].([]interface{})[0].(map[string]interface{})["what"])
 		}
-
 	}
 
 	/// tag2
@@ -313,7 +306,6 @@ func TestCreateDocument_Tags(t *testing.T) {
 	assert.Equal(t, "https://pb33f.io", doc.Tags.Value[1].Value.ExternalDocs.Value.URL.Value)
 	assert.NotEmpty(t, doc.Tags.Value[1].Value.ExternalDocs.Value.URL.Value)
 	assert.Len(t, doc.Tags.Value[1].Value.Extensions, 0)
-
 }
 
 func TestCreateDocument_Paths(t *testing.T) {
@@ -438,7 +430,6 @@ func TestCreateDocument_Paths(t *testing.T) {
 	assert.NotNil(t, servers)
 	assert.Len(t, servers, 1)
 	assert.Equal(t, "https://pb33f.io", servers[0].Value.URL.Value)
-
 }
 
 func TestCreateDocument_Components_Schemas(t *testing.T) {
@@ -464,7 +455,6 @@ func TestCreateDocument_Components_Schemas(t *testing.T) {
 	p := fries.Value.Schema().FindProperty("favoriteDrink")
 	assert.Equal(t, "a frosty cold beverage can be coke or sprite",
 		p.Value.Schema().Description.Value)
-
 }
 
 func TestCreateDocument_Components_SecuritySchemes(t *testing.T) {
@@ -493,7 +483,6 @@ func TestCreateDocument_Components_SecuritySchemes(t *testing.T) {
 	readScope = oAuth.Flows.Value.AuthorizationCode.Value.FindScope("write:burgers")
 	assert.NotNil(t, readScope)
 	assert.Equal(t, "modify burgers and stuff", readScope.Value)
-
 }
 
 func TestCreateDocument_Components_Responses(t *testing.T) {
@@ -506,7 +495,6 @@ func TestCreateDocument_Components_Responses(t *testing.T) {
 	assert.NotNil(t, dressingResponse.Value)
 	assert.Equal(t, "all the dressings for a burger.", dressingResponse.Value.Description.Value)
 	assert.Len(t, dressingResponse.Value.Content.Value, 1)
-
 }
 
 func TestCreateDocument_Components_Examples(t *testing.T) {
@@ -593,7 +581,6 @@ func TestCreateDocument_Component_Discriminator(t *testing.T) {
 	assert.Nil(t, dsc.FindMappingValue("don't exist"))
 	assert.NotNil(t, doc.GetExternalDocs())
 	assert.Nil(t, doc.FindSecurityRequirement("scooby doo"))
-
 }
 
 func TestCreateDocument_CheckAdditionalProperties_Schema(t *testing.T) {
@@ -601,11 +588,8 @@ func TestCreateDocument_CheckAdditionalProperties_Schema(t *testing.T) {
 	components := doc.Components.Value
 	d := components.FindSchema("Dressing")
 	assert.NotNil(t, d.Value.Schema().AdditionalProperties.Value)
-	if n, ok := d.Value.Schema().AdditionalProperties.Value.(*base.SchemaProxy); ok {
-		assert.Equal(t, "something in here.", n.Schema().Description.Value)
-	} else {
-		assert.Fail(t, "should be a schema")
-	}
+
+	assert.True(t, d.Value.Schema().AdditionalProperties.Value.IsA(), "should be a schema")
 }
 
 func TestCreateDocument_CheckAdditionalProperties_Bool(t *testing.T) {
@@ -613,7 +597,7 @@ func TestCreateDocument_CheckAdditionalProperties_Bool(t *testing.T) {
 	components := doc.Components.Value
 	d := components.FindSchema("Drink")
 	assert.NotNil(t, d.Value.Schema().AdditionalProperties.Value)
-	assert.True(t, d.Value.Schema().AdditionalProperties.Value.(bool))
+	assert.True(t, d.Value.Schema().AdditionalProperties.Value.B)
 }
 
 func TestCreateDocument_Components_Error(t *testing.T) {
@@ -667,7 +651,6 @@ components:
 		AllowRemoteReferences: false,
 	})
 	assert.Len(t, err, 1)
-
 }
 
 func TestCreateDocument_Paths_Errors(t *testing.T) {
@@ -776,8 +759,8 @@ func TestCreateDocument_YamlAnchor(t *testing.T) {
 	assert.NotNil(t, jsonGet)
 
 	// Should this work? It doesn't
-	//postJsonType := examplePath.GetValue().Post.GetValue().RequestBody.GetValue().FindContent("application/json")
-	//assert.NotNil(t, postJsonType)
+	// postJsonType := examplePath.GetValue().Post.GetValue().RequestBody.GetValue().FindContent("application/json")
+	// assert.NotNil(t, postJsonType)
 }
 
 func ExampleCreateDocument() {


### PR DESCRIPTION
This PR introduces a fix (via way of a breaking change) to allow a schema in an `additionalProperties` field to be accessed correctly. It also tried to standardise the access of bool/schema properties like `additionalProperties` and `unevaluatedProperties`.

This basically fixes the below schema not being returned as a `SchemaProxy`:

```
type: object
additionalProperties:
  allOf:
    - type: string
    - type: array
      items:
        type: string
```

also incidentally I found a bug that caused an infinite hang and fixed that as part of this