### PR TITLE
Added switch to resolver for preventing duplication.

### DIFF
--- a/datamodel/low/v3/create_document.go
+++ b/datamodel/low/v3/create_document.go
@@ -115,7 +115,9 @@ func createDocument(info *datamodel.SpecInfo, config *datamodel.DocumentConfigur
 	}
 	done = time.Duration(time.Since(now).Milliseconds())
 	if config.Logger != nil {
-		config.Logger.Debug("circular check completed", "ms", done)
+		if !config.SkipCircularReferenceCheck {
+			config.Logger.Debug("circular check completed", "ms", done)
+		}
 	}
 	// extract errors
 	roloErrs := rolodex.GetCaughtErrors()


### PR DESCRIPTION
Vacuum runs things multiple times. which is causing skew on references.

No new features, but will resolve #229 (when consumed by vacuum)