### PR TITLE
v0.13.7

### DIFF
--- a/datamodel/low/v2/swagger.go
+++ b/datamodel/low/v2/swagger.go
@@ -165,10 +165,7 @@ func createDocument(info *datamodel.SpecInfo, config *datamodel.DocumentConfigur
 				IndexConfig:   idxConfig,
 				FileFilters:   config.FileFilter,
 			}
-			fileFS, err := index.NewLocalFSWithConfig(&localFSConf)
-			if err != nil {
-				return nil, err
-			}
+			fileFS, _ := index.NewLocalFSWithConfig(&localFSConf)
 			idxConfig.AllowFileLookup = true
 
 			// add the filesystem to the rolodex

--- a/datamodel/low/v2/swagger.go
+++ b/datamodel/low/v2/swagger.go
@@ -19,7 +19,6 @@ import (
 	"github.com/pb33f/libopenapi/datamodel/low/base"
 	"github.com/pb33f/libopenapi/index"
 	"gopkg.in/yaml.v3"
-	"os"
 	"path/filepath"
 )
 
@@ -163,7 +162,7 @@ func createDocument(info *datamodel.SpecInfo, config *datamodel.DocumentConfigur
 			// create a local filesystem
 			localFSConf := index.LocalFSConfig{
 				BaseDirectory: cwd,
-				DirFS:         os.DirFS(cwd),
+				IndexConfig:   idxConfig,
 				FileFilters:   config.FileFilter,
 			}
 			fileFS, err := index.NewLocalFSWithConfig(&localFSConf)

--- a/datamodel/low/v2/swagger_test.go
+++ b/datamodel/low/v2/swagger_test.go
@@ -406,7 +406,7 @@ func TestRolodexLocalFileSystem_BadPath(t *testing.T) {
 	cf.BasePath = "/NOWHERE"
 	cf.FileFilter = []string{"first.yaml", "second.yaml", "third.yaml"}
 	lDoc, err := CreateDocumentFromConfig(info, cf)
-	assert.Nil(t, lDoc)
+	assert.NotNil(t, lDoc)
 	assert.Error(t, err)
 }
 

--- a/datamodel/low/v3/create_document.go
+++ b/datamodel/low/v3/create_document.go
@@ -64,11 +64,7 @@ func createDocument(info *datamodel.SpecInfo, config *datamodel.DocumentConfigur
 				FileFilters:   config.FileFilter,
 			}
 
-			fileFS, err := index.NewLocalFSWithConfig(&localFSConf)
-			if err != nil {
-				return nil, err
-			}
-
+			fileFS, _ := index.NewLocalFSWithConfig(&localFSConf)
 			idxConfig.AllowFileLookup = true
 
 			// add the filesystem to the rolodex

--- a/datamodel/low/v3/create_document.go
+++ b/datamodel/low/v3/create_document.go
@@ -3,7 +3,6 @@ package v3
 import (
 	"context"
 	"errors"
-	"os"
 	"path/filepath"
 	"sync"
 
@@ -61,7 +60,7 @@ func createDocument(info *datamodel.SpecInfo, config *datamodel.DocumentConfigur
 			// create a local filesystem
 			localFSConf := index.LocalFSConfig{
 				BaseDirectory: cwd,
-				DirFS:         os.DirFS(cwd),
+				IndexConfig:   idxConfig,
 				FileFilters:   config.FileFilter,
 			}
 

--- a/datamodel/low/v3/create_document_test.go
+++ b/datamodel/low/v3/create_document_test.go
@@ -114,7 +114,7 @@ func TestRolodexLocalFileSystem_BadPath(t *testing.T) {
 	cf.BasePath = "/NOWHERE"
 	cf.FileFilter = []string{"first.yaml", "second.yaml", "third.yaml"}
 	lDoc, err := CreateDocumentFromConfig(info, cf)
-	assert.Nil(t, lDoc)
+	assert.NotNil(t, lDoc)
 	assert.Error(t, err)
 }
 

--- a/index/resolver.go
+++ b/index/resolver.go
@@ -732,7 +732,8 @@ func (resolver *Resolver) extractRelatives(ref *Reference, node, parent *yaml.No
 												if strings.HasPrefix(ref.FullDefinition, "#/") {
 													def = fmt.Sprintf("#/%s", exp[1])
 												} else {
-													def = fmt.Sprintf("%s#/%s", ref.FullDefinition, exp[1])
+													fdexp := strings.Split(ref.FullDefinition, "#/")
+													def = fmt.Sprintf("%s#/%s", fdexp[0], exp[1])
 												}
 											}
 										}

--- a/index/rolodex_file_loader.go
+++ b/index/rolodex_file_loader.go
@@ -84,7 +84,7 @@ func (l *LocalFS) Open(name string) (fs.File, error) {
 					idx, idxError := extractedFile.Index(&copiedCfg)
 
 					if idxError != nil && idx == nil {
-						l.readingErrors = append(l.readingErrors, idxError)
+						extractedFile.readingErrors = append(l.readingErrors, idxError)
 					} else {
 
 						// for each index, we need a resolver

--- a/index/search_index.go
+++ b/index/search_index.go
@@ -92,6 +92,7 @@ func (index *SpecIndex) SearchIndexForReferenceByReferenceWithContext(ctx contex
 	if strings.Contains(ref, "%") {
 		// decode the url.
 		ref, _ = url.QueryUnescape(ref)
+		refAlt, _ = url.QueryUnescape(refAlt)
 	}
 
 	if r, ok := index.allMappedRefs[ref]; ok {


### PR DESCRIPTION
The rolodex was indexing the entire basepath down (which is by design) by default. This is undesirable for some use-cases, because all kinds of non-project files are sucked in.

The new behavior indexes files recursively, and only reference files are inspected and indexed as they are discovered.

No breaking changes, no new features.