### PR TITLE
Fix lint issues in util

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -564,7 +564,8 @@ func IsHttpVerb(verb string) bool {
 }
 
 // define bracket name expression
-var bracketNameExp = regexp.MustCompile("^(\\w+)\\[(\\w+)\\]$")
+var bracketNameExp = regexp.MustCompile(`^(\w+)\[(\w+)\]$`)
+var pathCharExp = regexp.MustCompile(`[%=;~.]`)
 
 func ConvertComponentIdIntoFriendlyPathSearch(id string) (string, string) {
 	segs := strings.Split(id, "/")
@@ -573,8 +574,7 @@ func ConvertComponentIdIntoFriendlyPathSearch(id string) (string, string) {
 
 	// check for strange spaces, chars and if found, wrap them up, clean them and create a new cleaned path.
 	for i := range segs {
-		pathCharExp, _ := regexp.MatchString("[%=;~.]", segs[i])
-		if pathCharExp {
+		if pathCharExp.Match([]byte(segs[i])) {
 			segs[i], _ = url.QueryUnescape(strings.ReplaceAll(segs[i], "~1", "/"))
 			segs[i] = fmt.Sprintf("['%s']", segs[i])
 			if len(cleaned) > 0 {
@@ -612,11 +612,9 @@ func ConvertComponentIdIntoFriendlyPathSearch(id string) (string, string) {
 	_, err := strconv.ParseInt(name, 10, 32)
 	var replaced string
 	if err != nil {
-		replaced = strings.ReplaceAll(fmt.Sprintf("%s",
-			strings.Join(cleaned, ".")), "#", "$")
+		replaced = strings.ReplaceAll(strings.Join(cleaned, "."), "#", "$")
 	} else {
-		replaced = strings.ReplaceAll(fmt.Sprintf("%s",
-			strings.Join(cleaned, ".")), "#", "$")
+		replaced = strings.ReplaceAll(strings.Join(cleaned, "."), "#", "$")
 	}
 
 	if len(replaced) > 0 {

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,11 +1,12 @@
 package utils
 
 import (
-	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
 	"os"
 	"sync"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
 )
 
 type petstore []byte
@@ -168,8 +169,7 @@ func TestConvertInterfaceToStringArray_NoType(t *testing.T) {
 }
 
 func TestConvertInterfaceToStringArray_Invalid(t *testing.T) {
-	var d interface{}
-	d = "I am a carrot"
+	var d interface{} = "I am a carrot"
 	parsed := ConvertInterfaceToStringArray(d)
 	assert.Nil(t, parsed)
 }
@@ -195,8 +195,7 @@ func TestConvertInterfaceArrayToStringArray_NoType(t *testing.T) {
 }
 
 func TestConvertInterfaceArrayToStringArray_Invalid(t *testing.T) {
-	var d interface{}
-	d = "weed is good"
+	var d interface{} = "weed is good"
 	parsed := ConvertInterfaceArrayToStringArray(d)
 	assert.Nil(t, parsed)
 }
@@ -229,12 +228,11 @@ func TestExtractValueFromInterfaceMap_Flat(t *testing.T) {
 	m["maddy"] = "niblet"
 	d = m
 	parsed := ExtractValueFromInterfaceMap("maddy", d)
-	assert.Equal(t, "niblet", parsed.(interface{}))
+	assert.Equal(t, "niblet", parsed)
 }
 
 func TestExtractValueFromInterfaceMap_NotFound(t *testing.T) {
-	var d interface{}
-	d = "not a map"
+	var d interface{} = "not a map"
 	parsed := ExtractValueFromInterfaceMap("melody", d)
 	assert.Nil(t, parsed)
 }
@@ -684,6 +682,14 @@ func TestConvertComponentIdIntoFriendlyPathSearch_Crazy(t *testing.T) {
 	segment, path := ConvertComponentIdIntoFriendlyPathSearch("#/components/schemas/gpg-key/properties/subkeys/example/0/expires_at")
 	assert.Equal(t, "$.components.schemas.gpg-key.properties.subkeys.example[0].expires_at", path)
 	assert.Equal(t, "expires_at", segment)
+}
+
+func BenchmarkConvertComponentIdIntoFriendlyPathSearch_Crazy(t *testing.B) {
+	for n := 0; n < t.N; n++ {
+		segment, path := ConvertComponentIdIntoFriendlyPathSearch("#/components/schemas/gpg-key/properties/subkeys/example/0/expires_at")
+		assert.Equal(t, "$.components.schemas.gpg-key.properties.subkeys.example[0].expires_at", path)
+		assert.Equal(t, "expires_at", segment)
+	}
 }
 
 func TestConvertComponentIdIntoFriendlyPathSearch_Simple(t *testing.T) {


### PR DESCRIPTION
Also reduce execution time of ConvertComponentIdIntoFriendlyPathSearch by 50-60% and add benchmark

Lint issues fixed:
```
utils/utils.go:567:22: S1007: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (gosimple)
var bracketNameExp = regexp.MustCompile("^(\\w+)\\[(\\w+)\\]$")
                     ^
utils/utils_test.go:232:28: S1040: type assertion to the same type: parsed already has type interface{} (gosimple)
        assert.Equal(t, "niblet", parsed.(interface{}))
                                  ^
utils/utils_test.go:171:2: S1021: should merge variable declaration with assignment on next line (gosimple)
        var d interface{}
        ^
utils/utils_test.go:198:2: S1021: should merge variable declaration with assignment on next line (gosimple)
        var d interface{}
        ^
utils/utils_test.go:236:2: S1021: should merge variable declaration with assignment on next line (gosimple)
        var d interface{}
        ^
utils/utils.go:615:33: S1025: the argument is already a string, there's no need to use fmt.Sprintf (gosimple)
                replaced = strings.ReplaceAll(fmt.Sprintf("%s",
                                              ^
utils/utils.go:618:33: S1025: the argument is already a string, there's no need to use fmt.Sprintf (gosimple)
                replaced = strings.ReplaceAll(fmt.Sprintf("%s",
                                              ^
utils/utils.go:576:21: SA6000: calling regexp.MatchString in a loop has poor performance, consider using regexp.Compile (staticcheck)                pathCharExp, _ := regexp.MatchString("[%=;~.]", segs[i])
                                  ^
```