### PR TITLE
add tests for security schemes prefixed with `x-` and `X-`

### DIFF
--- a/datamodel/high/v3/document_test.go
+++ b/datamodel/high/v3/document_test.go
@@ -275,7 +275,7 @@ func TestNewDocument_Components_Responses(t *testing.T) {
 func TestNewDocument_Components_SecuritySchemes(t *testing.T) {
 	initTest()
 	h := NewDocument(lowDoc)
-	assert.Len(t, h.Components.SecuritySchemes, 3)
+	assert.Len(t, h.Components.SecuritySchemes, 5)
 
 	api := h.Components.SecuritySchemes["APIKeyScheme"]
 	assert.Equal(t, "an apiKey security scheme", api.Description)
@@ -294,6 +294,14 @@ func TestNewDocument_Components_SecuritySchemes(t *testing.T) {
 	assert.Len(t, oAuth.Flows.Implicit.Scopes, 2)
 	assert.Equal(t, "read all burgers", oAuth.Flows.Implicit.Scopes["read:burgers"])
 	assert.Equal(t, "https://pb33f.io/oauth", oAuth.Flows.AuthorizationCode.AuthorizationUrl)
+
+	basic := h.Components.SecuritySchemes["x-basic"]
+	assert.NotNil(t, basic)
+	assert.Equal(t, "a basic security scheme", basic.Description)
+
+	bearer := h.Components.SecuritySchemes["X-Bearer"]
+	assert.NotNil(t, bearer)
+	assert.Equal(t, "a bearer security scheme", bearer.Description)
 
 	// check the lowness is low.
 	assert.Equal(t, 380, oAuth.Flows.GoLow().Implicit.Value.Scopes.KeyNode.Line)

--- a/datamodel/low/v3/create_document_test.go
+++ b/datamodel/low/v3/create_document_test.go
@@ -461,7 +461,7 @@ func TestCreateDocument_Components_SecuritySchemes(t *testing.T) {
 	initTest()
 	components := doc.Components.Value
 	securitySchemes := components.SecuritySchemes.Value
-	assert.Len(t, securitySchemes, 3)
+	assert.Len(t, securitySchemes, 5)
 
 	apiKey := components.FindSecurityScheme("APIKeyScheme").Value
 	assert.NotNil(t, apiKey)
@@ -472,6 +472,14 @@ func TestCreateDocument_Components_SecuritySchemes(t *testing.T) {
 	assert.Equal(t, "an oAuth security scheme", oAuth.Description.Value)
 	assert.NotNil(t, oAuth.Flows.Value.Implicit.Value)
 	assert.NotNil(t, oAuth.Flows.Value.AuthorizationCode.Value)
+
+	basic := components.FindSecurityScheme("x-basic").Value
+	assert.NotNil(t, basic)
+	assert.Equal(t, "a basic security scheme", basic.Description.Value)
+
+	bearer := components.FindSecurityScheme("X-Bearer").Value
+	assert.NotNil(t, bearer)
+	assert.Equal(t, "a bearer security scheme", bearer.Description.Value)
 
 	scopes := oAuth.Flows.Value.Implicit.Value.Scopes.Value
 	assert.NotNil(t, scopes)

--- a/test_specs/burgershop.openapi-modified.yaml
+++ b/test_specs/burgershop.openapi-modified.yaml
@@ -398,6 +398,14 @@ components:
           scopes:
             write:burgers: modify burgers and stuff
             read:burgers: read all the burgers
+    x-basic:
+      description: a basic security scheme
+      type: http
+      scheme: basic
+    X-Bearer:
+      description: a bearer security scheme
+      type: http
+      scheme: bearer
   parameters:
     BurgerHeader:
       in: header

--- a/test_specs/burgershop.openapi.yaml
+++ b/test_specs/burgershop.openapi.yaml
@@ -386,6 +386,14 @@ components:
           scopes:
             write:burgers: modify burgers and stuff
             read:burgers: read all the burgers
+    x-basic:
+      description: a basic security scheme
+      type: http
+      scheme: basic
+    X-Bearer:
+      description: a bearer security scheme
+      type: http
+      scheme: bearer
   parameters:
     BurgerHeader:
       in: header


### PR DESCRIPTION
Creates test cases for #54 . Test case passes for `X-`, but fails for `x-`. Not confident enough to contribute a fix, so any help fixing these test cases would be greatly appreciated.

Hopefully adding this will prevent regressions in the future!