### PR TITLE
Missing Line and Column Information in model.ChangeContext for Enum Changes fix

### DIFF
--- a/what-changed/model/comparison_functions.go
+++ b/what-changed/model/comparison_functions.go
@@ -405,7 +405,9 @@ func ExtractStringValueSliceChanges(lParam, rParam []low.ValueReference[string],
 
 func toString(v any) string {
 	if y, ok := v.(*yaml.Node); ok {
-		_ = y.Encode(&v)
+		copy := *y
+		_ = copy.Encode(&copy)
+		return fmt.Sprint(copy)
 	}
 
 	return fmt.Sprint(v)

--- a/what-changed/model/schema_test.go
+++ b/what-changed/model/schema_test.go
@@ -460,6 +460,8 @@ components:
 	assert.Equal(t, PropertyAdded, changes.Changes[0].ChangeType)
 	assert.Equal(t, "d", changes.Changes[0].New)
 	assert.Equal(t, v3.EnumLabel, changes.Changes[0].Property)
+	assert.Equal(t, 5, *changes.GetAllChanges()[0].Context.NewLine)
+	assert.Equal(t, 20, *changes.GetAllChanges()[0].Context.NewColumn)
 }
 
 func TestCompareSchemas_EnumRemoved(t *testing.T) {
@@ -488,6 +490,8 @@ components:
 	assert.Equal(t, PropertyRemoved, changes.Changes[0].ChangeType)
 	assert.Equal(t, "d", changes.Changes[0].Original)
 	assert.Equal(t, v3.EnumLabel, changes.Changes[0].Property)
+	assert.Equal(t, 5, *changes.GetAllChanges()[0].Context.OriginalLine)
+	assert.Equal(t, 20, *changes.GetAllChanges()[0].Context.OriginalColumn)
 }
 
 func TestCompareSchemas_PropertyAdded(t *testing.T) {
@@ -2711,7 +2715,7 @@ components:
         - type: array
           items:
             type: string
-          example: 
+          example:
             oh: my`
 	right := `openapi: 3.0
 components:


### PR DESCRIPTION
A fix for issue #231 

I have addressed the issue by implementing a simple fix: removing the encoding from the toString function. However, it became apparent that this alone was insufficient. The toString function is crucial when storing the node.Yaml enum object string value as a key in a map, which is used for comparison between the right and left sides. 

To mitigate this issue, I have modified the toString function to return the encoded string without including the column and line information. To prevent the loss of the original object's line and column data, I have utilized a copy of the object. This ensures that the comparison is not adversely affected by the line and column information, while still preserving the integrity of the original object's data.