### PR TITLE
v0.13.12

### DIFF
--- a/datamodel/high/base/schema_proxy.go
+++ b/datamodel/high/base/schema_proxy.go
@@ -4,7 +4,6 @@
 package base
 
 import (
-	"fmt"
 	"github.com/pb33f/libopenapi/datamodel/high"
 	"github.com/pb33f/libopenapi/datamodel/low"
 	"github.com/pb33f/libopenapi/datamodel/low/base"
@@ -122,7 +121,6 @@ func (sp *SchemaProxy) GetReferenceOrigin() *index.NodeOrigin {
 	if sp.schema != nil {
 		return sp.schema.Value.GetSchemaReferenceLocation()
 	}
-	fmt.Print("fuck man")
 	return nil
 }
 

--- a/datamodel/high/base/schema_proxy.go
+++ b/datamodel/high/base/schema_proxy.go
@@ -4,9 +4,11 @@
 package base
 
 import (
+	"fmt"
 	"github.com/pb33f/libopenapi/datamodel/high"
 	"github.com/pb33f/libopenapi/datamodel/low"
 	"github.com/pb33f/libopenapi/datamodel/low/base"
+	"github.com/pb33f/libopenapi/index"
 	"github.com/pb33f/libopenapi/utils"
 	"gopkg.in/yaml.v3"
 	"sync"
@@ -112,6 +114,16 @@ func (sp *SchemaProxy) GetReference() string {
 		return sp.refStr
 	}
 	return sp.schema.Value.GetSchemaReference()
+}
+
+// GetReferenceOrigin returns a pointer to the index.NodeOrigin of the $ref if this SchemaProxy is a reference to another Schema.
+// returns nil if the origin cannot be found (which, means there is a bug, and we need to fix it).
+func (sp *SchemaProxy) GetReferenceOrigin() *index.NodeOrigin {
+	if sp.schema != nil {
+		return sp.schema.Value.GetSchemaReferenceLocation()
+	}
+	fmt.Print("fuck man")
+	return nil
 }
 
 // BuildSchema operates the same way as Schema, except it will return any error along with the *Schema

--- a/datamodel/high/base/schema_proxy_test.go
+++ b/datamodel/high/base/schema_proxy_test.go
@@ -50,6 +50,9 @@ func TestSchemaProxy_MarshalYAML(t *testing.T) {
 
 	sp := NewSchemaProxy(&lowRef)
 
+	origin := sp.GetReferenceOrigin()
+	assert.Nil(t, origin)
+
 	rend, _ := sp.Render()
 	assert.Equal(t, "$ref: '#/components/schemas/nice'", strings.TrimSpace(string(rend)))
 
@@ -65,4 +68,9 @@ func TestCreateSchemaProxyRef(t *testing.T) {
 	sp := CreateSchemaProxyRef("#/components/schemas/MySchema")
 	assert.Equal(t, "#/components/schemas/MySchema", sp.GetReference())
 	assert.True(t, sp.IsReference())
+}
+
+func TestSchemaProxy_NoSchema_GetOrigin(t *testing.T) {
+	sp := &SchemaProxy{}
+	assert.Nil(t, sp.GetReferenceOrigin())
 }

--- a/datamodel/high/v3/document_test.go
+++ b/datamodel/high/v3/document_test.go
@@ -481,7 +481,7 @@ func TestDigitalOceanAsDocFromSHA(t *testing.T) {
 		}
 		config.RemoteURLHandler = func(url string) (*http.Response, error) {
 			request, _ := http.NewRequest(http.MethodGet, url, nil)
-			request.Header.Set("Authorization", fmt.Sprintf("Bearer %s", os.Getenv("GITHUB_TOKEN")))
+			request.Header.Set("Authorization", fmt.Sprintf("Bearer %s", os.Getenv("GH_PAT")))
 			return client.Do(request)
 		}
 	}
@@ -506,7 +506,7 @@ func TestDigitalOceanAsDocFromMain(t *testing.T) {
 	}
 
 	config.Logger = slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
-		Level: slog.LevelDebug,
+		Level: slog.LevelError,
 	}))
 
 	if os.Getenv("GH_PAT") != "" {

--- a/datamodel/high/v3/document_test.go
+++ b/datamodel/high/v3/document_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"
 	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"os"
@@ -445,6 +446,9 @@ func TestDigitalOceanAsDocViaCheckout(t *testing.T) {
 		AllowFileReferences:   true,
 		AllowRemoteReferences: true,
 		BasePath:              basePath,
+		Logger: slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		})),
 	}
 
 	lowDoc, err = lowv3.CreateDocumentFromConfig(info, &config)
@@ -500,6 +504,10 @@ func TestDigitalOceanAsDocFromMain(t *testing.T) {
 		AllowRemoteReferences: true,
 		BaseURL:               baseURL,
 	}
