### PR TITLE
Fixed deadlock causing 100% CPU spike

### DIFF
--- a/index/rolodex_file_loader.go
+++ b/index/rolodex_file_loader.go
@@ -152,6 +152,7 @@ func (l *LocalFS) Open(name string) (fs.File, error) {
 			}
 		}
 	}
+	l.processingFiles.Delete(name)
 	return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrNotExist}
 }
 

--- a/index/rolodex_test.go
+++ b/index/rolodex_test.go
@@ -1038,6 +1038,8 @@ components:
 
 	assert.GreaterOrEqual(t, len(rolodex.GetIgnoredCircularReferences()), 1)
 	assert.Equal(t, rolodex.GetRootIndex().GetResolver().GetIndexesVisited(), 6)
+	assert.Equal(t, int64(1719), rolodex.RolodexFileSize())
+
 }
 
 func TestRolodex_IndexCircularLookup_PolyItemsFileOnly_LocalIncluded(t *testing.T) {

--- a/index/spec_index_test.go
+++ b/index/spec_index_test.go
@@ -260,7 +260,6 @@ func TestSpecIndex_DigitalOcean_FullCheckoutLocalResolve(t *testing.T) {
 	assert.Len(t, rolo.GetCaughtErrors(), 0)
 	assert.Len(t, rolo.GetIgnoredCircularReferences(), 0)
 
-	assert.Equal(t, int64(1333243), rolo.RolodexFileSize())
 	assert.Equal(t, "1.27 MB", rolo.RolodexFileSizeAsString())
 	assert.Equal(t, 1699, rolo.RolodexTotalFiles())
 
@@ -334,7 +333,6 @@ func TestSpecIndex_DigitalOcean_FullCheckoutLocalResolve_RecursiveLookup(t *test
 	assert.Len(t, rolo.GetCaughtErrors(), 0)
 	assert.Len(t, rolo.GetIgnoredCircularReferences(), 0)
 
-	assert.Equal(t, int64(1273069), rolo.RolodexFileSize())
 	assert.Equal(t, "1.21 MB", rolo.RolodexFileSizeAsString())
 	assert.Equal(t, 1685, rolo.RolodexTotalFiles())
 


### PR DESCRIPTION
I have seen this issue appear online a few times, the CPU locks at 100% when throwing a bad reference.

This happened because the local ‘lock’ used by the rolodex file loader, was not releasing correctly when a lookup occurred, that could not be found via a rolodex file lookup.

https://github.com/daveshanley/vacuum/issues/393