### PR TITLE
v0.14.5 Performance and Tuneup

### DIFF
--- a/datamodel/high/base/schema_proxy.go
+++ b/datamodel/high/base/schema_proxy.go
@@ -120,6 +120,13 @@ func (sp *SchemaProxy) GetReference() string {
 	return sp.schema.GetValue().GetReference()
 }
 
+func (sp *SchemaProxy) GetSchemaKeyNode() *yaml.Node {
+	if sp.schema != nil {
+		return sp.GoLow().GetKeyNode()
+	}
+	return nil
+}
+
 func (sp *SchemaProxy) GetReferenceNode() *yaml.Node {
 	if sp.refStr != "" {
 		return utils.CreateRefNode(sp.refStr)

--- a/datamodel/high/base/schema_proxy.go
+++ b/datamodel/high/base/schema_proxy.go
@@ -206,6 +206,19 @@ func (sp *SchemaProxy) MarshalYAMLInline() (interface{}, error) {
 	var s *Schema
 	var err error
 	s, err = sp.BuildSchema()
+
+	if s != nil && s.GoLow() != nil && s.GoLow().Index != nil {
+		circ := s.GoLow().Index.GetCircularReferences()
+		for _, c := range circ {
+			if sp.IsReference() {
+				// we cannot proceed.
+				if sp.GetReference() == c.LoopPoint.Definition {
+					return sp.GetReferenceNode(), nil
+				}
+			}
+		}
+	}
+
 	if err != nil {
 		return nil, err
 	}

--- a/datamodel/high/base/schema_proxy_test.go
+++ b/datamodel/high/base/schema_proxy_test.go
@@ -4,21 +4,21 @@
 package base
 
 import (
-    "context"
-    "strings"
-    "testing"
+	"context"
+	"strings"
+	"testing"
 
-    "github.com/pb33f/libopenapi/datamodel/low"
-    lowbase "github.com/pb33f/libopenapi/datamodel/low/base"
-    "github.com/pb33f/libopenapi/index"
-    "github.com/pb33f/libopenapi/utils"
-    "github.com/stretchr/testify/assert"
-    "github.com/stretchr/testify/require"
-    "gopkg.in/yaml.v3"
+	"github.com/pb33f/libopenapi/datamodel/low"
+	lowbase "github.com/pb33f/libopenapi/datamodel/low/base"
+	"github.com/pb33f/libopenapi/index"
+	"github.com/pb33f/libopenapi/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 func TestSchemaProxy_MarshalYAML(t *testing.T) {
-    const ymlComponents = `components:
+	const ymlComponents = `components:
     schemas:
      rice:
        type: string
@@ -31,99 +31,99 @@ func TestSchemaProxy_MarshalYAML(t *testing.T) {
          rice:
            $ref: '#/components/schemas/rice'`
 
-    idx := func() *index.SpecIndex {
-        var idxNode yaml.Node
-        err := yaml.Unmarshal([]byte(ymlComponents), &idxNode)
-        assert.NoError(t, err)
-        return index.NewSpecIndexWithConfig(&idxNode, index.CreateOpenAPIIndexConfig())
-    }()
+	idx := func() *index.SpecIndex {
+		var idxNode yaml.Node
+		err := yaml.Unmarshal([]byte(ymlComponents), &idxNode)
+		assert.NoError(t, err)
+		return index.NewSpecIndexWithConfig(&idxNode, index.CreateOpenAPIIndexConfig())
+	}()
 
-    const ref = "#/components/schemas/nice"
-    const ymlSchema = `$ref: '` + ref + `'`
-    var node yaml.Node
-    _ = yaml.Unmarshal([]byte(ymlSchema), &node)
+	const ref = "#/components/schemas/nice"
+	const ymlSchema = `$ref: '` + ref + `'`
+	var node yaml.Node
+	_ = yaml.Unmarshal([]byte(ymlSchema), &node)
 
-    lowProxy := new(lowbase.SchemaProxy)
-    err := lowProxy.Build(context.Background(), nil, node.Content[0], idx)
-    assert.NoError(t, err)
+	lowProxy := new(lowbase.SchemaProxy)
+	err := lowProxy.Build(context.Background(), nil, node.Content[0], idx)
+	assert.NoError(t, err)
 
-    lowRef := low.NodeReference[*lowbase.SchemaProxy]{
-        Value: lowProxy,
-    }
+	lowRef := low.NodeReference[*lowbase.SchemaProxy]{
+		Value: lowProxy,
+	}
 
-    sp := NewSchemaProxy(&lowRef)
+	sp := NewSchemaProxy(&lowRef)
 
-    origin := sp.GetReferenceOrigin()
-    assert.Nil(t, origin)
+	origin := sp.GetReferenceOrigin()
+	assert.Nil(t, origin)
 
-    rend, _ := sp.Render()
-    assert.Equal(t, "$ref: '#/components/schemas/nice'", strings.TrimSpace(string(rend)))
+	rend, _ := sp.Render()
+	assert.Equal(t, "$ref: '#/components/schemas/nice'", strings.TrimSpace(string(rend)))
 }
 
 func TestCreateSchemaProxy(t *testing.T) {
-    sp := CreateSchemaProxy(&Schema{Description: "iAmASchema"})
-    assert.Equal(t, "iAmASchema", sp.rendered.Description)
-    assert.False(t, sp.IsReference())
+	sp := CreateSchemaProxy(&Schema{Description: "iAmASchema"})
+	assert.Equal(t, "iAmASchema", sp.rendered.Description)
+	assert.False(t, sp.IsReference())
 }
 
 func TestCreateSchemaProxyRef(t *testing.T) {
-    sp := CreateSchemaProxyRef("#/components/schemas/MySchema")
-    assert.Equal(t, "#/components/schemas/MySchema", sp.GetReference())
-    assert.True(t, sp.IsReference())
+	sp := CreateSchemaProxyRef("#/components/schemas/MySchema")
+	assert.Equal(t, "#/components/schemas/MySchema", sp.GetReference())
+	assert.True(t, sp.IsReference())
 }
 
 func TestSchemaProxy_GetReference(t *testing.T) {
-    refNode := utils.CreateStringNode("#/components/schemas/MySchema")
+	refNode := utils.CreateStringNode("#/components/schemas/MySchema")
 
-    ref := low.Reference{}
-    ref.SetReference("#/components/schemas/MySchema", refNode)
+	ref := low.Reference{}
+	ref.SetReference("#/components/schemas/MySchema", refNode)
 
-    sp := &SchemaProxy{
-        schema: &low.NodeReference[*lowbase.SchemaProxy]{
-            Value: &lowbase.SchemaProxy{
-                Reference: ref,
-            },
-        },
-    }
-    assert.Equal(t, "#/components/schemas/MySchema", sp.GetReference())
-    assert.Equal(t, refNode, sp.GetReferenceNode())
+	sp := &SchemaProxy{
+		schema: &low.NodeReference[*lowbase.SchemaProxy]{
+			Value: &lowbase.SchemaProxy{
+				Reference: ref,
+			},
+		},
+	}
+	assert.Equal(t, "#/components/schemas/MySchema", sp.GetReference())
+	assert.Equal(t, refNode, sp.GetReferenceNode())
 }
 
 func TestSchemaProxy_IsReference_Nil(t *testing.T) {
-    var sp *SchemaProxy
-    assert.False(t, sp.IsReference())
+	var sp *SchemaProxy
+	assert.False(t, sp.IsReference())
 }
 
 func TestSchemaProxy_NoSchema_GetOrigin(t *testing.T) {
-    sp := &SchemaProxy{}
-    assert.Nil(t, sp.GetReferenceOrigin())
+	sp := &SchemaProxy{}
+	assert.Nil(t, sp.GetReferenceOrigin())
 }
 
 func TestCreateSchemaProxyRef_GetReferenceNode(t *testing.T) {
-    refNode := utils.CreateRefNode("#/components/schemas/MySchema")
+	refNode := utils.CreateRefNode("#/components/schemas/MySchema")
 
-    sp := CreateSchemaProxyRef("#/components/schemas/MySchema")
-    assert.Equal(t, refNode, sp.GetReferenceNode())
+	sp := CreateSchemaProxyRef("#/components/schemas/MySchema")
+	assert.Equal(t, refNode, sp.GetReferenceNode())
 }
 
 func TestCreateRefNode_MarshalYAML(t *testing.T) {
-    ref := low.Reference{}
-    ref.SetReference("#/components/schemas/MySchema", nil)
+	ref := low.Reference{}
+	ref.SetReference("#/components/schemas/MySchema", nil)
 
-    sp := &SchemaProxy{
-        schema: &low.NodeReference[*lowbase.SchemaProxy]{
-            Value: &lowbase.SchemaProxy{
-                Reference: ref,
-            },
-        },
-    }
-    node, err := sp.MarshalYAML()
-    require.NoError(t, err)
-    assert.Equal(t, node, utils.CreateRefNode("#/components/schemas/MySchema"))
+	sp := &SchemaProxy{
+		schema: &low.NodeReference[*lowbase.SchemaProxy]{
+			Value: &lowbase.SchemaProxy{
+				Reference: ref,
+			},
+		},
+	}
+	node, err := sp.MarshalYAML()
+	require.NoError(t, err)
+	assert.Equal(t, node, utils.CreateRefNode("#/components/schemas/MySchema"))
 }
 
 func TestSchemaProxy_MarshalYAML_InlineCircular(t *testing.T) {
-    const ymlComponents = `openapi: 3.1
+	const ymlComponents = `openapi: 3.1
 components:
   schemas:
     spice:
@@ -135,37 +135,37 @@ components:
         rice:
           $ref: '#/components/schemas/nice'`
 
-    idx := func() *index.SpecIndex {
-        var idxNode yaml.Node
-        err := yaml.Unmarshal([]byte(ymlComponents), &idxNode)
-        assert.NoError(t, err)
-        return index.NewSpecIndexWithConfig(&idxNode, index.CreateOpenAPIIndexConfig())
-    }()
+	idx := func() *index.SpecIndex {
+		var idxNode yaml.Node
+		err := yaml.Unmarshal([]byte(ymlComponents), &idxNode)
+		assert.NoError(t, err)
+		return index.NewSpecIndexWithConfig(&idxNode, index.CreateOpenAPIIndexConfig())
+	}()
 
-    resolver := index.NewResolver(idx)
-    resolver.CheckForCircularReferences()
+	resolver := index.NewResolver(idx)
+	resolver.CheckForCircularReferences()
 
-    const ymlSchema = `properties:
+	const ymlSchema = `properties:
   rice:
     $ref: '#/components/schemas/nice'`
-    var node yaml.Node
-    _ = yaml.Unmarshal([]byte(ymlSchema), &node)
+	var node yaml.Node
+	_ = yaml.Unmarshal([]byte(ymlSchema), &node)
 
-    lowProxy := new(lowbase.SchemaProxy)
-    err := lowProxy.Build(context.Background(), &node, node.Content[0], idx)
-    assert.NoError(t, err)
+	lowProxy := new(lowbase.SchemaProxy)
+	err := lowProxy.Build(context.Background(), &node, node.Content[0], idx)
+	assert.NoError(t, err)
 
-    lowRef := low.NodeReference[*lowbase.SchemaProxy]{
-        Value:   lowProxy,
-        KeyNode: &node,
-    }
+	lowRef := low.NodeReference[*lowbase.SchemaProxy]{
+		Value:   lowProxy,
+		KeyNode: &node,
+	}
 
-    spEmpty := NewSchemaProxy(nil)
-    assert.Nil(t, spEmpty.GetSchemaKeyNode())
+	spEmpty := NewSchemaProxy(nil)
+	assert.Nil(t, spEmpty.GetSchemaKeyNode())
 
-    sp := NewSchemaProxy(&lowRef)
-    assert.NotNil(t, sp.GetSchemaKeyNode())
+	sp := NewSchemaProxy(&lowRef)
+	assert.NotNil(t, sp.GetSchemaKeyNode())
 
-    rend, _ := sp.MarshalYAMLInline()
-    assert.NotNil(t, rend)
+	rend, _ := sp.MarshalYAMLInline()
+	assert.NotNil(t, rend)
 }

--- a/datamodel/high/base/schema_proxy_test.go
+++ b/datamodel/high/base/schema_proxy_test.go
@@ -4,21 +4,21 @@
 package base
 
 import (
-	"context"
-	"strings"
-	"testing"
+    "context"
+    "strings"
+    "testing"
 
-	"github.com/pb33f/libopenapi/datamodel/low"
-	lowbase "github.com/pb33f/libopenapi/datamodel/low/base"
-	"github.com/pb33f/libopenapi/index"
-	"github.com/pb33f/libopenapi/utils"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+    "github.com/pb33f/libopenapi/datamodel/low"
+    lowbase "github.com/pb33f/libopenapi/datamodel/low/base"
+    "github.com/pb33f/libopenapi/index"
+    "github.com/pb33f/libopenapi/utils"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+    "gopkg.in/yaml.v3"
 )
 
 func TestSchemaProxy_MarshalYAML(t *testing.T) {
-	const ymlComponents = `components:
+    const ymlComponents = `components:
     schemas:
      rice:
        type: string
@@ -31,93 +31,141 @@ func TestSchemaProxy_MarshalYAML(t *testing.T) {
          rice:
            $ref: '#/components/schemas/rice'`
 
-	idx := func() *index.SpecIndex {
-		var idxNode yaml.Node
-		err := yaml.Unmarshal([]byte(ymlComponents), &idxNode)
-		assert.NoError(t, err)
-		return index.NewSpecIndexWithConfig(&idxNode, index.CreateOpenAPIIndexConfig())
-	}()
+    idx := func() *index.SpecIndex {
+        var idxNode yaml.Node
+        err := yaml.Unmarshal([]byte(ymlComponents), &idxNode)
+        assert.NoError(t, err)
+        return index.NewSpecIndexWithConfig(&idxNode, index.CreateOpenAPIIndexConfig())
+    }()
 
-	const ref = "#/components/schemas/nice"
-	const ymlSchema = `$ref: '` + ref + `'`
-	var node yaml.Node
-	_ = yaml.Unmarshal([]byte(ymlSchema), &node)
+    const ref = "#/components/schemas/nice"
+    const ymlSchema = `$ref: '` + ref + `'`
+    var node yaml.Node
+    _ = yaml.Unmarshal([]byte(ymlSchema), &node)
 
-	lowProxy := new(lowbase.SchemaProxy)
-	err := lowProxy.Build(context.Background(), nil, node.Content[0], idx)
-	assert.NoError(t, err)
+    lowProxy := new(lowbase.SchemaProxy)
+    err := lowProxy.Build(context.Background(), nil, node.Content[0], idx)
+    assert.NoError(t, err)
 
-	lowRef := low.NodeReference[*lowbase.SchemaProxy]{
-		Value: lowProxy,
-	}
+    lowRef := low.NodeReference[*lowbase.SchemaProxy]{
+        Value: lowProxy,
+    }
 
-	sp := NewSchemaProxy(&lowRef)
+    sp := NewSchemaProxy(&lowRef)
 
-	origin := sp.GetReferenceOrigin()
-	assert.Nil(t, origin)
+    origin := sp.GetReferenceOrigin()
+    assert.Nil(t, origin)
 
-	rend, _ := sp.Render()
-	assert.Equal(t, "$ref: '#/components/schemas/nice'", strings.TrimSpace(string(rend)))
+    rend, _ := sp.Render()
+    assert.Equal(t, "$ref: '#/components/schemas/nice'", strings.TrimSpace(string(rend)))
 }
 
 func TestCreateSchemaProxy(t *testing.T) {
-	sp := CreateSchemaProxy(&Schema{Description: "iAmASchema"})
-	assert.Equal(t, "iAmASchema", sp.rendered.Description)
-	assert.False(t, sp.IsReference())
+    sp := CreateSchemaProxy(&Schema{Description: "iAmASchema"})
+    assert.Equal(t, "iAmASchema", sp.rendered.Description)
+    assert.False(t, sp.IsReference())
 }
 
 func TestCreateSchemaProxyRef(t *testing.T) {
-	sp := CreateSchemaProxyRef("#/components/schemas/MySchema")
-	assert.Equal(t, "#/components/schemas/MySchema", sp.GetReference())
-	assert.True(t, sp.IsReference())
+    sp := CreateSchemaProxyRef("#/components/schemas/MySchema")
+    assert.Equal(t, "#/components/schemas/MySchema", sp.GetReference())
+    assert.True(t, sp.IsReference())
 }
 
 func TestSchemaProxy_GetReference(t *testing.T) {
-	refNode := utils.CreateStringNode("#/components/schemas/MySchema")
+    refNode := utils.CreateStringNode("#/components/schemas/MySchema")
 
-	ref := low.Reference{}
-	ref.SetReference("#/components/schemas/MySchema", refNode)
+    ref := low.Reference{}
+    ref.SetReference("#/components/schemas/MySchema", refNode)
 
-	sp := &SchemaProxy{
-		schema: &low.NodeReference[*lowbase.SchemaProxy]{
-			Value: &lowbase.SchemaProxy{
-				Reference: ref,
-			},
-		},
-	}
-	assert.Equal(t, "#/components/schemas/MySchema", sp.GetReference())
-	assert.Equal(t, refNode, sp.GetReferenceNode())
+    sp := &SchemaProxy{
+        schema: &low.NodeReference[*lowbase.SchemaProxy]{
+            Value: &lowbase.SchemaProxy{
+                Reference: ref,
+            },
+        },
+    }
+    assert.Equal(t, "#/components/schemas/MySchema", sp.GetReference())
+    assert.Equal(t, refNode, sp.GetReferenceNode())
 }
 
 func TestSchemaProxy_IsReference_Nil(t *testing.T) {
-	var sp *SchemaProxy
-	assert.False(t, sp.IsReference())
+    var sp *SchemaProxy
+    assert.False(t, sp.IsReference())
 }
 
 func TestSchemaProxy_NoSchema_GetOrigin(t *testing.T) {
-	sp := &SchemaProxy{}
-	assert.Nil(t, sp.GetReferenceOrigin())
+    sp := &SchemaProxy{}
+    assert.Nil(t, sp.GetReferenceOrigin())
 }
 
 func TestCreateSchemaProxyRef_GetReferenceNode(t *testing.T) {
-	refNode := utils.CreateRefNode("#/components/schemas/MySchema")
+    refNode := utils.CreateRefNode("#/components/schemas/MySchema")
 
-	sp := CreateSchemaProxyRef("#/components/schemas/MySchema")
-	assert.Equal(t, refNode, sp.GetReferenceNode())
+    sp := CreateSchemaProxyRef("#/components/schemas/MySchema")
+    assert.Equal(t, refNode, sp.GetReferenceNode())
 }
 
 func TestCreateRefNode_MarshalYAML(t *testing.T) {
-	ref := low.Reference{}
-	ref.SetReference("#/components/schemas/MySchema", nil)
+    ref := low.Reference{}
+    ref.SetReference("#/components/schemas/MySchema", nil)
 
-	sp := &SchemaProxy{
-		schema: &low.NodeReference[*lowbase.SchemaProxy]{
-			Value: &lowbase.SchemaProxy{
-				Reference: ref,
-			},
-		},
-	}
-	node, err := sp.MarshalYAML()
-	require.NoError(t, err)
-	assert.Equal(t, node, utils.CreateRefNode("#/components/schemas/MySchema"))
+    sp := &SchemaProxy{
+        schema: &low.NodeReference[*lowbase.SchemaProxy]{
+            Value: &lowbase.SchemaProxy{
+                Reference: ref,
+            },
+        },
+    }
+    node, err := sp.MarshalYAML()
+    require.NoError(t, err)
+    assert.Equal(t, node, utils.CreateRefNode("#/components/schemas/MySchema"))
+}
+
+func TestSchemaProxy_MarshalYAML_InlineCircular(t *testing.T) {
+    const ymlComponents = `openapi: 3.1
+components:
+  schemas:
+    spice:
+      properties:
+        ice:
+          $ref: '#/components/schemas/nice'
+    nice:
+      properties:
+        rice:
+          $ref: '#/components/schemas/nice'`
+
+    idx := func() *index.SpecIndex {
+        var idxNode yaml.Node
+        err := yaml.Unmarshal([]byte(ymlComponents), &idxNode)
+        assert.NoError(t, err)
+        return index.NewSpecIndexWithConfig(&idxNode, index.CreateOpenAPIIndexConfig())
+    }()
+
+    resolver := index.NewResolver(idx)
+    resolver.CheckForCircularReferences()
+
+    const ymlSchema = `properties:
+  rice:
+    $ref: '#/components/schemas/nice'`
+    var node yaml.Node
+    _ = yaml.Unmarshal([]byte(ymlSchema), &node)
+
+    lowProxy := new(lowbase.SchemaProxy)
+    err := lowProxy.Build(context.Background(), &node, node.Content[0], idx)
+    assert.NoError(t, err)
+
+    lowRef := low.NodeReference[*lowbase.SchemaProxy]{
+        Value:   lowProxy,
+        KeyNode: &node,
+    }
+
+    spEmpty := NewSchemaProxy(nil)
+    assert.Nil(t, spEmpty.GetSchemaKeyNode())
+
+    sp := NewSchemaProxy(&lowRef)
+    assert.NotNil(t, sp.GetSchemaKeyNode())
+
+    rend, _ := sp.MarshalYAMLInline()
+    assert.NotNil(t, rend)
 }

--- a/datamodel/high/node_builder.go
+++ b/datamodel/high/node_builder.go
@@ -450,6 +450,7 @@ func (n *NodeBuilder) AddYAMLNode(parent *yaml.Node, entry *nodes.NodeEntry) *ya
 			} else {
 				// try an inline render if we can, otherwise there is no option but to default to the
 				// full render.
+
 				if _, ko := r.(RenderableInline); ko {
 					rawRender, _ = r.(RenderableInline).MarshalYAMLInline()
 				} else {

--- a/datamodel/low/base/contact.go
+++ b/datamodel/low/base/contact.go
@@ -17,14 +17,16 @@ import (
 //	v2 - https://swagger.io/specification/v2/#contactObject
 //	v3 - https://spec.openapis.org/oas/v3.1.0#contact-object
 type Contact struct {
-	Name  low.NodeReference[string]
-	URL   low.NodeReference[string]
-	Email low.NodeReference[string]
+	Name    low.NodeReference[string]
+	URL     low.NodeReference[string]
+	Email   low.NodeReference[string]
+	KeyNode *yaml.Node
 	*low.Reference
 }
 
 // Build is not implemented for Contact (there is nothing to build).
-func (c *Contact) Build(_ context.Context, _, _ *yaml.Node, _ *index.SpecIndex) error {
+func (c *Contact) Build(_ context.Context, keyNode, _ *yaml.Node, _ *index.SpecIndex) error {
+	c.KeyNode = keyNode
 	c.Reference = new(low.Reference)
 	// not implemented.
 	return nil

--- a/datamodel/low/base/contact.go
+++ b/datamodel/low/base/contact.go
@@ -17,16 +17,18 @@ import (
 //	v2 - https://swagger.io/specification/v2/#contactObject
 //	v3 - https://spec.openapis.org/oas/v3.1.0#contact-object
 type Contact struct {
-	Name    low.NodeReference[string]
-	URL     low.NodeReference[string]
-	Email   low.NodeReference[string]
-	KeyNode *yaml.Node
+	Name     low.NodeReference[string]
+	URL      low.NodeReference[string]
+	Email    low.NodeReference[string]
+	KeyNode  *yaml.Node
+	RootNode *yaml.Node
 	*low.Reference
 }
 
 // Build is not implemented for Contact (there is nothing to build).
-func (c *Contact) Build(_ context.Context, keyNode, _ *yaml.Node, _ *index.SpecIndex) error {
+func (c *Contact) Build(_ context.Context, keyNode, root *yaml.Node, _ *index.SpecIndex) error {
 	c.KeyNode = keyNode
+	c.RootNode = root
 	c.Reference = new(low.Reference)
 	// not implemented.
 	return nil

--- a/datamodel/low/base/example.go
+++ b/datamodel/low/base/example.go
@@ -25,6 +25,7 @@ type Example struct {
 	Value         low.NodeReference[*yaml.Node]
 	ExternalValue low.NodeReference[string]
 	Extensions    *orderedmap.Map[low.KeyReference[string], low.ValueReference[*yaml.Node]]
+	KeyNode       *yaml.Node
 	*low.Reference
 }
 
@@ -55,7 +56,8 @@ func (ex *Example) Hash() [32]byte {
 }
 
 // Build extracts extensions and example value
-func (ex *Example) Build(_ context.Context, _, root *yaml.Node, _ *index.SpecIndex) error {
+func (ex *Example) Build(_ context.Context, keyNode, root *yaml.Node, _ *index.SpecIndex) error {
+	ex.KeyNode = keyNode
 	root = utils.NodeAlias(root)
 	utils.CheckForMergeNodes(root)
 	ex.Reference = new(low.Reference)

--- a/datamodel/low/base/example.go
+++ b/datamodel/low/base/example.go
@@ -26,6 +26,7 @@ type Example struct {
 	ExternalValue low.NodeReference[string]
 	Extensions    *orderedmap.Map[low.KeyReference[string], low.ValueReference[*yaml.Node]]
 	KeyNode       *yaml.Node
+	RootNode      *yaml.Node
 	*low.Reference
 }
 
@@ -59,6 +60,7 @@ func (ex *Example) Hash() [32]byte {
 func (ex *Example) Build(_ context.Context, keyNode, root *yaml.Node, _ *index.SpecIndex) error {
 	ex.KeyNode = keyNode
 	root = utils.NodeAlias(root)
+	ex.RootNode = root
 	utils.CheckForMergeNodes(root)
 	ex.Reference = new(low.Reference)
 	ex.Extensions = low.ExtractExtensions(root)

--- a/datamodel/low/base/external_doc.go
+++ b/datamodel/low/base/external_doc.go
@@ -26,6 +26,7 @@ type ExternalDoc struct {
 	URL         low.NodeReference[string]
 	Extensions  *orderedmap.Map[low.KeyReference[string], low.ValueReference[*yaml.Node]]
 	KeyNode     *yaml.Node
+	RootNode    *yaml.Node
 	*low.Reference
 }
 
@@ -38,6 +39,7 @@ func (ex *ExternalDoc) FindExtension(ext string) *low.ValueReference[*yaml.Node]
 func (ex *ExternalDoc) Build(_ context.Context, keyNode, root *yaml.Node, idx *index.SpecIndex) error {
 	ex.KeyNode = keyNode
 	root = utils.NodeAlias(root)
+	ex.RootNode = root
 	utils.CheckForMergeNodes(root)
 	ex.Reference = new(low.Reference)
 	ex.Extensions = low.ExtractExtensions(root)

--- a/datamodel/low/base/external_doc.go
+++ b/datamodel/low/base/external_doc.go
@@ -25,6 +25,7 @@ type ExternalDoc struct {
 	Description low.NodeReference[string]
 	URL         low.NodeReference[string]
 	Extensions  *orderedmap.Map[low.KeyReference[string], low.ValueReference[*yaml.Node]]
+	KeyNode     *yaml.Node
 	*low.Reference
 }
 
@@ -34,7 +35,8 @@ func (ex *ExternalDoc) FindExtension(ext string) *low.ValueReference[*yaml.Node]
 }
 
 // Build will extract extensions from the ExternalDoc instance.
-func (ex *ExternalDoc) Build(_ context.Context, _, root *yaml.Node, idx *index.SpecIndex) error {
+func (ex *ExternalDoc) Build(_ context.Context, keyNode, root *yaml.Node, idx *index.SpecIndex) error {
+	ex.KeyNode = keyNode
 	root = utils.NodeAlias(root)
 	utils.CheckForMergeNodes(root)
 	ex.Reference = new(low.Reference)

--- a/datamodel/low/base/info.go
+++ b/datamodel/low/base/info.go
@@ -33,6 +33,7 @@ type Info struct {
 	Version        low.NodeReference[string]
 	Extensions     *orderedmap.Map[low.KeyReference[string], low.ValueReference[*yaml.Node]]
 	KeyNode        *yaml.Node
+	RootNode       *yaml.Node
 	*low.Reference
 }
 
@@ -50,6 +51,7 @@ func (i *Info) GetExtensions() *orderedmap.Map[low.KeyReference[string], low.Val
 func (i *Info) Build(ctx context.Context, keyNode, root *yaml.Node, idx *index.SpecIndex) error {
 	i.KeyNode = keyNode
 	root = utils.NodeAlias(root)
+	i.RootNode = root
 	utils.CheckForMergeNodes(root)
 	i.Reference = new(low.Reference)
 	i.Extensions = low.ExtractExtensions(root)

--- a/datamodel/low/base/info.go
+++ b/datamodel/low/base/info.go
@@ -32,6 +32,7 @@ type Info struct {
 	License        low.NodeReference[*License]
 	Version        low.NodeReference[string]
 	Extensions     *orderedmap.Map[low.KeyReference[string], low.ValueReference[*yaml.Node]]
+	KeyNode        *yaml.Node
 	*low.Reference
 }
 
@@ -46,7 +47,8 @@ func (i *Info) GetExtensions() *orderedmap.Map[low.KeyReference[string], low.Val
 }
 
 // Build will extract out the Contact and Info objects from the supplied root node.
-func (i *Info) Build(ctx context.Context, _, root *yaml.Node, idx *index.SpecIndex) error {
+func (i *Info) Build(ctx context.Context, keyNode, root *yaml.Node, idx *index.SpecIndex) error {
+	i.KeyNode = keyNode
 	root = utils.NodeAlias(root)
 	utils.CheckForMergeNodes(root)
 	i.Reference = new(low.Reference)

--- a/datamodel/low/base/license.go
+++ b/datamodel/low/base/license.go
@@ -23,6 +23,7 @@ type License struct {
 	URL        low.NodeReference[string]
 	Identifier low.NodeReference[string]
 	KeyNode    *yaml.Node
+	RootNode   *yaml.Node
 	*low.Reference
 }
 
@@ -30,6 +31,7 @@ type License struct {
 func (l *License) Build(ctx context.Context, keyNode, root *yaml.Node, idx *index.SpecIndex) error {
 	l.KeyNode = keyNode
 	root = utils.NodeAlias(root)
+	l.RootNode = root
 	utils.CheckForMergeNodes(root)
 	l.Reference = new(low.Reference)
 	if l.URL.Value != "" && l.Identifier.Value != "" {

--- a/datamodel/low/base/license.go
+++ b/datamodel/low/base/license.go
@@ -22,11 +22,13 @@ type License struct {
 	Name       low.NodeReference[string]
 	URL        low.NodeReference[string]
 	Identifier low.NodeReference[string]
+	KeyNode    *yaml.Node
 	*low.Reference
 }
 
 // Build out a license, complain if both a URL and identifier are present as they are mutually exclusive
-func (l *License) Build(ctx context.Context, _, root *yaml.Node, idx *index.SpecIndex) error {
+func (l *License) Build(ctx context.Context, keyNode, root *yaml.Node, idx *index.SpecIndex) error {
+	l.KeyNode = keyNode
 	root = utils.NodeAlias(root)
 	utils.CheckForMergeNodes(root)
 	l.Reference = new(low.Reference)

--- a/datamodel/low/base/schema.go
+++ b/datamodel/low/base/schema.go
@@ -1188,7 +1188,8 @@ func buildSchema(ctx context.Context, schemas chan schemaProxyBuildResult, label
 				}
 			}
 		} else {
-			errors <- fmt.Errorf("build schema failed: unexpected node type: %s, line %d, col %d", valueNode.Tag, valueNode.Line, valueNode.Column)
+			errors <- fmt.Errorf("build schema failed: unexpected data type: '%s', line %d, col %d",
+				utils.MakeTagReadable(valueNode), valueNode.Line, valueNode.Column)
 		}
 	}
 }

--- a/datamodel/low/base/security_requirement.go
+++ b/datamodel/low/base/security_requirement.go
@@ -28,6 +28,7 @@ import (
 type SecurityRequirement struct {
 	Requirements low.ValueReference[*orderedmap.Map[low.KeyReference[string], low.ValueReference[[]low.ValueReference[string]]]]
 	KeyNode      *yaml.Node
+	RootNode     *yaml.Node
 	*low.Reference
 }
 
@@ -35,6 +36,7 @@ type SecurityRequirement struct {
 func (s *SecurityRequirement) Build(_ context.Context, keyNode, root *yaml.Node, _ *index.SpecIndex) error {
 	s.KeyNode = keyNode
 	root = utils.NodeAlias(root)
+	s.RootNode = root
 	utils.CheckForMergeNodes(root)
 	s.Reference = new(low.Reference)
 	var labelNode *yaml.Node

--- a/datamodel/low/base/security_requirement.go
+++ b/datamodel/low/base/security_requirement.go
@@ -27,11 +27,13 @@ import (
 //   - https://swagger.io/specification/#security-requirement-object
 type SecurityRequirement struct {
 	Requirements low.ValueReference[*orderedmap.Map[low.KeyReference[string], low.ValueReference[[]low.ValueReference[string]]]]
+	KeyNode      *yaml.Node
 	*low.Reference
 }
 
 // Build will extract security requirements from the node (the structure is odd, to be honest)
-func (s *SecurityRequirement) Build(_ context.Context, _, root *yaml.Node, _ *index.SpecIndex) error {
+func (s *SecurityRequirement) Build(_ context.Context, keyNode, root *yaml.Node, _ *index.SpecIndex) error {
+	s.KeyNode = keyNode
 	root = utils.NodeAlias(root)
 	utils.CheckForMergeNodes(root)
 	s.Reference = new(low.Reference)

--- a/datamodel/low/base/tag.go
+++ b/datamodel/low/base/tag.go
@@ -26,6 +26,7 @@ type Tag struct {
 	Description  low.NodeReference[string]
 	ExternalDocs low.NodeReference[*ExternalDoc]
 	Extensions   *orderedmap.Map[low.KeyReference[string], low.ValueReference[*yaml.Node]]
+	KeyNode      *yaml.Node
 	*low.Reference
 }
 
@@ -35,7 +36,8 @@ func (t *Tag) FindExtension(ext string) *low.ValueReference[*yaml.Node] {
 }
 
 // Build will extract extensions and external docs for the Tag.
-func (t *Tag) Build(ctx context.Context, _, root *yaml.Node, idx *index.SpecIndex) error {
+func (t *Tag) Build(ctx context.Context, keyNode, root *yaml.Node, idx *index.SpecIndex) error {
+	t.KeyNode = keyNode
 	root = utils.NodeAlias(root)
 	utils.CheckForMergeNodes(root)
 	t.Reference = new(low.Reference)

--- a/datamodel/low/base/tag.go
+++ b/datamodel/low/base/tag.go
@@ -27,6 +27,7 @@ type Tag struct {
 	ExternalDocs low.NodeReference[*ExternalDoc]
 	Extensions   *orderedmap.Map[low.KeyReference[string], low.ValueReference[*yaml.Node]]
 	KeyNode      *yaml.Node
+	RootNode     *yaml.Node
 	*low.Reference
 }
 
@@ -39,6 +40,7 @@ func (t *Tag) FindExtension(ext string) *low.ValueReference[*yaml.Node] {
 func (t *Tag) Build(ctx context.Context, keyNode, root *yaml.Node, idx *index.SpecIndex) error {
 	t.KeyNode = keyNode
 	root = utils.NodeAlias(root)
+	t.RootNode = root
 	utils.CheckForMergeNodes(root)
 	t.Reference = new(low.Reference)
 	t.Extensions = low.ExtractExtensions(root)

--- a/datamodel/low/v3/callback.go
+++ b/datamodel/low/v3/callback.go
@@ -27,6 +27,7 @@ type Callback struct {
 	Expression *orderedmap.Map[low.KeyReference[string], low.ValueReference[*PathItem]]
 	Extensions *orderedmap.Map[low.KeyReference[string], low.ValueReference[*yaml.Node]]
 	KeyNode    *yaml.Node
+	RootNode   *yaml.Node
 	*low.Reference
 }
 
@@ -44,6 +45,7 @@ func (cb *Callback) FindExpression(exp string) *low.ValueReference[*PathItem] {
 func (cb *Callback) Build(ctx context.Context, keyNode, root *yaml.Node, idx *index.SpecIndex) error {
 	cb.KeyNode = keyNode
 	root = utils.NodeAlias(root)
+	cb.RootNode = root
 	utils.CheckForMergeNodes(root)
 	cb.Reference = new(low.Reference)
 	cb.Extensions = low.ExtractExtensions(root)

--- a/datamodel/low/v3/callback.go
+++ b/datamodel/low/v3/callback.go
@@ -26,6 +26,7 @@ import (
 type Callback struct {
 	Expression *orderedmap.Map[low.KeyReference[string], low.ValueReference[*PathItem]]
 	Extensions *orderedmap.Map[low.KeyReference[string], low.ValueReference[*yaml.Node]]
+	KeyNode    *yaml.Node
 	*low.Reference
 }
 
@@ -40,7 +41,8 @@ func (cb *Callback) FindExpression(exp string) *low.ValueReference[*PathItem] {
 }
 
 // Build will extract extensions, expressions and PathItem objects for Callback
-func (cb *Callback) Build(ctx context.Context, _, root *yaml.Node, idx *index.SpecIndex) error {
+func (cb *Callback) Build(ctx context.Context, keyNode, root *yaml.Node, idx *index.SpecIndex) error {
+	cb.KeyNode = keyNode
 	root = utils.NodeAlias(root)
 	utils.CheckForMergeNodes(root)
 	cb.Reference = new(low.Reference)

--- a/datamodel/low/v3/create_document_test.go
+++ b/datamodel/low/v3/create_document_test.go
@@ -840,7 +840,7 @@ func TestCreateDocument_YamlAnchor(t *testing.T) {
 	assert.NotNil(t, postParams)
 	assert.Equal(t, 1, len(getParams))
 	assert.Equal(t, 1, len(postParams))
-	assert.Equal(t, getParams, postParams)
+	assert.Equal(t, getParams[0].ValueNode, postParams[0].ValueNode)
 
 	// check post request body
 	responses := examplePath.GetValue().Get.GetValue().GetResponses().Value.(*Responses)

--- a/datamodel/low/v3/create_document_test.go
+++ b/datamodel/low/v3/create_document_test.go
@@ -768,7 +768,7 @@ paths:
 	var err error
 	_, err = CreateDocumentFromConfig(info, &datamodel.DocumentConfiguration{})
 	assert.Equal(t,
-		"path item build failed: cannot find reference:  at line 4, col 10", err.Error())
+		"path item build failed: cannot find reference: '' at line 4, col 10", err.Error())
 }
 
 func TestCreateDocument_Tags_Errors(t *testing.T) {

--- a/datamodel/low/v3/encoding.go
+++ b/datamodel/low/v3/encoding.go
@@ -24,6 +24,7 @@ type Encoding struct {
 	Style         low.NodeReference[string]
 	Explode       low.NodeReference[bool]
 	AllowReserved low.NodeReference[bool]
+	KeyNode       *yaml.Node
 	*low.Reference
 }
 
@@ -50,7 +51,8 @@ func (en *Encoding) Hash() [32]byte {
 }
 
 // Build will extract all Header objects from supplied node.
-func (en *Encoding) Build(ctx context.Context, _, root *yaml.Node, idx *index.SpecIndex) error {
+func (en *Encoding) Build(ctx context.Context, keyNode, root *yaml.Node, idx *index.SpecIndex) error {
+	en.KeyNode = keyNode
 	root = utils.NodeAlias(root)
 	utils.CheckForMergeNodes(root)
 	en.Reference = new(low.Reference)

--- a/datamodel/low/v3/encoding.go
+++ b/datamodel/low/v3/encoding.go
@@ -25,6 +25,7 @@ type Encoding struct {
 	Explode       low.NodeReference[bool]
 	AllowReserved low.NodeReference[bool]
 	KeyNode       *yaml.Node
+	RootNode      *yaml.Node
 	*low.Reference
 }
 
@@ -54,6 +55,7 @@ func (en *Encoding) Hash() [32]byte {
 func (en *Encoding) Build(ctx context.Context, keyNode, root *yaml.Node, idx *index.SpecIndex) error {
 	en.KeyNode = keyNode
 	root = utils.NodeAlias(root)
+	en.RootNode = root
 	utils.CheckForMergeNodes(root)
 	en.Reference = new(low.Reference)
 	headers, hL, hN, err := low.ExtractMap[*Header](ctx, HeadersLabel, root, idx)

--- a/datamodel/low/v3/header.go
+++ b/datamodel/low/v3/header.go
@@ -32,6 +32,7 @@ type Header struct {
 	Examples        low.NodeReference[*orderedmap.Map[low.KeyReference[string], low.ValueReference[*base.Example]]]
 	Content         low.NodeReference[*orderedmap.Map[low.KeyReference[string], low.ValueReference[*MediaType]]]
 	Extensions      *orderedmap.Map[low.KeyReference[string], low.ValueReference[*yaml.Node]]
+	KeyNode         *yaml.Node
 	*low.Reference
 }
 
@@ -86,7 +87,8 @@ func (h *Header) Hash() [32]byte {
 }
 
 // Build will extract extensions, examples, schema and content/media types from node.
-func (h *Header) Build(ctx context.Context, _, root *yaml.Node, idx *index.SpecIndex) error {
+func (h *Header) Build(ctx context.Context, keyNode, root *yaml.Node, idx *index.SpecIndex) error {
+	h.KeyNode = keyNode
 	root = utils.NodeAlias(root)
 	utils.CheckForMergeNodes(root)
 	h.Reference = new(low.Reference)

--- a/datamodel/low/v3/header.go
+++ b/datamodel/low/v3/header.go
@@ -33,6 +33,7 @@ type Header struct {
 	Content         low.NodeReference[*orderedmap.Map[low.KeyReference[string], low.ValueReference[*MediaType]]]
 	Extensions      *orderedmap.Map[low.KeyReference[string], low.ValueReference[*yaml.Node]]
 	KeyNode         *yaml.Node
+	RootNode        *yaml.Node
 	*low.Reference
 }
 
@@ -90,6 +91,7 @@ func (h *Header) Hash() [32]byte {
 func (h *Header) Build(ctx context.Context, keyNode, root *yaml.Node, idx *index.SpecIndex) error {
 	h.KeyNode = keyNode
 	root = utils.NodeAlias(root)
+	h.RootNode = root
 	utils.CheckForMergeNodes(root)
 	h.Reference = new(low.Reference)
 	h.Extensions = low.ExtractExtensions(root)

--- a/datamodel/low/v3/link.go
+++ b/datamodel/low/v3/link.go
@@ -35,6 +35,7 @@ type Link struct {
 	Description  low.NodeReference[string]
 	Server       low.NodeReference[*Server]
 	Extensions   *orderedmap.Map[low.KeyReference[string], low.ValueReference[*yaml.Node]]
+	KeyNode      *yaml.Node
 	*low.Reference
 }
 
@@ -54,7 +55,8 @@ func (l *Link) FindExtension(ext string) *low.ValueReference[*yaml.Node] {
 }
 
 // Build will extract extensions and servers from the node.
-func (l *Link) Build(ctx context.Context, _, root *yaml.Node, idx *index.SpecIndex) error {
+func (l *Link) Build(ctx context.Context, keyNode, root *yaml.Node, idx *index.SpecIndex) error {
+	l.KeyNode = keyNode
 	root = utils.NodeAlias(root)
 	utils.CheckForMergeNodes(root)
 	l.Reference = new(low.Reference)

--- a/datamodel/low/v3/link.go
+++ b/datamodel/low/v3/link.go
@@ -4,15 +4,15 @@
 package v3
 
 import (
-    "context"
-    "crypto/sha256"
-    "strings"
+	"context"
+	"crypto/sha256"
+	"strings"
 
-    "github.com/pb33f/libopenapi/datamodel/low"
-    "github.com/pb33f/libopenapi/index"
-    "github.com/pb33f/libopenapi/orderedmap"
-    "github.com/pb33f/libopenapi/utils"
-    "gopkg.in/yaml.v3"
+	"github.com/pb33f/libopenapi/datamodel/low"
+	"github.com/pb33f/libopenapi/index"
+	"github.com/pb33f/libopenapi/orderedmap"
+	"github.com/pb33f/libopenapi/utils"
+	"gopkg.in/yaml.v3"
 )
 
 // Link represents a low-level OpenAPI 3+ Link object.
@@ -28,71 +28,71 @@ import (
 // in an operation and using them as parameters while invoking the linked operation.
 //   - https://spec.openapis.org/oas/v3.1.0#link-object
 type Link struct {
-    OperationRef low.NodeReference[string]
-    OperationId  low.NodeReference[string]
-    Parameters   low.NodeReference[*orderedmap.Map[low.KeyReference[string], low.ValueReference[string]]]
-    RequestBody  low.NodeReference[string]
-    Description  low.NodeReference[string]
-    Server       low.NodeReference[*Server]
-    Extensions   *orderedmap.Map[low.KeyReference[string], low.ValueReference[*yaml.Node]]
-    KeyNode      *yaml.Node
-    RootNode     *yaml.Node
-    *low.Reference
+	OperationRef low.NodeReference[string]
+	OperationId  low.NodeReference[string]
+	Parameters   low.NodeReference[*orderedmap.Map[low.KeyReference[string], low.ValueReference[string]]]
+	RequestBody  low.NodeReference[string]
+	Description  low.NodeReference[string]
+	Server       low.NodeReference[*Server]
+	Extensions   *orderedmap.Map[low.KeyReference[string], low.ValueReference[*yaml.Node]]
+	KeyNode      *yaml.Node
+	RootNode     *yaml.Node
+	*low.Reference
 }
 
 // GetExtensions returns all Link extensions and satisfies the low.HasExtensions interface.
 func (l *Link) GetExtensions() *orderedmap.Map[low.KeyReference[string], low.ValueReference[*yaml.Node]] {
-    return l.Extensions
+	return l.Extensions
 }
 
 // FindParameter will attempt to locate a parameter string value, using a parameter name input.
 func (l *Link) FindParameter(pName string) *low.ValueReference[string] {
-    return low.FindItemInOrderedMap[string](pName, l.Parameters.Value)
+	return low.FindItemInOrderedMap[string](pName, l.Parameters.Value)
 }
 
 // FindExtension will attempt to locate an extension with a specific key
 func (l *Link) FindExtension(ext string) *low.ValueReference[*yaml.Node] {
-    return low.FindItemInOrderedMap(ext, l.Extensions)
+	return low.FindItemInOrderedMap(ext, l.Extensions)
 }
 
 // Build will extract extensions and servers from the node.
 func (l *Link) Build(ctx context.Context, keyNode, root *yaml.Node, idx *index.SpecIndex) error {
-    l.KeyNode = keyNode
-    root = utils.NodeAlias(root)
-	
-    utils.CheckForMergeNodes(root)
-    l.Reference = new(low.Reference)
-    l.Extensions = low.ExtractExtensions(root)
-    // extract server.
-    ser, sErr := low.ExtractObject[*Server](ctx, ServerLabel, root, idx)
-    if sErr != nil {
-        return sErr
-    }
-    l.Server = ser
-    return nil
+	l.KeyNode = keyNode
+	root = utils.NodeAlias(root)
+
+	utils.CheckForMergeNodes(root)
+	l.Reference = new(low.Reference)
+	l.Extensions = low.ExtractExtensions(root)
+	// extract server.
+	ser, sErr := low.ExtractObject[*Server](ctx, ServerLabel, root, idx)
+	if sErr != nil {
+		return sErr
+	}
+	l.Server = ser
+	return nil
 }
 
 // Hash will return a consistent SHA256 Hash of the Link object
 func (l *Link) Hash() [32]byte {
-    var f []string
-    if l.Description.Value != "" {
-        f = append(f, l.Description.Value)
-    }
-    if l.OperationRef.Value != "" {
-        f = append(f, l.OperationRef.Value)
-    }
-    if l.OperationId.Value != "" {
-        f = append(f, l.OperationId.Value)
-    }
-    if l.RequestBody.Value != "" {
-        f = append(f, l.RequestBody.Value)
-    }
-    if l.Server.Value != nil {
-        f = append(f, low.GenerateHashString(l.Server.Value))
-    }
-    for pair := orderedmap.First(orderedmap.SortAlpha(l.Parameters.Value)); pair != nil; pair = pair.Next() {
-        f = append(f, pair.Value().Value)
-    }
-    f = append(f, low.HashExtensions(l.Extensions)...)
-    return sha256.Sum256([]byte(strings.Join(f, "|")))
+	var f []string
+	if l.Description.Value != "" {
+		f = append(f, l.Description.Value)
+	}
+	if l.OperationRef.Value != "" {
+		f = append(f, l.OperationRef.Value)
+	}
+	if l.OperationId.Value != "" {
+		f = append(f, l.OperationId.Value)
+	}
+	if l.RequestBody.Value != "" {
+		f = append(f, l.RequestBody.Value)
+	}
+	if l.Server.Value != nil {
+		f = append(f, low.GenerateHashString(l.Server.Value))
+	}
+	for pair := orderedmap.First(orderedmap.SortAlpha(l.Parameters.Value)); pair != nil; pair = pair.Next() {
+		f = append(f, pair.Value().Value)
+	}
+	f = append(f, low.HashExtensions(l.Extensions)...)
+	return sha256.Sum256([]byte(strings.Join(f, "|")))
 }

--- a/datamodel/low/v3/link.go
+++ b/datamodel/low/v3/link.go
@@ -4,15 +4,15 @@
 package v3
 
 import (
-	"context"
-	"crypto/sha256"
-	"strings"
+    "context"
+    "crypto/sha256"
+    "strings"
 
-	"github.com/pb33f/libopenapi/datamodel/low"
-	"github.com/pb33f/libopenapi/index"
-	"github.com/pb33f/libopenapi/orderedmap"
-	"github.com/pb33f/libopenapi/utils"
-	"gopkg.in/yaml.v3"
+    "github.com/pb33f/libopenapi/datamodel/low"
+    "github.com/pb33f/libopenapi/index"
+    "github.com/pb33f/libopenapi/orderedmap"
+    "github.com/pb33f/libopenapi/utils"
+    "gopkg.in/yaml.v3"
 )
 
 // Link represents a low-level OpenAPI 3+ Link object.
@@ -28,69 +28,71 @@ import (
 // in an operation and using them as parameters while invoking the linked operation.
 //   - https://spec.openapis.org/oas/v3.1.0#link-object
 type Link struct {
-	OperationRef low.NodeReference[string]
-	OperationId  low.NodeReference[string]
-	Parameters   low.NodeReference[*orderedmap.Map[low.KeyReference[string], low.ValueReference[string]]]
-	RequestBody  low.NodeReference[string]
-	Description  low.NodeReference[string]
-	Server       low.NodeReference[*Server]
-	Extensions   *orderedmap.Map[low.KeyReference[string], low.ValueReference[*yaml.Node]]
-	KeyNode      *yaml.Node
-	*low.Reference
+    OperationRef low.NodeReference[string]
+    OperationId  low.NodeReference[string]
+    Parameters   low.NodeReference[*orderedmap.Map[low.KeyReference[string], low.ValueReference[string]]]
+    RequestBody  low.NodeReference[string]
+    Description  low.NodeReference[string]
+    Server       low.NodeReference[*Server]
+    Extensions   *orderedmap.Map[low.KeyReference[string], low.ValueReference[*yaml.Node]]
+    KeyNode      *yaml.Node
+    RootNode     *yaml.Node
+    *low.Reference
 }
 
 // GetExtensions returns all Link extensions and satisfies the low.HasExtensions interface.
 func (l *Link) GetExtensions() *orderedmap.Map[low.KeyReference[string], low.ValueReference[*yaml.Node]] {
-	return l.Extensions
+    return l.Extensions
 }
 
 // FindParameter will attempt to locate a parameter string value, using a parameter name input.
 func (l *Link) FindParameter(pName string) *low.ValueReference[string] {
-	return low.FindItemInOrderedMap[string](pName, l.Parameters.Value)
+    return low.FindItemInOrderedMap[string](pName, l.Parameters.Value)
 }
 
 // FindExtension will attempt to locate an extension with a specific key
 func (l *Link) FindExtension(ext string) *low.ValueReference[*yaml.Node] {
-	return low.FindItemInOrderedMap(ext, l.Extensions)
+    return low.FindItemInOrderedMap(ext, l.Extensions)
 }
 
 // Build will extract extensions and servers from the node.
 func (l *Link) Build(ctx context.Context, keyNode, root *yaml.Node, idx *index.SpecIndex) error {
-	l.KeyNode = keyNode
-	root = utils.NodeAlias(root)
-	utils.CheckForMergeNodes(root)
-	l.Reference = new(low.Reference)
-	l.Extensions = low.ExtractExtensions(root)
-	// extract server.
-	ser, sErr := low.ExtractObject[*Server](ctx, ServerLabel, root, idx)
-	if sErr != nil {
-		return sErr
-	}
-	l.Server = ser
-	return nil
+    l.KeyNode = keyNode
+    root = utils.NodeAlias(root)
+	
+    utils.CheckForMergeNodes(root)
+    l.Reference = new(low.Reference)
+    l.Extensions = low.ExtractExtensions(root)
+    // extract server.
+    ser, sErr := low.ExtractObject[*Server](ctx, ServerLabel, root, idx)
+    if sErr != nil {
+        return sErr
+    }
+    l.Server = ser
+    return nil
 }
 
 // Hash will return a consistent SHA256 Hash of the Link object
 func (l *Link) Hash() [32]byte {
-	var f []string
-	if l.Description.Value != "" {
-		f = append(f, l.Description.Value)
-	}
-	if l.OperationRef.Value != "" {
-		f = append(f, l.OperationRef.Value)
-	}
-	if l.OperationId.Value != "" {
-		f = append(f, l.OperationId.Value)
-	}
-	if l.RequestBody.Value != "" {
-		f = append(f, l.RequestBody.Value)
-	}
-	if l.Server.Value != nil {
-		f = append(f, low.GenerateHashString(l.Server.Value))
-	}
-	for pair := orderedmap.First(orderedmap.SortAlpha(l.Parameters.Value)); pair != nil; pair = pair.Next() {
-		f = append(f, pair.Value().Value)
-	}
-	f = append(f, low.HashExtensions(l.Extensions)...)
-	return sha256.Sum256([]byte(strings.Join(f, "|")))
+    var f []string
+    if l.Description.Value != "" {
+        f = append(f, l.Description.Value)
+    }
+    if l.OperationRef.Value != "" {
+        f = append(f, l.OperationRef.Value)
+    }
+    if l.OperationId.Value != "" {
+        f = append(f, l.OperationId.Value)
+    }
+    if l.RequestBody.Value != "" {
+        f = append(f, l.RequestBody.Value)
+    }
+    if l.Server.Value != nil {
+        f = append(f, low.GenerateHashString(l.Server.Value))
+    }
+    for pair := orderedmap.First(orderedmap.SortAlpha(l.Parameters.Value)); pair != nil; pair = pair.Next() {
+        f = append(f, pair.Value().Value)
+    }
+    f = append(f, low.HashExtensions(l.Extensions)...)
+    return sha256.Sum256([]byte(strings.Join(f, "|")))
 }

--- a/datamodel/low/v3/media_type.go
+++ b/datamodel/low/v3/media_type.go
@@ -27,6 +27,7 @@ type MediaType struct {
 	Encoding   low.NodeReference[*orderedmap.Map[low.KeyReference[string], low.ValueReference[*Encoding]]]
 	Extensions *orderedmap.Map[low.KeyReference[string], low.ValueReference[*yaml.Node]]
 	KeyNode    *yaml.Node
+	RootNode   *yaml.Node
 	*low.Reference
 }
 
@@ -59,6 +60,7 @@ func (mt *MediaType) GetAllExamples() *orderedmap.Map[low.KeyReference[string], 
 func (mt *MediaType) Build(ctx context.Context, keyNode, root *yaml.Node, idx *index.SpecIndex) error {
 	mt.KeyNode = keyNode
 	root = utils.NodeAlias(root)
+	mt.RootNode = root
 	utils.CheckForMergeNodes(root)
 	mt.Reference = new(low.Reference)
 	mt.Extensions = low.ExtractExtensions(root)

--- a/datamodel/low/v3/media_type.go
+++ b/datamodel/low/v3/media_type.go
@@ -26,6 +26,7 @@ type MediaType struct {
 	Examples   low.NodeReference[*orderedmap.Map[low.KeyReference[string], low.ValueReference[*base.Example]]]
 	Encoding   low.NodeReference[*orderedmap.Map[low.KeyReference[string], low.ValueReference[*Encoding]]]
 	Extensions *orderedmap.Map[low.KeyReference[string], low.ValueReference[*yaml.Node]]
+	KeyNode    *yaml.Node
 	*low.Reference
 }
 
@@ -55,7 +56,8 @@ func (mt *MediaType) GetAllExamples() *orderedmap.Map[low.KeyReference[string], 
 }
 
 // Build will extract examples, extensions, schema and encoding from node.
-func (mt *MediaType) Build(ctx context.Context, _, root *yaml.Node, idx *index.SpecIndex) error {
+func (mt *MediaType) Build(ctx context.Context, keyNode, root *yaml.Node, idx *index.SpecIndex) error {
+	mt.KeyNode = keyNode
 	root = utils.NodeAlias(root)
 	utils.CheckForMergeNodes(root)
 	mt.Reference = new(low.Reference)

--- a/datamodel/low/v3/oauth_flows.go
+++ b/datamodel/low/v3/oauth_flows.go
@@ -24,6 +24,7 @@ type OAuthFlows struct {
 	ClientCredentials low.NodeReference[*OAuthFlow]
 	AuthorizationCode low.NodeReference[*OAuthFlow]
 	Extensions        *orderedmap.Map[low.KeyReference[string], low.ValueReference[*yaml.Node]]
+	KeyNode           *yaml.Node
 	*low.Reference
 }
 
@@ -38,7 +39,8 @@ func (o *OAuthFlows) FindExtension(ext string) *low.ValueReference[*yaml.Node] {
 }
 
 // Build will extract extensions and all OAuthFlow types from the supplied node.
-func (o *OAuthFlows) Build(ctx context.Context, _, root *yaml.Node, idx *index.SpecIndex) error {
+func (o *OAuthFlows) Build(ctx context.Context, keyNode, root *yaml.Node, idx *index.SpecIndex) error {
+	o.KeyNode = keyNode
 	root = utils.NodeAlias(root)
 	utils.CheckForMergeNodes(root)
 	o.Reference = new(low.Reference)

--- a/datamodel/low/v3/oauth_flows.go
+++ b/datamodel/low/v3/oauth_flows.go
@@ -25,6 +25,7 @@ type OAuthFlows struct {
 	AuthorizationCode low.NodeReference[*OAuthFlow]
 	Extensions        *orderedmap.Map[low.KeyReference[string], low.ValueReference[*yaml.Node]]
 	KeyNode           *yaml.Node
+	RootNode          *yaml.Node
 	*low.Reference
 }
 
@@ -42,6 +43,7 @@ func (o *OAuthFlows) FindExtension(ext string) *low.ValueReference[*yaml.Node] {
 func (o *OAuthFlows) Build(ctx context.Context, keyNode, root *yaml.Node, idx *index.SpecIndex) error {
 	o.KeyNode = keyNode
 	root = utils.NodeAlias(root)
+	o.RootNode = root
 	utils.CheckForMergeNodes(root)
 	o.Reference = new(low.Reference)
 	o.Extensions = low.ExtractExtensions(root)

--- a/datamodel/low/v3/operation.go
+++ b/datamodel/low/v3/operation.go
@@ -37,6 +37,7 @@ type Operation struct {
 	Security     low.NodeReference[[]low.ValueReference[*base.SecurityRequirement]]
 	Servers      low.NodeReference[[]low.ValueReference[*Server]]
 	Extensions   *orderedmap.Map[low.KeyReference[string], low.ValueReference[*yaml.Node]]
+	KeyNode      *yaml.Node
 	*low.Reference
 }
 
@@ -59,7 +60,8 @@ func (o *Operation) FindSecurityRequirement(name string) []low.ValueReference[st
 }
 
 // Build will extract external docs, parameters, request body, responses, callbacks, security and servers.
-func (o *Operation) Build(ctx context.Context, _, root *yaml.Node, idx *index.SpecIndex) error {
+func (o *Operation) Build(ctx context.Context, keyNode, root *yaml.Node, idx *index.SpecIndex) error {
+	o.KeyNode = keyNode
 	root = utils.NodeAlias(root)
 	utils.CheckForMergeNodes(root)
 	o.Reference = new(low.Reference)

--- a/datamodel/low/v3/operation.go
+++ b/datamodel/low/v3/operation.go
@@ -38,6 +38,7 @@ type Operation struct {
 	Servers      low.NodeReference[[]low.ValueReference[*Server]]
 	Extensions   *orderedmap.Map[low.KeyReference[string], low.ValueReference[*yaml.Node]]
 	KeyNode      *yaml.Node
+	RootNode     *yaml.Node
 	*low.Reference
 }
 
@@ -62,6 +63,7 @@ func (o *Operation) FindSecurityRequirement(name string) []low.ValueReference[st
 // Build will extract external docs, parameters, request body, responses, callbacks, security and servers.
 func (o *Operation) Build(ctx context.Context, keyNode, root *yaml.Node, idx *index.SpecIndex) error {
 	o.KeyNode = keyNode
+	o.RootNode = root
 	root = utils.NodeAlias(root)
 	utils.CheckForMergeNodes(root)
 	o.Reference = new(low.Reference)

--- a/datamodel/low/v3/parameter.go
+++ b/datamodel/low/v3/parameter.go
@@ -22,6 +22,7 @@ import (
 // A unique parameter is defined by a combination of a name and location.
 //   - https://spec.openapis.org/oas/v3.1.0#parameter-object
 type Parameter struct {
+	KeyNode         *yaml.Node
 	Name            low.NodeReference[string]
 	In              low.NodeReference[string]
 	Description     low.NodeReference[string]
@@ -60,8 +61,9 @@ func (p *Parameter) GetExtensions() *orderedmap.Map[low.KeyReference[string], lo
 }
 
 // Build will extract examples, extensions and content/media types.
-func (p *Parameter) Build(ctx context.Context, _, root *yaml.Node, idx *index.SpecIndex) error {
+func (p *Parameter) Build(ctx context.Context, keyNode, root *yaml.Node, idx *index.SpecIndex) error {
 	root = utils.NodeAlias(root)
+	p.KeyNode = keyNode
 	utils.CheckForMergeNodes(root)
 	p.Reference = new(low.Reference)
 	p.Extensions = low.ExtractExtensions(root)

--- a/datamodel/low/v3/parameter.go
+++ b/datamodel/low/v3/parameter.go
@@ -23,6 +23,7 @@ import (
 //   - https://spec.openapis.org/oas/v3.1.0#parameter-object
 type Parameter struct {
 	KeyNode         *yaml.Node
+	RootNode        *yaml.Node
 	Name            low.NodeReference[string]
 	In              low.NodeReference[string]
 	Description     low.NodeReference[string]
@@ -64,6 +65,7 @@ func (p *Parameter) GetExtensions() *orderedmap.Map[low.KeyReference[string], lo
 func (p *Parameter) Build(ctx context.Context, keyNode, root *yaml.Node, idx *index.SpecIndex) error {
 	root = utils.NodeAlias(root)
 	p.KeyNode = keyNode
+	p.RootNode = root
 	utils.CheckForMergeNodes(root)
 	p.Reference = new(low.Reference)
 	p.Extensions = low.ExtractExtensions(root)

--- a/datamodel/low/v3/path_item.go
+++ b/datamodel/low/v3/path_item.go
@@ -39,6 +39,7 @@ type PathItem struct {
 	Servers     low.NodeReference[[]low.ValueReference[*Server]]
 	Parameters  low.NodeReference[[]low.ValueReference[*Parameter]]
 	Extensions  *orderedmap.Map[low.KeyReference[string], low.ValueReference[*yaml.Node]]
+	KeyNode     *yaml.Node
 	*low.Reference
 }
 
@@ -103,7 +104,8 @@ func (p *PathItem) GetExtensions() *orderedmap.Map[low.KeyReference[string], low
 
 // Build extracts extensions, parameters, servers and each http method defined.
 // everything is extracted asynchronously for speed.
-func (p *PathItem) Build(ctx context.Context, _, root *yaml.Node, idx *index.SpecIndex) error {
+func (p *PathItem) Build(ctx context.Context, keyNode, root *yaml.Node, idx *index.SpecIndex) error {
+	p.KeyNode = keyNode
 	root = utils.NodeAlias(root)
 	utils.CheckForMergeNodes(root)
 	p.Reference = new(low.Reference)

--- a/datamodel/low/v3/path_item.go
+++ b/datamodel/low/v3/path_item.go
@@ -40,6 +40,7 @@ type PathItem struct {
 	Parameters  low.NodeReference[[]low.ValueReference[*Parameter]]
 	Extensions  *orderedmap.Map[low.KeyReference[string], low.ValueReference[*yaml.Node]]
 	KeyNode     *yaml.Node
+	RootNode    *yaml.Node
 	*low.Reference
 }
 
@@ -105,8 +106,9 @@ func (p *PathItem) GetExtensions() *orderedmap.Map[low.KeyReference[string], low
 // Build extracts extensions, parameters, servers and each http method defined.
 // everything is extracted asynchronously for speed.
 func (p *PathItem) Build(ctx context.Context, keyNode, root *yaml.Node, idx *index.SpecIndex) error {
-	p.KeyNode = keyNode
 	root = utils.NodeAlias(root)
+	p.KeyNode = keyNode
+	p.RootNode = root
 	utils.CheckForMergeNodes(root)
 	p.Reference = new(low.Reference)
 	p.Extensions = low.ExtractExtensions(root)

--- a/datamodel/low/v3/paths.go
+++ b/datamodel/low/v3/paths.go
@@ -27,6 +27,7 @@ import (
 type Paths struct {
 	PathItems  *orderedmap.Map[low.KeyReference[string], low.ValueReference[*PathItem]]
 	Extensions *orderedmap.Map[low.KeyReference[string], low.ValueReference[*yaml.Node]]
+	KeyNode    *yaml.Node
 	*low.Reference
 }
 
@@ -64,7 +65,8 @@ func (p *Paths) GetExtensions() *orderedmap.Map[low.KeyReference[string], low.Va
 }
 
 // Build will extract extensions and all PathItems. This happens asynchronously for speed.
-func (p *Paths) Build(ctx context.Context, _, root *yaml.Node, idx *index.SpecIndex) error {
+func (p *Paths) Build(ctx context.Context, keyNode, root *yaml.Node, idx *index.SpecIndex) error {
+	p.KeyNode = keyNode
 	root = utils.NodeAlias(root)
 	utils.CheckForMergeNodes(root)
 	p.Reference = new(low.Reference)

--- a/datamodel/low/v3/paths.go
+++ b/datamodel/low/v3/paths.go
@@ -173,7 +173,7 @@ func extractPathItemsMap(ctx context.Context, root *yaml.Node, idx *index.SpecIn
 						}
 					}
 				} else {
-					return buildResult{}, fmt.Errorf("path item build failed: cannot find reference: %s at line %d, col %d",
+					return buildResult{}, fmt.Errorf("path item build failed: cannot find reference: '%s' at line %d, col %d",
 						pNode.Content[1].Value, pNode.Content[1].Line, pNode.Content[1].Column)
 				}
 			}
@@ -183,7 +183,7 @@ func extractPathItemsMap(ctx context.Context, root *yaml.Node, idx *index.SpecIn
 			err := path.Build(foundContext, cNode, pNode, idx)
 			if err != nil {
 				if idx != nil && idx.GetLogger() != nil {
-					idx.GetLogger().Error(fmt.Sprintf("error building path item '%s'", err.Error()))
+					idx.GetLogger().Error(fmt.Sprintf("error building path item: %s", err.Error()))
 				}
 				// return buildResult{}, err
 			}

--- a/datamodel/low/v3/paths.go
+++ b/datamodel/low/v3/paths.go
@@ -28,6 +28,7 @@ type Paths struct {
 	PathItems  *orderedmap.Map[low.KeyReference[string], low.ValueReference[*PathItem]]
 	Extensions *orderedmap.Map[low.KeyReference[string], low.ValueReference[*yaml.Node]]
 	KeyNode    *yaml.Node
+	RootNode   *yaml.Node
 	*low.Reference
 }
 
@@ -66,8 +67,9 @@ func (p *Paths) GetExtensions() *orderedmap.Map[low.KeyReference[string], low.Va
 
 // Build will extract extensions and all PathItems. This happens asynchronously for speed.
 func (p *Paths) Build(ctx context.Context, keyNode, root *yaml.Node, idx *index.SpecIndex) error {
-	p.KeyNode = keyNode
 	root = utils.NodeAlias(root)
+	p.KeyNode = keyNode
+	p.RootNode = root
 	utils.CheckForMergeNodes(root)
 	p.Reference = new(low.Reference)
 	p.Extensions = low.ExtractExtensions(root)

--- a/datamodel/low/v3/paths_test.go
+++ b/datamodel/low/v3/paths_test.go
@@ -222,7 +222,7 @@ func TestPaths_Build_BadParams(t *testing.T) {
 
 	_ = n.Build(context.Background(), nil, idxNode.Content[0], idx)
 	er := buf.String()
-	assert.Contains(t, er, "array build failed, input is not an array, line 3, column 5'")
+	assert.Contains(t, er, "array build failed, input is not an array, line 3, column 5")
 }
 
 func TestPaths_Build_BadRef(t *testing.T) {
@@ -259,7 +259,7 @@ func TestPaths_Build_BadRef(t *testing.T) {
 
 	_ = n.Build(context.Background(), nil, idxNode.Content[0], idx)
 	assert.Contains(t, buf.String(), "unable to locate reference anywhere in the rolodex\" reference=#/no-where")
-	assert.Contains(t, buf.String(), "error building path item 'path item build failed: cannot find reference: #/no-where at line 4, col 10'")
+	assert.Contains(t, buf.String(), "error building path item: path item build failed: cannot find reference: #/no-where at line 4, col 10")
 }
 
 func TestPathItem_Build_GoodRef(t *testing.T) {
@@ -327,7 +327,7 @@ func TestPathItem_Build_BadRef(t *testing.T) {
 
 	_ = n.Build(context.Background(), nil, idxNode.Content[0], idx)
 	assert.Contains(t, buf.String(), "unable to locate reference anywhere in the rolodex\" reference=#/~1cakes/NotFound")
-	assert.Contains(t, buf.String(), "error building path item 'path item build failed: cannot find reference: #/~1another~1path/get at line 4, col 10")
+	assert.Contains(t, buf.String(), "error building path item: path item build failed: cannot find reference: #/~1another~1path/get at line 4, col 10")
 }
 
 func TestPathNoOps(t *testing.T) {
@@ -459,7 +459,7 @@ func TestPath_Build_Using_CircularRefWithOp(t *testing.T) {
 	assert.NoError(t, err)
 
 	_ = n.Build(context.Background(), nil, rootNode.Content[0], idx)
-	assert.Contains(t, buf.String(), "error building path item 'build schema failed: circular reference 'post -> post -> post' found during lookup at line 4, column 7, It cannot be resolved'")
+	assert.Contains(t, buf.String(), "error building path item: build schema failed: circular reference 'post -> post -> post' found during lookup at line 4, column 7, It cannot be resolved")
 }
 
 func TestPaths_Build_BrokenOp(t *testing.T) {
@@ -486,7 +486,7 @@ func TestPaths_Build_BrokenOp(t *testing.T) {
 	assert.NoError(t, err)
 
 	_ = n.Build(context.Background(), nil, idxNode.Content[0], idx)
-	assert.Contains(t, buf.String(), "error building path item 'object extraction failed: reference at line 4, column 7 is empty, it cannot be resolved'")
+	assert.Contains(t, buf.String(), "error building path item: object extraction failed: reference at line 4, column 7 is empty, it cannot be resolved")
 }
 
 func TestPaths_Hash(t *testing.T) {

--- a/datamodel/low/v3/request_body.go
+++ b/datamodel/low/v3/request_body.go
@@ -24,6 +24,7 @@ type RequestBody struct {
 	Required    low.NodeReference[bool]
 	Extensions  *orderedmap.Map[low.KeyReference[string], low.ValueReference[*yaml.Node]]
 	KeyNode     *yaml.Node
+	RootNode    *yaml.Node
 	*low.Reference
 }
 
@@ -46,6 +47,7 @@ func (rb *RequestBody) FindContent(cType string) *low.ValueReference[*MediaType]
 func (rb *RequestBody) Build(ctx context.Context, keyNode, root *yaml.Node, idx *index.SpecIndex) error {
 	rb.KeyNode = keyNode
 	root = utils.NodeAlias(root)
+	rb.RootNode = root
 	utils.CheckForMergeNodes(root)
 	rb.Reference = new(low.Reference)
 	rb.Extensions = low.ExtractExtensions(root)

--- a/datamodel/low/v3/request_body.go
+++ b/datamodel/low/v3/request_body.go
@@ -23,6 +23,7 @@ type RequestBody struct {
 	Content     low.NodeReference[*orderedmap.Map[low.KeyReference[string], low.ValueReference[*MediaType]]]
 	Required    low.NodeReference[bool]
 	Extensions  *orderedmap.Map[low.KeyReference[string], low.ValueReference[*yaml.Node]]
+	KeyNode     *yaml.Node
 	*low.Reference
 }
 
@@ -42,7 +43,8 @@ func (rb *RequestBody) FindContent(cType string) *low.ValueReference[*MediaType]
 }
 
 // Build will extract extensions and MediaType objects from the node.
-func (rb *RequestBody) Build(ctx context.Context, _, root *yaml.Node, idx *index.SpecIndex) error {
+func (rb *RequestBody) Build(ctx context.Context, keyNode, root *yaml.Node, idx *index.SpecIndex) error {
+	rb.KeyNode = keyNode
 	root = utils.NodeAlias(root)
 	utils.CheckForMergeNodes(root)
 	rb.Reference = new(low.Reference)

--- a/datamodel/low/v3/response.go
+++ b/datamodel/low/v3/response.go
@@ -28,6 +28,7 @@ type Response struct {
 	Extensions  *orderedmap.Map[low.KeyReference[string], low.ValueReference[*yaml.Node]]
 	Links       low.NodeReference[*orderedmap.Map[low.KeyReference[string], low.ValueReference[*Link]]]
 	KeyNode     *yaml.Node
+	RootNode    *yaml.Node
 	*low.Reference
 }
 
@@ -60,6 +61,7 @@ func (r *Response) FindLink(hType string) *low.ValueReference[*Link] {
 func (r *Response) Build(ctx context.Context, keyNode, root *yaml.Node, idx *index.SpecIndex) error {
 	r.KeyNode = keyNode
 	root = utils.NodeAlias(root)
+	r.RootNode = root
 	utils.CheckForMergeNodes(root)
 	r.Reference = new(low.Reference)
 	r.Extensions = low.ExtractExtensions(root)

--- a/datamodel/low/v3/response.go
+++ b/datamodel/low/v3/response.go
@@ -27,6 +27,7 @@ type Response struct {
 	Content     low.NodeReference[*orderedmap.Map[low.KeyReference[string], low.ValueReference[*MediaType]]]
 	Extensions  *orderedmap.Map[low.KeyReference[string], low.ValueReference[*yaml.Node]]
 	Links       low.NodeReference[*orderedmap.Map[low.KeyReference[string], low.ValueReference[*Link]]]
+	KeyNode     *yaml.Node
 	*low.Reference
 }
 
@@ -56,7 +57,8 @@ func (r *Response) FindLink(hType string) *low.ValueReference[*Link] {
 }
 
 // Build will extract headers, extensions, content and links from node.
-func (r *Response) Build(ctx context.Context, _, root *yaml.Node, idx *index.SpecIndex) error {
+func (r *Response) Build(ctx context.Context, keyNode, root *yaml.Node, idx *index.SpecIndex) error {
+	r.KeyNode = keyNode
 	root = utils.NodeAlias(root)
 	utils.CheckForMergeNodes(root)
 	r.Reference = new(low.Reference)

--- a/datamodel/low/v3/responses.go
+++ b/datamodel/low/v3/responses.go
@@ -39,6 +39,7 @@ type Responses struct {
 	Default    low.NodeReference[*Response]
 	Extensions *orderedmap.Map[low.KeyReference[string], low.ValueReference[*yaml.Node]]
 	KeyNode    *yaml.Node
+	RootNode   *yaml.Node
 	*low.Reference
 }
 
@@ -51,6 +52,7 @@ func (r *Responses) GetExtensions() *orderedmap.Map[low.KeyReference[string], lo
 func (r *Responses) Build(ctx context.Context, keyNode, root *yaml.Node, idx *index.SpecIndex) error {
 	r.KeyNode = keyNode
 	root = utils.NodeAlias(root)
+	r.RootNode = root
 	r.Reference = new(low.Reference)
 	r.Extensions = low.ExtractExtensions(root)
 	utils.CheckForMergeNodes(root)

--- a/datamodel/low/v3/responses.go
+++ b/datamodel/low/v3/responses.go
@@ -38,6 +38,7 @@ type Responses struct {
 	Codes      *orderedmap.Map[low.KeyReference[string], low.ValueReference[*Response]]
 	Default    low.NodeReference[*Response]
 	Extensions *orderedmap.Map[low.KeyReference[string], low.ValueReference[*yaml.Node]]
+	KeyNode    *yaml.Node
 	*low.Reference
 }
 
@@ -47,7 +48,8 @@ func (r *Responses) GetExtensions() *orderedmap.Map[low.KeyReference[string], lo
 }
 
 // Build will extract default response and all Response objects for each code
-func (r *Responses) Build(ctx context.Context, _, root *yaml.Node, idx *index.SpecIndex) error {
+func (r *Responses) Build(ctx context.Context, keyNode, root *yaml.Node, idx *index.SpecIndex) error {
+	r.KeyNode = keyNode
 	root = utils.NodeAlias(root)
 	r.Reference = new(low.Reference)
 	r.Extensions = low.ExtractExtensions(root)

--- a/datamodel/low/v3/security_scheme.go
+++ b/datamodel/low/v3/security_scheme.go
@@ -36,6 +36,7 @@ type SecurityScheme struct {
 	OpenIdConnectUrl low.NodeReference[string]
 	Extensions       *orderedmap.Map[low.KeyReference[string], low.ValueReference[*yaml.Node]]
 	KeyNode          *yaml.Node
+	RootNode         *yaml.Node
 	*low.Reference
 }
 
@@ -53,6 +54,7 @@ func (ss *SecurityScheme) GetExtensions() *orderedmap.Map[low.KeyReference[strin
 func (ss *SecurityScheme) Build(ctx context.Context, keyNode, root *yaml.Node, idx *index.SpecIndex) error {
 	ss.KeyNode = keyNode
 	root = utils.NodeAlias(root)
+	ss.RootNode = root
 	utils.CheckForMergeNodes(root)
 	ss.Reference = new(low.Reference)
 	ss.Extensions = low.ExtractExtensions(root)

--- a/datamodel/low/v3/security_scheme.go
+++ b/datamodel/low/v3/security_scheme.go
@@ -35,6 +35,7 @@ type SecurityScheme struct {
 	Flows            low.NodeReference[*OAuthFlows]
 	OpenIdConnectUrl low.NodeReference[string]
 	Extensions       *orderedmap.Map[low.KeyReference[string], low.ValueReference[*yaml.Node]]
+	KeyNode          *yaml.Node
 	*low.Reference
 }
 
@@ -49,7 +50,8 @@ func (ss *SecurityScheme) GetExtensions() *orderedmap.Map[low.KeyReference[strin
 }
 
 // Build will extract OAuthFlows and extensions from the node.
-func (ss *SecurityScheme) Build(ctx context.Context, _, root *yaml.Node, idx *index.SpecIndex) error {
+func (ss *SecurityScheme) Build(ctx context.Context, keyNode, root *yaml.Node, idx *index.SpecIndex) error {
+	ss.KeyNode = keyNode
 	root = utils.NodeAlias(root)
 	utils.CheckForMergeNodes(root)
 	ss.Reference = new(low.Reference)

--- a/datamodel/low/v3/server.go
+++ b/datamodel/low/v3/server.go
@@ -23,6 +23,7 @@ type Server struct {
 	Variables   low.NodeReference[*orderedmap.Map[low.KeyReference[string], low.ValueReference[*ServerVariable]]]
 	Extensions  *orderedmap.Map[low.KeyReference[string], low.ValueReference[*yaml.Node]]
 	KeyNode     *yaml.Node
+	RootNode    *yaml.Node
 	*low.Reference
 }
 
@@ -40,6 +41,7 @@ func (s *Server) FindVariable(serverVar string) *low.ValueReference[*ServerVaria
 func (s *Server) Build(_ context.Context, keyNode, root *yaml.Node, _ *index.SpecIndex) error {
 	s.KeyNode = keyNode
 	root = utils.NodeAlias(root)
+	s.RootNode = root
 	utils.CheckForMergeNodes(root)
 	s.Reference = new(low.Reference)
 	s.Extensions = low.ExtractExtensions(root)

--- a/datamodel/low/v3/server.go
+++ b/datamodel/low/v3/server.go
@@ -22,6 +22,7 @@ type Server struct {
 	Description low.NodeReference[string]
 	Variables   low.NodeReference[*orderedmap.Map[low.KeyReference[string], low.ValueReference[*ServerVariable]]]
 	Extensions  *orderedmap.Map[low.KeyReference[string], low.ValueReference[*yaml.Node]]
+	KeyNode     *yaml.Node
 	*low.Reference
 }
 
@@ -36,7 +37,8 @@ func (s *Server) FindVariable(serverVar string) *low.ValueReference[*ServerVaria
 }
 
 // Build will extract server variables from the supplied node.
-func (s *Server) Build(_ context.Context, _, root *yaml.Node, _ *index.SpecIndex) error {
+func (s *Server) Build(_ context.Context, keyNode, root *yaml.Node, _ *index.SpecIndex) error {
+	s.KeyNode = keyNode
 	root = utils.NodeAlias(root)
 	utils.CheckForMergeNodes(root)
 	s.Reference = new(low.Reference)

--- a/datamodel/spec_info.go
+++ b/datamodel/spec_info.go
@@ -7,11 +7,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
-	"time"
-
 	"github.com/pb33f/libopenapi/utils"
 	"gopkg.in/yaml.v3"
+	"strings"
+	"time"
 )
 
 const (

--- a/index/extract_refs.go
+++ b/index/extract_refs.go
@@ -529,8 +529,8 @@ func (index *SpecIndex) ExtractRefs(node, parent *yaml.Node, seenPath []string, 
 					}
 				}
 
-				seenPath = append(seenPath, strings.ReplaceAll(n.Value, "/", "~1"))
-				//seenPath = append(seenPath, n.Value)
+				//seenPath = append(seenPath, strings.ReplaceAll(n.Value, "/", "~1"))
+				seenPath = append(seenPath, n.Value)
 				prev = n.Value
 			}
 

--- a/index/resolver.go
+++ b/index/resolver.go
@@ -743,7 +743,6 @@ func (resolver *Resolver) extractRelatives(ref *Reference, node, parent *yaml.No
 							v := node.Content[i+1].Content[q]
 							if utils.IsNodeMap(v) {
 								if d, _, l := utils.IsNodeRefValue(v); d {
-
 									// create full definition lookup based on ref.
 									def := l
 									exp := strings.Split(l, "#/")
@@ -853,6 +852,10 @@ func (resolver *Resolver) extractRelatives(ref *Reference, node, parent *yaml.No
 											}
 										}
 									}
+								} else {
+									depth++
+									found = append(found, resolver.extractRelatives(ref, v, n,
+										foundRelatives, journey, seen, resolve, depth)...)
 								}
 							}
 						}

--- a/index/rolodex_test.go
+++ b/index/rolodex_test.go
@@ -221,7 +221,7 @@ func TestRolodex_LocalNonNativeRemoteFS_ReadFile(t *testing.T) {
 	assert.Nil(t, r.GetIndex())
 	assert.Equal(t, "pizza", r.GetContent())
 	assert.Equal(t, "http://localhost/goodstat.yaml", r.GetFullPath())
-	assert.Equal(t, time.Now().UnixMilli(), r.ModTime().UnixMilli())
+	assert.Greater(t, r.ModTime().UnixMilli(), int64(1))
 	assert.Equal(t, int64(5), r.Size())
 	assert.False(t, r.IsDir())
 	assert.Nil(t, r.Sys())

--- a/index/spec_index.go
+++ b/index/spec_index.go
@@ -971,7 +971,7 @@ func (index *SpecIndex) GetOperationCount() int {
 							Definition: m.Value,
 							Name:       m.Value,
 							Node:       method.Content[y+1],
-							Path:       fmt.Sprintf("$.paths.%s.%s", p.Value, m.Value),
+							Path:       fmt.Sprintf("$.paths['%s'].%s", p.Value, m.Value),
 							ParentNode: m,
 						}
 						if locatedPathRefs[p.Value] == nil {
@@ -1039,7 +1039,7 @@ func (index *SpecIndex) GetOperationsParameterCount() int {
 								Name:       serverRef.Value,
 								Node:       serverRef,
 								ParentNode: prop,
-								Path:       fmt.Sprintf("$.paths.%s.servers[%d]", pathItemNode.Value, i),
+								Path:       fmt.Sprintf("$.paths['%s'].servers[%d]", pathItemNode.Value, i),
 							}
 							serverRefs = append(serverRefs, ref)
 						}
@@ -1123,7 +1123,7 @@ func (index *SpecIndex) GetOperationsParameterCount() int {
 											Name:       "servers",
 											Node:       serverRef,
 											ParentNode: httpMethodProp,
-											Path:       fmt.Sprintf("$.paths.%s.%s.servers[%d]", pathItemNode.Value, prop.Value, i),
+											Path:       fmt.Sprintf("$.paths['%s'].%s.servers[%d]", pathItemNode.Value, prop.Value, i),
 										}
 										serverRefs = append(serverRefs, ref)
 									}

--- a/index/spec_index_test.go
+++ b/index/spec_index_test.go
@@ -1214,7 +1214,7 @@ components:
 				assert.Equal(t, "$.components.parameters.param2", params["/"]["get"]["#/components/parameters/param2"][0].Path)
 			}
 			if assert.Contains(t, params["/"]["get"], "test") {
-				assert.Equal(t, "$.paths./.get.parameters[2]", params["/"]["get"]["test"][0].Path)
+				assert.Equal(t, "$.paths['/'].get.parameters[2]", params["/"]["get"]["test"][0].Path)
 			}
 		}
 	}
@@ -1255,7 +1255,7 @@ paths:
 					opPath = ""
 				}
 
-				assert.Equal(t, fmt.Sprintf("$.paths.%s%s.servers[%d]", path, opPath, i), server.Path)
+				assert.Equal(t, fmt.Sprintf("$.paths['%s']%s.servers[%d]", path, opPath, i), server.Path)
 			}
 		}
 	}
@@ -1278,7 +1278,7 @@ func TestSpecIndex_schemaComponentsHaveParentsAndPaths(t *testing.T) {
 
 	for _, schema := range schemas {
 		assert.NotNil(t, schema.ParentNode)
-		assert.Equal(t, fmt.Sprintf("$.components.schemas.%s", schema.Name), schema.Path)
+		assert.Equal(t, fmt.Sprintf("$.components.schemas['%s']", schema.Name), schema.Path)
 	}
 }
 
@@ -1497,12 +1497,12 @@ paths:
 
 	paths := idx.GetAllPaths()
 
-	assert.Equal(t, "$.paths./test.get", paths["/test"]["get"].Path)
+	assert.Equal(t, "$.paths['/test'].get", paths["/test"]["get"].Path)
 	assert.Equal(t, 9, paths["/test"]["get"].ParentNode.Line)
-	assert.Equal(t, "$.paths./test.post", paths["/test"]["post"].Path)
+	assert.Equal(t, "$.paths['/test'].post", paths["/test"]["post"].Path)
 	assert.Equal(t, 13, paths["/test"]["post"].ParentNode.Line)
-	assert.Equal(t, "$.paths./test2.delete", paths["/test2"]["delete"].Path)
+	assert.Equal(t, "$.paths['/test2'].delete", paths["/test2"]["delete"].Path)
 	assert.Equal(t, 18, paths["/test2"]["delete"].ParentNode.Line)
-	assert.Equal(t, "$.paths./test2.put", paths["/test2"]["put"].Path)
+	assert.Equal(t, "$.paths['/test2'].put", paths["/test2"]["put"].Path)
 	assert.Equal(t, 22, paths["/test2"]["put"].ParentNode.Line)
 }

--- a/index/utility_methods.go
+++ b/index/utility_methods.go
@@ -30,7 +30,7 @@ func (index *SpecIndex) extractDefinitionsAndSchemas(schemasNode *yaml.Node, pat
 			Definition:            def,
 			Name:                  name,
 			Node:                  schema,
-			Path:                  fmt.Sprintf("$.components.schemas.%s", name),
+			Path:                  fmt.Sprintf("$.components.schemas['%s']", name),
 			ParentNode:            schemasNode,
 			RequiredRefProperties: extractDefinitionRequiredRefProperties(schemasNode, map[string][]string{}, fullDef, index),
 		}
@@ -384,9 +384,9 @@ func (index *SpecIndex) scanOperationParams(params []*yaml.Node, pathItemNode *y
 
 			// if this is a duplicate, add an error and ignore it
 			if index.paramOpRefs[pathItemNode.Value][method][paramRefName] != nil {
-				path := fmt.Sprintf("$.paths.%s.%s.parameters[%d]", pathItemNode.Value, method, i)
+				path := fmt.Sprintf("$.paths['%s'].%s.parameters[%d]", pathItemNode.Value, method, i)
 				if method == "top" {
-					path = fmt.Sprintf("$.paths.%s.parameters[%d]", pathItemNode.Value, i)
+					path = fmt.Sprintf("$.paths['%s'].parameters[%d]", pathItemNode.Value, i)
 				}
 
 				index.operationParamErrors = append(index.operationParamErrors, &IndexingError{
@@ -408,9 +408,9 @@ func (index *SpecIndex) scanOperationParams(params []*yaml.Node, pathItemNode *y
 			// param is inline.
 			_, vn := utils.FindKeyNode("name", param.Content)
 
-			path := fmt.Sprintf("$.paths.%s.%s.parameters[%d]", pathItemNode.Value, method, i)
+			path := fmt.Sprintf("$.paths['%s'].%s.parameters[%d]", pathItemNode.Value, method, i)
 			if method == "top" {
-				path = fmt.Sprintf("$.paths.%s.parameters[%d]", pathItemNode.Value, i)
+				path = fmt.Sprintf("$.paths['%s'].parameters[%d]", pathItemNode.Value, i)
 			}
 
 			if vn == nil {
@@ -452,9 +452,9 @@ func (index *SpecIndex) scanOperationParams(params []*yaml.Node, pathItemNode *y
 
 					if currentIn != nil && checkIn != nil && currentIn.Value == checkIn.Value {
 
-						path := fmt.Sprintf("$.paths.%s.%s.parameters[%d]", pathItemNode.Value, method, i)
+						path := fmt.Sprintf("$.paths['%s'].%s.parameters[%d]", pathItemNode.Value, method, i)
 						if method == "top" {
-							path = fmt.Sprintf("$.paths.%s.parameters[%d]", pathItemNode.Value, i)
+							path = fmt.Sprintf("$.paths['%s'].parameters[%d]", pathItemNode.Value, i)
 						}
 
 						index.operationParamErrors = append(index.operationParamErrors, &IndexingError{

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -114,24 +114,17 @@ func FindNodesWithoutDeserializing(node *yaml.Node, jsonPath string) ([]*yaml.No
 
 	// this can spin out, to lets gatekeep it.
 	done := make(chan bool)
-	eChan := make(chan error)
 	var results []*yaml.Node
 	timeout, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
-	go func(d chan bool, e chan error) {
-		var er error
-		results, er = path.Find(node)
-		if er != nil {
-			e <- er
-		}
+	go func(d chan bool) {
+		results, _ = path.Find(node)
 		done <- true
-	}(done, eChan)
+	}(done)
 
 	select {
 	case <-done:
 		return results, nil
-	case er := <-eChan:
-		return nil, er
 	case <-timeout.Done():
 		return nil, fmt.Errorf("node lookup timeout exceeded")
 	}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -913,3 +913,20 @@ func TestDetermineJSONWhitespaceLength_None(t *testing.T) {
 	someBytes := []byte(`{"hello": "world"}`)
 	assert.Equal(t, 0, DetermineWhitespaceLength(string(someBytes)))
 }
+
+func TestTimeoutFind(t *testing.T) {
+	a := &yaml.Node{
+		Value: "chicken",
+	}
+	b := &yaml.Node{
+		Value: "nuggets",
+	}
+
+	// loopy loop.
+	a.Content = append(a.Content, b)
+	b.Content = append(b.Content, a)
+
+	nodes, err := FindNodesWithoutDeserializing(a, "$..nuggets")
+	assert.Error(t, err)
+	assert.Nil(t, nodes)
+}


### PR DESCRIPTION
No new features, however a deeper check for circular references was added after being discovered in the wild. Also the `RootNode` and `KeyNode` values of all low level model objects are now available. 

Added a check to prevent run-away schema rendering when operating recursively.

Added a timeout guard to any JSON Path lookups in utils. 
