### PR TITLE
v0.13.21

### DIFF
--- a/index/index_model.go
+++ b/index/index_model.go
@@ -276,6 +276,7 @@ type SpecIndex struct {
 	logger                              *slog.Logger
 	nodeMap                             map[int]map[int]*yaml.Node
 	nodeMapCompleted                    chan bool
+	pendingResolve                      []refMap
 }
 
 // GetResolver returns the resolver for this index.

--- a/index/resolver.go
+++ b/index/resolver.go
@@ -308,12 +308,6 @@ func visitIndex(res *Resolver, idx *SpecIndex) {
 			}
 		}
 	}
-
-	//map everything afterwards
-	//for r := range refs {
-	//refs[r].ref.Node.Content = refs[r].nodes
-	//}
-
 }
 
 // VisitReference will visit a reference as part of a journey and will return resolved nodes.

--- a/index/rolodex.go
+++ b/index/rolodex.go
@@ -399,6 +399,11 @@ func (r *Rolodex) Resolve() {
 		r.safeCircularReferences = append(r.safeCircularReferences, res.GetSafeCircularReferences()...)
 		r.infiniteCircularReferences = append(r.infiniteCircularReferences, res.GetInfiniteCircularReferences()...)
 	}
+
+	// resolve pending nodes
+	for _, res := range resolvers {
+		res.ResolvePendingNodes()
+	}
 	r.resolved = true
 }
 

--- a/index/search_index.go
+++ b/index/search_index.go
@@ -43,6 +43,9 @@ func (index *SpecIndex) SearchIndexForReferenceByReferenceWithContext(ctx contex
 	ref := searchRef.FullDefinition
 	refAlt := ref
 	absPath := index.specAbsolutePath
+	if searchRef.RemoteLocation != "" {
+		absPath = searchRef.RemoteLocation
+	}
 	if absPath == "" {
 		absPath = index.config.BasePath
 	}


### PR DESCRIPTION
Resolves resolving. haha

Deeply nested resolving was getting jumbled because the resolver was stitching together references as it was resolving, so when other threads went looking for a reference, they got the resolved one instead, which means the resolver lost its place in the stack. 

Stitching for original references is now done after the resolver has visited every index.