+
+	config.Logger = slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
 
 	if os.Getenv("GH_PAT") != "" {
 		client := &http.Client{

--- a/datamodel/low/base/schema_proxy.go
+++ b/datamodel/low/base/schema_proxy.go
@@ -6,6 +6,7 @@ package base
 import (
 	"context"
 	"crypto/sha256"
+	"fmt"
 
 	"github.com/pb33f/libopenapi/index"
 	"github.com/pb33f/libopenapi/utils"
@@ -130,6 +131,21 @@ func (sp *SchemaProxy) SetReference(ref string) {
 // IsSchemaReference()
 func (sp *SchemaProxy) GetSchemaReference() string {
 	return sp.referenceLookup
+}
+
+func (sp *SchemaProxy) GetSchemaReferenceLocation() *index.NodeOrigin {
+	if sp.idx != nil {
+		origin := sp.idx.FindNodeOrigin(sp.vn)
+		if origin != nil {
+			return origin
+		}
+		if sp.idx.GetRolodex() != nil {
+			origin = sp.idx.GetRolodex().FindNodeOrigin(sp.vn)
+			return origin
+		}
+	}
+	fmt.Println("ooooooh my arse")
+	return nil
 }
 
 // GetKeyNode will return the yaml.Node pointer that is a key for value node.

--- a/datamodel/low/base/schema_proxy.go
+++ b/datamodel/low/base/schema_proxy.go
@@ -6,8 +6,6 @@ package base
 import (
 	"context"
 	"crypto/sha256"
-	"fmt"
-
 	"github.com/pb33f/libopenapi/index"
 	"github.com/pb33f/libopenapi/utils"
 	"gopkg.in/yaml.v3"
@@ -144,7 +142,6 @@ func (sp *SchemaProxy) GetSchemaReferenceLocation() *index.NodeOrigin {
 			return origin
 		}
 	}
-	fmt.Println("ooooooh my arse")
 	return nil
 }
 

--- a/datamodel/low/base/schema_proxy_test.go
+++ b/datamodel/low/base/schema_proxy_test.go
@@ -6,6 +6,7 @@ package base
 import (
 	"context"
 	"github.com/pb33f/libopenapi/datamodel/low"
+	"github.com/pb33f/libopenapi/index"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"
 	"testing"
@@ -94,5 +95,69 @@ x-common-definitions:
 	assert.NoError(t, err)
 	assert.Len(t, sch.Schema().Enum.Value, 3)
 	assert.Equal(t, "The type of life cycle", sch.Schema().Description.Value)
+
+}
+
+func TestSchemaProxy_GetSchemaReferenceLocation(t *testing.T) {
+
+	yml := `type: object
+properties:
+  name:
+    type: string
+    description: thing`
+
+	var idxNodeA yaml.Node
+	e := yaml.Unmarshal([]byte(yml), &idxNodeA)
+	assert.NoError(t, e)
+
+	yml = `
+type: object
+properties:
+  name:
+    type: string
+    description: thang`
+
+	var schA SchemaProxy
+	var schB SchemaProxy
+	var schC SchemaProxy
+	var idxNodeB yaml.Node
+	_ = yaml.Unmarshal([]byte(yml), &idxNodeB)
+
+	c := index.CreateOpenAPIIndexConfig()
+	rolo := index.NewRolodex(c)
+	rolo.SetRootNode(&idxNodeA)
+	_ = rolo.IndexTheRolodex()
+
+	err := schA.Build(context.Background(), nil, idxNodeA.Content[0], rolo.GetRootIndex())
+	assert.NoError(t, err)
+	err = schB.Build(context.Background(), nil, idxNodeB.Content[0].Content[3].Content[1], rolo.GetRootIndex())
+	assert.NoError(t, err)
+
+	rolo.GetRootIndex().SetAbsolutePath("/rooty/rootster")
+	origin := schA.GetSchemaReferenceLocation()
+	assert.NotNil(t, origin)
+	assert.Equal(t, "/rooty/rootster", origin.AbsoluteLocation)
+
+	// mess things up so it cannot be found
+	schA.vn = schB.vn
+	origin = schA.GetSchemaReferenceLocation()
+	assert.Nil(t, origin)
+
+	// create a new index
+	idx := index.NewSpecIndexWithConfig(&idxNodeB, c)
+	idx.SetAbsolutePath("/boaty/mcboatface")
+
+	// add the index to the rolodex
+	rolo.AddIndex(idx)
+
+	// can now find the origin
+	origin = schA.GetSchemaReferenceLocation()
+	assert.NotNil(t, origin)
+	assert.Equal(t, "/boaty/mcboatface", origin.AbsoluteLocation)
+
+	// do it again, but with no index
+	err = schC.Build(context.Background(), nil, idxNodeA.Content[0], nil)
+	origin = schC.GetSchemaReferenceLocation()
+	assert.Nil(t, origin)
 
 }

--- a/datamodel/low/extraction_functions.go
+++ b/datamodel/low/extraction_functions.go
@@ -100,10 +100,12 @@ func LocateRefNodeWithContext(ctx context.Context, root *yaml.Node, idx *index.S
 					if strings.HasPrefix(specPath, "http") {
 						u, _ := url.Parse(specPath)
 						p := ""
-						if u.Path != "" {
+						if u.Path != "" && explodedRefValue[0] != "" {
 							p = filepath.Dir(u.Path)
 						}
-						u.Path = filepath.Join(p, explodedRefValue[0])
+						if p != "" && explodedRefValue[0] != "" {
+							u.Path = filepath.Join(p, explodedRefValue[0])
+						}
 						u.Fragment = ""
 						rv = fmt.Sprintf("%s#%s", u.String(), explodedRefValue[1])
 

--- a/datamodel/low/extraction_functions_test.go
+++ b/datamodel/low/extraction_functions_test.go
@@ -1724,12 +1724,38 @@ func TestLocateRefNode_CurrentPathKey_HttpLink(t *testing.T) {
 			},
 			{
 				Kind:  yaml.ScalarNode,
-				Value: "http://cakes.com#/components/schemas/thing",
+				Value: "http://cakes.com/nice#/components/schemas/thing",
 			},
 		},
 	}
 
 	ctx := context.WithValue(context.Background(), index.CurrentPathKey, "http://cakes.com#/components/schemas/thing")
+
+	idx := index.NewSpecIndexWithConfig(&no, index.CreateClosedAPIIndexConfig())
+	n, i, e, c := LocateRefNodeWithContext(ctx, &no, idx)
+	assert.Nil(t, n)
+	assert.NotNil(t, i)
+	assert.NotNil(t, e)
+	assert.NotNil(t, c)
+}
+
+func TestLocateRefNode_CurrentPathKey_HttpLink_Local(t *testing.T) {
+
+	no := yaml.Node{
+		Kind: yaml.MappingNode,
+		Content: []*yaml.Node{
+			{
+				Kind:  yaml.ScalarNode,
+				Value: "$ref",
+			},
+			{
+				Kind:  yaml.ScalarNode,
+				Value: ".#/components/schemas/thing",
+			},
+		},
+	}
+
+	ctx := context.WithValue(context.Background(), index.CurrentPathKey, "http://cakes.com/nice/rice#/components/schemas/thing")
 
 	idx := index.NewSpecIndexWithConfig(&no, index.CreateClosedAPIIndexConfig())
 	n, i, e, c := LocateRefNodeWithContext(ctx, &no, idx)

--- a/datamodel/low/v3/create_document_test.go
+++ b/datamodel/low/v3/create_document_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/pb33f/libopenapi/index"
 	"github.com/pb33f/libopenapi/utils"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"os"
@@ -123,6 +124,9 @@ func TestRolodexRemoteFileSystem(t *testing.T) {
 	info, _ := datamodel.ExtractSpecInfo(data)
 
 	cf := datamodel.NewDocumentConfiguration()
+	cf.Logger = slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
 
 	baseUrl := "https://raw.githubusercontent.com/pb33f/libopenapi/main/test_specs"
 	u, _ := url.Parse(baseUrl)

--- a/index/index_model.go
+++ b/index/index_model.go
@@ -296,6 +296,16 @@ func (index *SpecIndex) GetCache() *syncmap.Map {
 	return index.cache
 }
 
+// SetAbsolutePath sets the absolute path to the spec file for the index. Will be absolute, either as a http link or a file.
+func (index *SpecIndex) SetAbsolutePath(absolutePath string) {
+	index.specAbsolutePath = absolutePath
+}
+
+// GetAbsolutePath returns the absolute path to the spec file for the index. Will be absolute, either as a http link or a file.
+func (index *SpecIndex) GetAbsolutePath() string {
+	return index.specAbsolutePath
+}
+
 // ExternalLookupFunction is for lookup functions that take a JSONSchema reference and tries to find that node in the
 // URI based document. Decides if the reference is local, remote or in a file.
 type ExternalLookupFunction func(id string) (foundNode *yaml.Node, rootNode *yaml.Node, lookupError error)

--- a/index/index_model.go
+++ b/index/index_model.go
@@ -274,6 +274,8 @@ type SpecIndex struct {
 	built                               bool
 	uri                                 []string
 	logger                              *slog.Logger
+	nodeMap                             map[int]map[int]*yaml.Node
+	nodeMapCompleted                    chan bool
 }
 
 // GetResolver returns the resolver for this index.

--- a/index/index_model.go
+++ b/index/index_model.go
@@ -301,8 +301,8 @@ func (index *SpecIndex) SetAbsolutePath(absolutePath string) {
 	index.specAbsolutePath = absolutePath
 }
 
-// GetAbsolutePath returns the absolute path to the spec file for the index. Will be absolute, either as a http link or a file.
-func (index *SpecIndex) GetAbsolutePath() string {
+// GetSpecAbsolutePath returns the absolute path to the spec file for the index. Will be absolute, either as a http link or a file.
+func (index *SpecIndex) GetSpecAbsolutePath() string {
 	return index.specAbsolutePath
 }
 

--- a/index/map_index_nodes.go
+++ b/index/map_index_nodes.go
@@ -78,13 +78,7 @@ func (index *SpecIndex) FindNodeOrigin(node *yaml.Node) *NodeOrigin {
 			if index.nodeMap[node.Line][node.Column] != nil {
 				foundNode := index.nodeMap[node.Line][node.Column]
 				match := true
-				if foundNode.Value != node.Value {
-					match = false
-				}
-				if foundNode.Kind != node.Kind {
-					match = false
-				}
-				if foundNode.Tag != node.Tag {
+				if foundNode.Value != node.Value || foundNode.Kind != node.Kind || foundNode.Tag != node.Tag {
 					match = false
 				}
 				if len(foundNode.Content) == len(node.Content) {

--- a/index/map_index_nodes.go
+++ b/index/map_index_nodes.go
@@ -1,0 +1,131 @@
+// Copyright 2023 Princess B33f Heavy Industries / Dave Shanley
+// SPDX-License-Identifier: MIT
+
+package index
+
+import (
+	"gopkg.in/yaml.v3"
+)
+
+type nodeMap struct {
+	line   int
+	column int
+	node   *yaml.Node
+}
+
+// NodeOrigin represents where a node has come from within a specification. This is not useful for single file specs,
+// but becomes very, very important when dealing with exploded specifications, and we need to know where in the mass
+// of files a node has come from.
+type NodeOrigin struct {
+	// Node is the node in question
+	Node *yaml.Node
+
+	// Line is yhe original line of where the node was found in the original file
+	Line int
+
+	// Column is the original column of where the node was found in the original file
+	Column int
+
+	// AbsoluteLocation is the absolute path to the reference was extracted from.
+	// This can either be an absolute path to a file, or a URL.
+	AbsoluteLocation string
+
+	// Index is the index that contains the node that was located in.
+	Index *SpecIndex
+}
+
+// GetNode returns a node from the spec based on a line and column. The second return var bool is true
+// if the node was found, false if not.
+func (index *SpecIndex) GetNode(line int, column int) (*yaml.Node, bool) {
+	if index.nodeMap[line] == nil {
+		return nil, false
+	}
+	node := index.nodeMap[line][column]
+	return node, node != nil
+}
+
+// MapNodes maps all nodes in the document to a map of line/column to node.
+func (index *SpecIndex) MapNodes(rootNode *yaml.Node) {
+	cruising := make(chan bool)
+	nodeChan := make(chan *nodeMap)
+	go func(nodeChan chan *nodeMap) {
+		for {
+			select {
+			case node, ok := <-nodeChan:
+				if !ok {
+					cruising <- true
+					return
+				}
+				if index.nodeMap[node.line] == nil {
+					index.nodeMap[node.line] = make(map[int]*yaml.Node)
+				}
+				index.nodeMap[node.line][node.column] = node.node
+			}
+		}
+	}(nodeChan)
+	go enjoyALuxuryCruise(rootNode, nodeChan, true)
+	<-cruising
+	close(cruising)
+	index.nodeMapCompleted <- true
+	close(index.nodeMapCompleted)
+}
+
+func (index *SpecIndex) FindNodeOrigin(node *yaml.Node) *NodeOrigin {
+
+	// local search, then throw up to rolodex for a full search
+	if node != nil {
+		if index.nodeMap[node.Line] != nil {
+			if index.nodeMap[node.Line][node.Column] != nil {
+				foundNode := index.nodeMap[node.Line][node.Column]
+				match := true
+				if foundNode.Value != node.Value {
+					match = false
+				}
+				if foundNode.Kind != node.Kind {
+					match = false
+				}
+				if foundNode.Tag != node.Tag {
+					match = false
+				}
+				if len(foundNode.Content) == len(node.Content) {
+					for i := range foundNode.Content {
+						if foundNode.Content[i].Value != node.Content[i].Value {
+							match = false
+						}
+					}
+				}
+				if match {
+					return &NodeOrigin{
+						Node:             foundNode,
+						Line:             node.Line,
+						Column:           node.Column,
+						AbsoluteLocation: index.specAbsolutePath,
+						Index:            index,
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func enjoyALuxuryCruise(node *yaml.Node, nodeChan chan *nodeMap, root bool) {
+	if len(node.Content) > 0 {
+		for _, child := range node.Content {
+			nodeChan <- &nodeMap{
+				line:   child.Line,
+				column: child.Column,
+				node:   child,
+			}
+			enjoyALuxuryCruise(child, nodeChan, false)
+		}
+	}
+	nodeChan <- &nodeMap{
+		line:   node.Line,
+		column: node.Column,
+		node:   node,
+	}
+	if root {
+		close(nodeChan)
+	}
+}

--- a/index/map_index_nodes.go
+++ b/index/map_index_nodes.go
@@ -70,13 +70,16 @@ func (index *SpecIndex) MapNodes(rootNode *yaml.Node) {
 	close(index.nodeMapCompleted)
 }
 
+// FindNodeOrigin searches this index for a matching node. If the node is found, a NodeOrigin
+// is returned, otherwise nil is returned.
 func (index *SpecIndex) FindNodeOrigin(node *yaml.Node) *NodeOrigin {
-
-	// local search, then throw up to rolodex for a full search
 	if node != nil {
 		if index.nodeMap[node.Line] != nil {
 			if index.nodeMap[node.Line][node.Column] != nil {
 				foundNode := index.nodeMap[node.Line][node.Column]
+				if foundNode.Kind == yaml.DocumentNode {
+					foundNode = foundNode.Content[0]
+				}
 				match := true
 				if foundNode.Value != node.Value || foundNode.Kind != node.Kind || foundNode.Tag != node.Tag {
 					match = false

--- a/index/map_index_nodes.go
+++ b/index/map_index_nodes.go
@@ -18,20 +18,20 @@ type nodeMap struct {
 // of files a node has come from.
 type NodeOrigin struct {
 	// Node is the node in question
-	Node *yaml.Node
+	Node *yaml.Node `json:"-"`
 
 	// Line is yhe original line of where the node was found in the original file
-	Line int
+	Line int `json:"line" yaml:"line"`
 
 	// Column is the original column of where the node was found in the original file
-	Column int
+	Column int `json:"column" yaml:"column"`
 
 	// AbsoluteLocation is the absolute path to the reference was extracted from.
 	// This can either be an absolute path to a file, or a URL.
-	AbsoluteLocation string
+	AbsoluteLocation string `json:"absolute_location" yaml:"absolute_location"`
 
 	// Index is the index that contains the node that was located in.
-	Index *SpecIndex
+	Index *SpecIndex `json:"-" yaml:"-"`
 }
 
 // GetNode returns a node from the spec based on a line and column. The second return var bool is true
@@ -68,42 +68,6 @@ func (index *SpecIndex) MapNodes(rootNode *yaml.Node) {
 	close(cruising)
 	index.nodeMapCompleted <- true
 	close(index.nodeMapCompleted)
-}
-
-// FindNodeOrigin searches this index for a matching node. If the node is found, a NodeOrigin
-// is returned, otherwise nil is returned.
-func (index *SpecIndex) FindNodeOrigin(node *yaml.Node) *NodeOrigin {
-	if node != nil {
-		if index.nodeMap[node.Line] != nil {
-			if index.nodeMap[node.Line][node.Column] != nil {
-				foundNode := index.nodeMap[node.Line][node.Column]
-				if foundNode.Kind == yaml.DocumentNode {
-					foundNode = foundNode.Content[0]
-				}
-				match := true
-				if foundNode.Value != node.Value || foundNode.Kind != node.Kind || foundNode.Tag != node.Tag {
-					match = false
-				}
-				if len(foundNode.Content) == len(node.Content) {
-					for i := range foundNode.Content {
-						if foundNode.Content[i].Value != node.Content[i].Value {
-							match = false
-						}
-					}
-				}
-				if match {
-					return &NodeOrigin{
-						Node:             foundNode,
-						Line:             node.Line,
-						Column:           node.Column,
-						AbsoluteLocation: index.specAbsolutePath,
-						Index:            index,
-					}
-				}
-			}
-		}
-	}
-	return nil
 }
 
 func enjoyALuxuryCruise(node *yaml.Node, nodeChan chan *nodeMap, root bool) {

--- a/index/map_index_nodes_test.go
+++ b/index/map_index_nodes_test.go
@@ -1,0 +1,87 @@
+// Copyright 2023 Princess B33f Heavy Industries / Dave Shanley
+// SPDX-License-Identifier: MIT
+
+package index
+
+import (
+	"github.com/pb33f/libopenapi/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/vmware-labs/yaml-jsonpath/pkg/yamlpath"
+	"gopkg.in/yaml.v3"
+	"os"
+	"reflect"
+	"testing"
+)
+
+func TestSpecIndex_MapNodes(t *testing.T) {
+
+	petstore, _ := os.ReadFile("../test_specs/petstorev3.json")
+	var rootNode yaml.Node
+	_ = yaml.Unmarshal(petstore, &rootNode)
+
+	index := NewSpecIndexWithConfig(&rootNode, CreateOpenAPIIndexConfig())
+
+	<-index.nodeMapCompleted
+
+	// look up a node and make sure they match exactly (same pointer)
+	path, _ := yamlpath.NewPath("$.paths./pet.put")
+	nodes, _ := path.Find(&rootNode)
+
+	keyNode, valueNode := utils.FindKeyNodeTop("operationId", nodes[0].Content)
+	mappedKeyNode, _ := index.GetNode(keyNode.Line, keyNode.Column)
+	mappedValueNode, _ := index.GetNode(valueNode.Line, valueNode.Column)
+
+	assert.Equal(t, keyNode, mappedKeyNode)
+	assert.Equal(t, valueNode, mappedValueNode)
+
+	// make sure the pointers are the same
+	p1 := reflect.ValueOf(keyNode).Pointer()
+	p2 := reflect.ValueOf(mappedKeyNode).Pointer()
+	assert.Equal(t, p1, p2)
+
+	// check missing line
+	var ok bool
+	mappedKeyNode, ok = index.GetNode(999, 999)
+	assert.False(t, ok)
+	assert.Nil(t, mappedKeyNode)
+
+	mappedKeyNode, ok = index.GetNode(12, 999)
+	assert.False(t, ok)
+	assert.Nil(t, mappedKeyNode)
+
+	index.nodeMap[15] = nil
+	mappedKeyNode, ok = index.GetNode(15, 999)
+	assert.False(t, ok)
+	assert.Nil(t, mappedKeyNode)
+
+}
+
+func BenchmarkSpecIndex_MapNodes(b *testing.B) {
+
+	petstore, _ := os.ReadFile("../test_specs/petstorev3.json")
+	var rootNode yaml.Node
+	_ = yaml.Unmarshal(petstore, &rootNode)
+	path, _ := yamlpath.NewPath("$.paths./pet.put")
+
+	for i := 0; i < b.N; i++ {
+
+		index := NewSpecIndexWithConfig(&rootNode, CreateOpenAPIIndexConfig())
+
+		<-index.nodeMapCompleted
+
+		// look up a node and make sure they match exactly (same pointer)
+		nodes, _ := path.Find(&rootNode)
+
+		keyNode, valueNode := utils.FindKeyNodeTop("operationId", nodes[0].Content)
+		mappedKeyNode, _ := index.GetNode(keyNode.Line, keyNode.Column)
+		mappedValueNode, _ := index.GetNode(valueNode.Line, valueNode.Column)
+
+		assert.Equal(b, keyNode, mappedKeyNode)
+		assert.Equal(b, valueNode, mappedValueNode)
+
+		// make sure the pointers are the same
+		p1 := reflect.ValueOf(keyNode).Pointer()
+		p2 := reflect.ValueOf(mappedKeyNode).Pointer()
+		assert.Equal(b, p1, p2)
+	}
+}

--- a/index/map_index_nodes_test.go
+++ b/index/map_index_nodes_test.go
@@ -53,7 +53,6 @@ func TestSpecIndex_MapNodes(t *testing.T) {
 	mappedKeyNode, ok = index.GetNode(15, 999)
 	assert.False(t, ok)
 	assert.Nil(t, mappedKeyNode)
-
 }
 
 func BenchmarkSpecIndex_MapNodes(b *testing.B) {

--- a/index/rolodex_file_loader_test.go
+++ b/index/rolodex_file_loader_test.go
@@ -8,6 +8,7 @@ import (
 	"gopkg.in/yaml.v3"
 	"io"
 	"io/fs"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"testing"
@@ -25,7 +26,14 @@ func TestRolodexLoadsFilesCorrectly_NoErrors(t *testing.T) {
 		"subfolder2/hello.jpg":  {Data: []byte("shop"), ModTime: time.Now()},
 	}
 
-	fileFS, err := NewLocalFS(".", testFS)
+	fileFS, err := NewLocalFSWithConfig(&LocalFSConfig{
+		BaseDirectory: ".",
+		Logger: slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		})),
+		DirFS: testFS,
+	})
+
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -150,7 +158,14 @@ func TestRolodexLocalFile_IndexSingleFile(t *testing.T) {
 		"i-am-a-dir": {Mode: fs.FileMode(fs.ModeDir), ModTime: time.Now()},
 	}
 
-	fileFS, _ := NewLocalFS("spec.yaml", testFS)
+	fileFS, _ := NewLocalFSWithConfig(&LocalFSConfig{
+		BaseDirectory: "spec.yaml",
+		Logger: slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		})),
+		DirFS: testFS,
+	})
+
 	files := fileFS.GetFiles()
 	assert.Len(t, files, 1)
 

--- a/index/rolodex_remote_loader.go
+++ b/index/rolodex_remote_loader.go
@@ -294,8 +294,8 @@ func (i *RemoteFS) Open(remoteURL string) (fs.File, error) {
 
 		i.logger.Debug("waiting for existing fetch to complete", "file", remoteURL,
 			"remoteURL", remoteParsedURL.String())
-		// Create a context with a timeout of 100 milliseconds.
-		ctxTimeout, cancel := context.WithTimeout(context.Background(), time.Millisecond*100)
+		// Create a context with a timeout of 120 milliseconds.
+		ctxTimeout, cancel := context.WithTimeout(context.Background(), time.Millisecond*120)
 		defer cancel()
 		f := make(chan *RemoteFile)
 		fwait := func(path string, c chan *RemoteFile) {
@@ -312,6 +312,7 @@ func (i *RemoteFS) Open(remoteURL string) (fs.File, error) {
 			i.logger.Info("waiting for remote file timed out, trying again", "file", remoteURL,
 				"remoteURL", remoteParsedURL.String())
 		case v := <-f:
+			close(f)
 			return v, nil
 		}
 	}

--- a/index/rolodex_remote_loader.go
+++ b/index/rolodex_remote_loader.go
@@ -312,7 +312,7 @@ func (i *RemoteFS) Open(remoteURL string) (fs.File, error) {
 			i.logger.Info("waiting for remote file timed out, trying again", "file", remoteURL,
 				"remoteURL", remoteParsedURL.String())
 		case v := <-f:
-			close(f)
+			//close(f)
 			return v, nil
 		}
 	}

--- a/index/rolodex_test.go
+++ b/index/rolodex_test.go
@@ -1366,6 +1366,9 @@ func TestRolodex_SimpleTest_OneDoc(t *testing.T) {
 	assert.Equal(t, fs.FileMode(0), f.Mode())
 	assert.Len(t, f.GetErrors(), 0)
 
+	// check the index has a rolodex reference
+	assert.NotNil(t, idx.GetRolodex())
+
 	// re-run the index should be a no-op
 	assert.NoError(t, rolo.IndexTheRolodex())
 	rolo.CheckForCircularReferences()

--- a/index/rolodex_test.go
+++ b/index/rolodex_test.go
@@ -8,6 +8,7 @@ import (
 	"gopkg.in/yaml.v3"
 	"io"
 	"io/fs"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -53,7 +54,13 @@ func TestRolodex_LocalNativeFS(t *testing.T) {
 
 	baseDir := "/tmp"
 
-	fileFS, err := NewLocalFS(baseDir, testFS)
+	fileFS, err := NewLocalFSWithConfig(&LocalFSConfig{
+		BaseDirectory: baseDir,
+		Logger: slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		})),
+		DirFS: testFS,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1313,7 +1320,14 @@ func TestRolodex_SimpleTest_OneDoc(t *testing.T) {
 
 	baseDir := "rolodex_test_data"
 
-	fileFS, err := NewLocalFS(baseDir, os.DirFS(baseDir))
+	fileFS, err := NewLocalFSWithConfig(&LocalFSConfig{
+		BaseDirectory: baseDir,
+		Logger: slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		})),
+		DirFS: os.DirFS(baseDir),
+	})
+
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/index/rolodex_test_data/dir1/utils/utils.yaml
+++ b/index/rolodex_test_data/dir1/utils/utils.yaml
@@ -2,10 +2,8 @@ type: object
 description: I am a utility for dir1
 properties:
   message:
-    type: string
+    type: object
     description: I am pointless dir1.
     properties:
-      link:
-        $ref: "../components.yaml#/components/schemas/GlobalComponent"
       shared:
         $ref: '../subdir1/shared.yaml#/components/schemas/SharedComponent'

--- a/index/rolodex_test_data/dir2/components.yaml
+++ b/index/rolodex_test_data/dir2/components.yaml
@@ -11,5 +11,11 @@ components:
         message:
           type: string
           description: I am pointless, but I am global dir2.
+    AnotherComponent:
+      type: object
+      description: Dir2 Another Component
+      properties:
+        message:
+          $ref: "subdir2/shared.yaml#/components/schemas/SharedComponent"
     SomeUtil:
       $ref: "utils/utils.yaml"

--- a/index/rolodex_test_data/dir2/subdir2/shared.yaml
+++ b/index/rolodex_test_data/dir2/subdir2/shared.yaml
@@ -8,8 +8,8 @@ components:
       type: object
       description: Dir2 Shared Component
       properties:
+        utilMessage:
+            $ref: "../utils/utils.yaml"
         message:
           type: string
           description: I am pointless, but I am shared dir2.
-    SomeUtil:
-      $ref: "../utils/utils.yaml"

--- a/index/rolodex_test_data/dir2/utils/utils.yaml
+++ b/index/rolodex_test_data/dir2/utils/utils.yaml
@@ -2,10 +2,5 @@ type: object
 description: I am a utility for dir2
 properties:
   message:
-    type: string
-    description: I am pointless dir2.
-    properties:
-      link:
-        $ref: "../components.yaml#/components/schemas/GlobalComponent"
-      shared:
-        $ref: '../subdir2/shared.yaml#/components/schemas/SharedComponent'
+    type: object
+    description: I am pointless dir2 utility, I am multiple levels deep.

--- a/index/rolodex_test_data/doc2.yaml
+++ b/index/rolodex_test_data/doc2.yaml
@@ -3,7 +3,43 @@ info:
   title: Rolodex Test Data
   version: 1.0.0
 paths:
-  /one/local:
+#  /one/local:
+#    get:
+#      responses:
+#        '200':
+#          description: OK
+#          content:
+#            application/json:
+#              schema:
+#                $ref: '#/components/schemas/Thing'
+#  /one/file:
+#    get:
+#      responses:
+#        '200':
+#          description: OK
+#          content:
+#            application/json:
+#              schema:
+#                $ref: 'components.yaml#/components/schemas/Ding'
+#  /nested/files1:
+#    get:
+#      responses:
+#        '200':
+#          description: OK
+#          content:
+#            application/json:
+#              schema:
+#                $ref: 'dir1/components.yaml#/components/schemas/GlobalComponent'
+#  /nested/files2:
+#    get:
+#      responses:
+#        '200':
+#          description: OK
+#          content:
+#            application/json:
+#              schema:
+#                $ref: 'dir2/components.yaml#/components/schemas/GlobalComponent'
+  /nested/files3:
     get:
       responses:
         '200':
@@ -11,34 +47,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Thing'
-  /one/file:
-    get:
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: 'components.yaml#/components/schemas/Ding'
-  /nested/files1:
-    get:
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: 'dir1/components.yaml#/components/schemas/GlobalComponent'
-  /nested/files2:
-    get:
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: 'dir2/components.yaml#/components/schemas/GlobalComponent'
+                $ref: 'dir2/components.yaml#/components/schemas/AnotherComponent'
 components:
   schemas:
     Thing:

--- a/index/search_rolodex.go
+++ b/index/search_rolodex.go
@@ -1,0 +1,54 @@
+// Copyright 2023 Princess B33f Heavy Industries / Dave Shanley
+// SPDX-License-Identifier: MIT
+
+package index
+
+import (
+	"fmt"
+	"gopkg.in/yaml.v3"
+)
+
+func (r *Rolodex) FindNodeOrigin(node *yaml.Node) *NodeOrigin {
+	//f := make(chan *NodeOrigin)
+	//d := make(chan bool)
+	//findNode := func(i int, node *yaml.Node) {
+	//	n := r.indexes[i].FindNodeOrigin(node)
+	//	if n != nil {
+	//		f <- n
+	//		return
+	//	}
+	//	d <- true
+	//}
+	//for i, _ := range r.indexes {
+	//	go findNode(i, node)
+	//}
+	//searched := 0
+	//for searched < len(r.indexes) {
+	//	select {
+	//	case n := <-f:
+	//		return n
+	//	case <-d:
+	//		searched++
+	//	}
+	//}
+	//return nil
+
+	if len(r.indexes) == 0 {
+		fmt.Println("NO FUCKING WAY MAN")
+	} else {
+		//fmt.Printf("searching %d files\n", len(r.indexes))
+	}
+	for i := range r.indexes {
+		n := r.indexes[i].FindNodeOrigin(node)
+		if n != nil {
+			return n
+		}
+	}
+	//	if n != nil {
+	//		f <- n
+	//		return
+	//	}
+	fmt.Println("my FUCKING ARSE")
+	return nil
+
+}

--- a/index/search_rolodex.go
+++ b/index/search_rolodex.go
@@ -32,5 +32,41 @@ func (r *Rolodex) FindNodeOrigin(node *yaml.Node) *NodeOrigin {
 			searched++
 		}
 	}
+	return r.GetRootIndex().FindNodeOrigin(node)
+}
+
+// FindNodeOrigin searches this index for a matching node. If the node is found, a NodeOrigin
+// is returned, otherwise nil is returned.
+func (index *SpecIndex) FindNodeOrigin(node *yaml.Node) *NodeOrigin {
+	if node != nil {
+		if index.nodeMap[node.Line] != nil {
+			if index.nodeMap[node.Line][node.Column] != nil {
+				foundNode := index.nodeMap[node.Line][node.Column]
+				if foundNode.Kind == yaml.DocumentNode {
+					foundNode = foundNode.Content[0]
+				}
+				match := true
+				if foundNode.Value != node.Value || foundNode.Kind != node.Kind || foundNode.Tag != node.Tag {
+					match = false
+				}
+				if len(foundNode.Content) == len(node.Content) {
+					for i := range foundNode.Content {
+						if foundNode.Content[i].Value != node.Content[i].Value {
+							match = false
+						}
+					}
+				}
+				if match {
+					return &NodeOrigin{
+						Node:             foundNode,
+						Line:             node.Line,
+						Column:           node.Column,
+						AbsoluteLocation: index.specAbsolutePath,
+						Index:            index,
+					}
+				}
+			}
+		}
+	}
 	return nil
 }

--- a/index/search_rolodex.go
+++ b/index/search_rolodex.go
@@ -4,51 +4,33 @@
 package index
 
 import (
-	"fmt"
 	"gopkg.in/yaml.v3"
 )
 
+// FindNodeOrigin searches all indexes for the origin of a node. If the node is found, a NodeOrigin
+// is returned, otherwise nil is returned.
 func (r *Rolodex) FindNodeOrigin(node *yaml.Node) *NodeOrigin {
-	//f := make(chan *NodeOrigin)
-	//d := make(chan bool)
-	//findNode := func(i int, node *yaml.Node) {
-	//	n := r.indexes[i].FindNodeOrigin(node)
-	//	if n != nil {
-	//		f <- n
-	//		return
-	//	}
-	//	d <- true
-	//}
-	//for i, _ := range r.indexes {
-	//	go findNode(i, node)
-	//}
-	//searched := 0
-	//for searched < len(r.indexes) {
-	//	select {
-	//	case n := <-f:
-	//		return n
-	//	case <-d:
-	//		searched++
-	//	}
-	//}
-	//return nil
-
-	if len(r.indexes) == 0 {
-		fmt.Println("NO FUCKING WAY MAN")
-	} else {
-		//fmt.Printf("searching %d files\n", len(r.indexes))
-	}
-	for i := range r.indexes {
+	f := make(chan *NodeOrigin)
+	d := make(chan bool)
+	findNode := func(i int, node *yaml.Node) {
 		n := r.indexes[i].FindNodeOrigin(node)
 		if n != nil {
+			f <- n
+			return
+		}
+		d <- true
+	}
+	for i, _ := range r.indexes {
+		go findNode(i, node)
+	}
+	searched := 0
+	for searched < len(r.indexes) {
+		select {
+		case n := <-f:
 			return n
+		case <-d:
+			searched++
 		}
 	}
-	//	if n != nil {
-	//		f <- n
-	//		return
-	//	}
-	fmt.Println("my FUCKING ARSE")
 	return nil
-
 }

--- a/index/search_rolodex_test.go
+++ b/index/search_rolodex_test.go
@@ -6,6 +6,7 @@ package index
 import (
 	"github.com/stretchr/testify/assert"
 	"github.com/vmware-labs/yaml-jsonpath/pkg/yamlpath"
+	"gopkg.in/yaml.v3"
 	"strings"
 	"testing"
 )
@@ -63,6 +64,23 @@ func TestRolodex_FindNodeOrigin(t *testing.T) {
 
 	// look for something that cannot exist
 	origin = rolo.FindNodeOrigin(nil)
+	assert.Nil(t, origin)
+
+	// modify the node and try again
+	m := *results[0]
+	m.Value = "I am a new message"
+	origin = rolo.FindNodeOrigin(&m)
+	assert.Nil(t, origin)
+
+	// copy, modify, and try again
+	o := *results[0]
+	o.Content = []*yaml.Node{
+		{Value: "beer"},
+	}
+	results[0].Content = []*yaml.Node{
+		{Value: "wine"},
+	}
+	origin = rolo.FindNodeOrigin(&o)
 	assert.Nil(t, origin)
 
 }

--- a/index/search_rolodex_test.go
+++ b/index/search_rolodex_test.go
@@ -107,20 +107,15 @@ func TestRolodex_FindNodeOrigin_ModifyLookup(t *testing.T) {
 
 	assert.Len(t, rolo.indexes, 4)
 
-	// extract something that can only exist after resolution
-	path := "$.paths./nested/files3.get.responses.200.content.application/json.schema.properties.message.properties.utilMessage.properties.message.description"
+	path := "$.paths./nested/files3.get.responses.200.content.application/json.schema"
 	yp, _ := yamlpath.NewPath(path)
 	results, _ := yp.Find(node)
 
 	// copy, modify, and try again
 	o := *results[0]
 	o.Content = []*yaml.Node{
-		{Value: "beer"},
-	}
-	results[0].Content = []*yaml.Node{
-		{Value: "wine"},
+		{Value: "beer"}, {Value: "wine"}, {Value: "cake"}, {Value: "burgers"}, {Value: "herbs"}, {Value: "spices"},
 	}
 	origin := rolo.FindNodeOrigin(&o)
 	assert.Nil(t, origin)
-
 }

--- a/index/search_rolodex_test.go
+++ b/index/search_rolodex_test.go
@@ -72,6 +72,9 @@ func TestRolodex_FindNodeOrigin(t *testing.T) {
 	origin = rolo.FindNodeOrigin(&m)
 	assert.Nil(t, origin)
 
+	// extract the doc root
+	origin = rolo.FindNodeOrigin(node)
+	assert.Nil(t, origin)
 }
 
 func TestRolodex_FindNodeOrigin_ModifyLookup(t *testing.T) {

--- a/index/spec_index.go
+++ b/index/spec_index.go
@@ -137,10 +137,6 @@ func (index *SpecIndex) BuildIndex() {
 	index.built = true
 }
 
-func (index *SpecIndex) GetSpecAbsolutePath() string {
-	return index.specAbsolutePath
-}
-
 func (index *SpecIndex) GetLogger() *slog.Logger {
 	return index.logger
 }

--- a/index/spec_index.go
+++ b/index/spec_index.go
@@ -66,6 +66,9 @@ func createNewIndex(rootNode *yaml.Node, index *SpecIndex, avoidBuildOut bool) *
 	if rootNode == nil {
 		return index
 	}
+	index.nodeMapCompleted = make(chan bool)
+	index.nodeMap = make(map[int]map[int]*yaml.Node)
+	go index.MapNodes(rootNode) // this can run async.
 
 	index.cache = new(syncmap.Map)
 
@@ -91,7 +94,7 @@ func createNewIndex(rootNode *yaml.Node, index *SpecIndex, avoidBuildOut bool) *
 	if !avoidBuildOut {
 		index.BuildIndex()
 	}
-
+	<- index.nodeMapCompleted
 	return index
 }
 
@@ -145,6 +148,10 @@ func (index *SpecIndex) GetLogger() *slog.Logger {
 // GetRootNode returns document root node.
 func (index *SpecIndex) GetRootNode() *yaml.Node {
 	return index.root
+}
+
+func (index *SpecIndex) GetRolodex() *Rolodex {
+	return index.rolodex
 }
 
 // GetGlobalTagsNode returns document root tags node.

--- a/index/spec_index.go
+++ b/index/spec_index.go
@@ -94,7 +94,7 @@ func createNewIndex(rootNode *yaml.Node, index *SpecIndex, avoidBuildOut bool) *
 	if !avoidBuildOut {
 		index.BuildIndex()
 	}
-	<- index.nodeMapCompleted
+	<-index.nodeMapCompleted
 	return index
 }
 

--- a/index/spec_index_test.go
+++ b/index/spec_index_test.go
@@ -519,6 +519,10 @@ func TestSpecIndex_PetstoreV3(t *testing.T) {
 	assert.Equal(t, 19, index.GetAllSummariesCount())
 	assert.Len(t, index.GetAllDescriptions(), 90)
 	assert.Len(t, index.GetAllSummaries(), 19)
+
+	index.SetAbsolutePath("/rooty/rootster")
+	assert.Equal(t, "/rooty/rootster", index.GetSpecAbsolutePath())
+
 }
 
 var mappedRefs = 15

--- a/index/spec_index_test.go
+++ b/index/spec_index_test.go
@@ -142,7 +142,7 @@ func TestSpecIndex_DigitalOcean(t *testing.T) {
 	cf.AllowRemoteLookup = true
 	cf.AvoidCircularReferenceCheck = true
 	cf.Logger = slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
-		Level: slog.LevelInfo,
+		Level: slog.LevelDebug,
 	}))
 
 	// setting this baseURL will override the base
@@ -166,7 +166,7 @@ func TestSpecIndex_DigitalOcean(t *testing.T) {
 		}
 		remoteFS.SetRemoteHandlerFunc(func(url string) (*http.Response, error) {
 			request, _ := http.NewRequest(http.MethodGet, url, nil)
-			request.Header.Set("Authorization", fmt.Sprintf("Bearer %s", os.Getenv("GITHUB_TOKEN")))
+			request.Header.Set("Authorization", fmt.Sprintf("Bearer %s", os.Getenv("GH_PAT")))
 			return client.Do(request)
 		})
 	}
@@ -178,6 +178,7 @@ func TestSpecIndex_DigitalOcean(t *testing.T) {
 	indexedErr := rolo.IndexTheRolodex()
 	assert.NoError(t, indexedErr)
 
+	// get all the files!
 	files := remoteFS.GetFiles()
 	fileLen := len(files)
 	assert.Equal(t, 1646, fileLen)

--- a/index/spec_index_test.go
+++ b/index/spec_index_test.go
@@ -142,7 +142,7 @@ func TestSpecIndex_DigitalOcean(t *testing.T) {
 	cf.AllowRemoteLookup = true
 	cf.AvoidCircularReferenceCheck = true
 	cf.Logger = slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
-		Level: slog.LevelDebug,
+		Level: slog.LevelError,
 	}))
 
 	// setting this baseURL will override the base

--- a/renderer/schema_renderer.go
+++ b/renderer/schema_renderer.go
@@ -57,7 +57,8 @@ func init() {
 // SchemaRenderer is a renderer that will generate random words, numbers and values based on a dictionary file.
 // The dictionary is just a slice of strings that is used to generate random words.
 type SchemaRenderer struct {
-	words []string
+	words           []string
+	disableRequired bool
 }
 
 // CreateRendererUsingDictionary will create a new SchemaRenderer using a custom dictionary file.
@@ -83,6 +84,13 @@ func (wr *SchemaRenderer) RenderSchema(schema *base.Schema) any {
 	structure := make(map[string]any)
 	wr.DiveIntoSchema(schema, rootType, structure, 0)
 	return structure[rootType].(any)
+}
+
+// DisableRequiredCheck will disable the required check when rendering a schema. This means that all properties
+// will be rendered, not just the required ones.
+// https://github.com/pb33f/libopenapi/issues/200
+func (wr *SchemaRenderer) DisableRequiredCheck() {
+	wr.disableRequired = true
 }
 
 // DiveIntoSchema will dive into a schema and inject values from examples into a map. If there are no examples in
@@ -219,7 +227,7 @@ func (wr *SchemaRenderer) DiveIntoSchema(schema *base.Schema, key string, struct
 			// check if this schema has required properties, if so, then only render required props, if not
 			// render everything in the schema.
 			checkProps := make(map[string]*base.SchemaProxy)
-			if len(schema.Required) > 0 {
+			if !wr.disableRequired && len(schema.Required) > 0 {
 				for _, requiredProp := range schema.Required {
 					checkProps[requiredProp] = properties[requiredProp]
 				}

--- a/renderer/schema_renderer_test.go
+++ b/renderer/schema_renderer_test.go
@@ -960,6 +960,32 @@ properties:
 	assert.Nil(t, journeyMap["pb33f"].(map[string]interface{})["fries"])
 }
 
+func TestRenderExample_Test_RequiredCheckDisabled(t *testing.T) {
+	testObject := `type: [object]
+required:
+  - drink
+properties:
+  burger:
+    type: string
+  fries:
+    type: string
+  drink:
+    type: string`
+
+	compiled := getSchema([]byte(testObject))
+
+	journeyMap := make(map[string]any)
+	wr := createSchemaRenderer()
+	wr.DisableRequiredCheck()
+	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, 0)
+
+	assert.NotNil(t, journeyMap["pb33f"])
+	drink := journeyMap["pb33f"].(map[string]interface{})["drink"].(string)
+	assert.NotNil(t, drink)
+	assert.NotNil(t, journeyMap["pb33f"].(map[string]interface{})["burger"])
+	assert.NotNil(t, journeyMap["pb33f"].(map[string]interface{})["fries"])
+}
+
 func TestRenderSchema_WithExample(t *testing.T) {
 	testObject := `type: [object]
 properties:


### PR DESCRIPTION
Added the ability to locate where a reference comes from 

- #177
- #200

A new method `GetReferenceOrigin()` exists on `SchemaProxy` that returns `*index.NodeOrigin`


```go 
type NodeOrigin struct {
  // Node is the node in question 
  Node *yaml.Node

  // Line is yhe original line of where the node was found in the original file
  Line int

  // Column is the original column of where the node was found in the original file 
  Column int

  // AbsoluteLocation is the absolute path to the reference was extracted from.
  // This can either be an absolute path to a file, or a URL.
  AbsoluteLocation string

  // Index is the index that contains the node that was located in.
  Index *SpecIndex
}
```

Also a new switch method features on the `renderer.SchemaRenderer` struct called `DisableRequiredCheck()` This will render all properties, regardless of the 'required` property values.
