### PR TITLE
Tuned circular reference handling

### DIFF
--- a/datamodel/high/v3/document_test.go
+++ b/datamodel/high/v3/document_test.go
@@ -391,7 +391,7 @@ func TestStripeAsDoc(t *testing.T) {
 	info, _ := datamodel.ExtractSpecInfo(data)
 	var err error
 	lowDoc, err = lowv3.CreateDocumentFromConfig(info, datamodel.NewDocumentConfiguration())
-	assert.Len(t, utils.UnwrapErrors(err), 2)
+	assert.Len(t, utils.UnwrapErrors(err), 1)
 	d := NewDocument(lowDoc)
 	assert.NotNil(t, d)
 }

--- a/datamodel/low/v3/create_document_test.go
+++ b/datamodel/low/v3/create_document_test.go
@@ -259,7 +259,7 @@ func TestCreateDocumentStripe(t *testing.T) {
 	data, _ := os.ReadFile("../../../test_specs/stripe.yaml")
 	info, _ := datamodel.ExtractSpecInfo(data)
 	d, err := CreateDocumentFromConfig(info, &datamodel.DocumentConfiguration{})
-	assert.Len(t, utils.UnwrapErrors(err), 2)
+	assert.Len(t, utils.UnwrapErrors(err), 1)
 
 	assert.Equal(t, "3.0.0", d.Version.Value)
 	assert.Equal(t, "Stripe API", d.Info.Value.Title.Value)

--- a/document_test.go
+++ b/document_test.go
@@ -219,7 +219,7 @@ func TestDocument_ResolveStripe(t *testing.T) {
 	rolo := model.Index.GetRolodex()
 	rolo.Resolve()
 
-	assert.Equal(t, 2, len(model.Index.GetRolodex().GetCaughtErrors()))
+	assert.Equal(t, 1, len(model.Index.GetRolodex().GetCaughtErrors()))
 
 }
 

--- a/index/resolver_test.go
+++ b/index/resolver_test.go
@@ -470,7 +470,7 @@ func TestResolver_DeepDepth(t *testing.T) {
 	found := resolver.extractRelatives(ref, refA, nil, nil, nil, nil, false, 0)
 
 	assert.Nil(t, found)
-	assert.Contains(t, buf.String(), "libopenapi resolver: relative depth exceeded 500 levels")
+	assert.Contains(t, buf.String(), "libopenapi resolver: relative depth exceeded 100 levels")
 }
 
 func TestResolver_ResolveComponents_Stripe_NoRolodex(t *testing.T) {
@@ -492,7 +492,7 @@ func TestResolver_ResolveComponents_Stripe_NoRolodex(t *testing.T) {
 	assert.NotNil(t, resolver)
 
 	circ := resolver.CheckForCircularReferences()
-	assert.Len(t, circ, 2)
+	assert.Len(t, circ, 1)
 
 	_, err := yaml.Marshal(resolver.resolvedRoot)
 	assert.NoError(t, err)
@@ -521,9 +521,10 @@ func TestResolver_ResolveComponents_Stripe(t *testing.T) {
 	// after resolving, the rolodex will have errors.
 	rolo.Resolve()
 
-	assert.Len(t, rolo.GetCaughtErrors(), 2)
-	assert.Len(t, rolo.GetRootIndex().GetResolver().GetNonPolymorphicCircularErrors(), 2)
+	assert.Len(t, rolo.GetCaughtErrors(), 1)
+	assert.Len(t, rolo.GetRootIndex().GetResolver().GetNonPolymorphicCircularErrors(), 1)
 	assert.Len(t, rolo.GetRootIndex().GetResolver().GetPolymorphicCircularErrors(), 0)
+	assert.Len(t, rolo.GetRootIndex().GetResolver().GetSafeCircularReferences(), 25)
 
 }
 
@@ -769,9 +770,13 @@ func ExampleNewResolver() {
 	// The Stripe API has a bunch of circular reference problems, mainly from polymorphism.
 	// So let's print them out.
 	//
-	fmt.Printf("There are %d circular reference errors, %d of them are polymorphic errors, %d are not",
-		len(circularErrors), len(resolver.GetPolymorphicCircularErrors()), len(resolver.GetNonPolymorphicCircularErrors()))
-	// Output: There are 2 circular reference errors, 0 of them are polymorphic errors, 2 are not
+	fmt.Printf("There is %d circular reference error, %d of them are polymorphic errors, %d are not\n"+
+		"with a total pf %d safe circular references.\n",
+		len(circularErrors), len(resolver.GetPolymorphicCircularErrors()), len(resolver.GetNonPolymorphicCircularErrors()),
+		len(resolver.GetSafeCircularReferences()))
+	// Output: There is 1 circular reference error, 0 of them are polymorphic errors, 1 are not
+	// with a total pf 25 safe circular references.
+
 }
 
 func ExampleResolvingError() {


### PR DESCRIPTION
stopped rolodex looking up root file, looking in components schemas for a reference also. Dropped stripe circular refs down by one. seems to be catching the duplicate now.