### PR TITLE
v0.13.15

### DIFF
--- a/index/resolver.go
+++ b/index/resolver.go
@@ -714,8 +714,19 @@ func (resolver *Resolver) extractRelatives(ref *Reference, node, parent *yaml.No
 														def = fmt.Sprintf("%s#/%s", u.String(), exp[1])
 
 													} else {
-														abs, _ := filepath.Abs(filepath.Join(filepath.Dir(ref.FullDefinition), exp[0]))
-														def = fmt.Sprintf("%s#/%s", abs, exp[1])
+														z := strings.Split(ref.FullDefinition, "#/")
+														if len(z) == 2 {
+															if len(z[0]) > 0 {
+																abs, _ := filepath.Abs(filepath.Join(filepath.Dir(z[0]), exp[0]))
+																def = fmt.Sprintf("%s#/%s", abs, exp[1])
+															} else {
+																abs, _ := filepath.Abs(exp[0])
+																def = fmt.Sprintf("%s#/%s", abs, exp[1])
+															}
+														} else {
+															abs, _ := filepath.Abs(filepath.Join(filepath.Dir(ref.FullDefinition), exp[0]))
+															def = fmt.Sprintf("%s#/%s", abs, exp[1])
+														}
 													}
 												}
 											} else {

--- a/index/rolodex.go
+++ b/index/rolodex.go
@@ -439,6 +439,7 @@ func (r *Rolodex) Open(location string) (RolodexFile, error) {
 	if !isUrl {
 		if len(r.localFS) <= 0 {
 			r.logger.Warn("[rolodex] no local file systems configured, cannot open local file", "location", location)
+			return nil, fmt.Errorf("the rolodex has no local file systems configured, cannot open local file '%s'", location)
 		}
 
 		for k, v := range r.localFS {

--- a/index/rolodex.go
+++ b/index/rolodex.go
@@ -437,6 +437,10 @@ func (r *Rolodex) Open(location string) (RolodexFile, error) {
 	}
 
 	if !isUrl {
+		if len(r.localFS) <= 0 {
+			r.logger.Warn("[rolodex] no local file systems configured, cannot open local file", "location", location)
+		}
+
 		for k, v := range r.localFS {
 
 			// check if this is a URL or an abs/rel reference.

--- a/index/rolodex_file_loader.go
+++ b/index/rolodex_file_loader.go
@@ -87,6 +87,7 @@ func (l *LocalFS) Open(name string) (fs.File, error) {
 				l.logger.Debug("[rolodex file loader]: waiting for existing OS load to complete", "file", name, "listeners", wait.listeners)
 
 				for !wait.done {
+					l.logger.Debug("[rolodex file loader]: sleeping for 200ns", "file", name, "listeners", wait.listeners)
 					time.Sleep(200 * time.Nanosecond) // breathe for a few nanoseconds.
 				}
 				wait.listeners--

--- a/index/rolodex_test.go
+++ b/index/rolodex_test.go
@@ -42,6 +42,17 @@ func TestRolodex_NoFS(t *testing.T) {
 
 }
 
+func TestRolodex_NoFSButHasRemoteFS(t *testing.T) {
+
+	rolo := NewRolodex(CreateOpenAPIIndexConfig())
+	rolo.AddRemoteFS("http://localhost", nil)
+	rf, err := rolo.Open("spec.yaml")
+	assert.Error(t, err)
+	assert.Equal(t, "the rolodex has no local file systems configured, cannot open local file 'spec.yaml'", err.Error())
+	assert.Nil(t, rf)
+
+}
+
 func TestRolodex_LocalNativeFS(t *testing.T) {
 
 	t.Parallel()

--- a/index/spec_index_test.go
+++ b/index/spec_index_test.go
@@ -260,7 +260,7 @@ func TestSpecIndex_DigitalOcean_FullCheckoutLocalResolve(t *testing.T) {
 	assert.Len(t, rolo.GetCaughtErrors(), 0)
 	assert.Len(t, rolo.GetIgnoredCircularReferences(), 0)
 
-	assert.Equal(t, int64(1331012), rolo.RolodexFileSize())
+	assert.Equal(t, int64(1331498), rolo.RolodexFileSize())
 	assert.Equal(t, "1.27 MB", rolo.RolodexFileSizeAsString())
 	assert.Equal(t, 1696, rolo.RolodexTotalFiles())
 
@@ -334,7 +334,7 @@ func TestSpecIndex_DigitalOcean_FullCheckoutLocalResolve_RecursiveLookup(t *test
 	assert.Len(t, rolo.GetCaughtErrors(), 0)
 	assert.Len(t, rolo.GetIgnoredCircularReferences(), 0)
 
-	assert.Equal(t, int64(1269396), rolo.RolodexFileSize())
+	assert.Equal(t, int64(1269882), rolo.RolodexFileSize())
 	assert.Equal(t, "1.21 MB", rolo.RolodexFileSizeAsString())
 	assert.Equal(t, 1682, rolo.RolodexTotalFiles())
 

--- a/index/spec_index_test.go
+++ b/index/spec_index_test.go
@@ -239,7 +239,7 @@ func TestSpecIndex_DigitalOcean_FullCheckoutLocalResolve(t *testing.T) {
 	files := fileFS.GetFiles()
 	fileLen := len(files)
 
-	assert.Equal(t, 1691, fileLen)
+	assert.Equal(t, 1696, fileLen)
 
 	rolo.AddLocalFS(basePath, fileFS)
 
@@ -251,8 +251,8 @@ func TestSpecIndex_DigitalOcean_FullCheckoutLocalResolve(t *testing.T) {
 
 	assert.NotNil(t, index)
 
-	assert.Len(t, index.GetMappedReferencesSequenced(), 299)
-	assert.Len(t, index.GetMappedReferences(), 299)
+	assert.Len(t, index.GetMappedReferencesSequenced(), 300)
+	assert.Len(t, index.GetMappedReferences(), 300)
 	assert.Len(t, fileFS.GetErrors(), 0)
 
 	// check circular references
@@ -260,9 +260,9 @@ func TestSpecIndex_DigitalOcean_FullCheckoutLocalResolve(t *testing.T) {
 	assert.Len(t, rolo.GetCaughtErrors(), 0)
 	assert.Len(t, rolo.GetIgnoredCircularReferences(), 0)
 
-	assert.Equal(t, int64(1328224), rolo.RolodexFileSize())
+	assert.Equal(t, int64(1331012), rolo.RolodexFileSize())
 	assert.Equal(t, "1.27 MB", rolo.RolodexFileSizeAsString())
-	assert.Equal(t, 1691, rolo.RolodexTotalFiles())
+	assert.Equal(t, 1696, rolo.RolodexTotalFiles())
 
 }
 
@@ -317,7 +317,7 @@ func TestSpecIndex_DigitalOcean_FullCheckoutLocalResolve_RecursiveLookup(t *test
 	files := fileFS.GetFiles()
 	fileLen := len(files)
 
-	assert.Equal(t, 1677, fileLen)
+	assert.Equal(t, 1682, fileLen)
 
 	assert.NoError(t, rErr)
 
@@ -325,8 +325,8 @@ func TestSpecIndex_DigitalOcean_FullCheckoutLocalResolve_RecursiveLookup(t *test
 
 	assert.NotNil(t, index)
 
-	assert.Len(t, index.GetMappedReferencesSequenced(), 299)
-	assert.Len(t, index.GetMappedReferences(), 299)
+	assert.Len(t, index.GetMappedReferencesSequenced(), 300)
+	assert.Len(t, index.GetMappedReferences(), 300)
 	assert.Len(t, fileFS.GetErrors(), 0)
 
 	// check circular references
@@ -334,9 +334,9 @@ func TestSpecIndex_DigitalOcean_FullCheckoutLocalResolve_RecursiveLookup(t *test
 	assert.Len(t, rolo.GetCaughtErrors(), 0)
 	assert.Len(t, rolo.GetIgnoredCircularReferences(), 0)
 
-	assert.Equal(t, int64(1266728), rolo.RolodexFileSize())
+	assert.Equal(t, int64(1269396), rolo.RolodexFileSize())
 	assert.Equal(t, "1.21 MB", rolo.RolodexFileSizeAsString())
-	assert.Equal(t, 1677, rolo.RolodexTotalFiles())
+	assert.Equal(t, 1682, rolo.RolodexTotalFiles())
 
 }
 

--- a/renderer/mock_generator.go
+++ b/renderer/mock_generator.go
@@ -64,6 +64,9 @@ func (mg *MockGenerator) SetPretty() {
 // The name parameter is optional, if provided, the mock generator will attempt to find an example with the given name.
 // If no name is provided, the first example will be used.
 func (mg *MockGenerator) GenerateMock(mock any, name string) ([]byte, error) {
+	if mock == nil || !reflect.ValueOf(mock).IsValid() || reflect.ValueOf(mock).IsNil() {
+		return nil, nil
+	}
 	v := reflect.ValueOf(mock).Elem()
 	num := v.NumField()
 	fieldCount := 0

--- a/renderer/mock_generator_test.go
+++ b/renderer/mock_generator_test.go
@@ -96,6 +96,18 @@ func TestNewMockGeneratorWithDictionary(t *testing.T) {
 	assert.NotNil(t, mg)
 }
 
+func TestMockGenerator_GenerateJSONMock_NoObject(t *testing.T) {
+
+	mg := NewMockGenerator(JSON)
+
+	var isNil any
+	isNil = nil
+
+	mock, err := mg.GenerateMock(isNil, "")
+	assert.NoError(t, err)
+	assert.Nil(t, mock)
+}
+
 func TestMockGenerator_GenerateJSONMock_BadObject(t *testing.T) {
 	type NotMockable struct {
 		pizza string


### PR DESCRIPTION
Fixes issues with mock generator getting upset. Updates digital ocean tests to reflect new spec, fixes a small resolver issue that showcased a file locking problem.

No new features, just fixes.