### PR TITLE
[bundler] Add exploded ref check against root document

### DIFF
--- a/bundler/bundler.go
+++ b/bundler/bundler.go
@@ -58,7 +58,7 @@ func bundle(model *v3.Document, inline bool) ([]byte, error) {
 			//if we're in the root document, don't bundle anything.
 			refExp := strings.Split(sequenced.FullDefinition, "#/")
 			if len(refExp) == 2 {
-				if refExp[0] == sequenced.Index.GetSpecAbsolutePath() {
+				if refExp[0] == sequenced.Index.GetSpecAbsolutePath() || refExp[0] == "" {
 					if root && !inline {
 						idx.GetLogger().Debug("[bundler] skipping local root reference",
 							"ref", sequenced.Definition)

--- a/bundler/bundler.go
+++ b/bundler/bundler.go
@@ -58,7 +58,7 @@ func bundle(model *v3.Document, inline bool) ([]byte, error) {
 			//if we're in the root document, don't bundle anything.
 			refExp := strings.Split(sequenced.FullDefinition, "#/")
 			if len(refExp) == 2 {
-				if refExp[0] == "" {
+				if refExp[0] == sequenced.Index.GetSpecAbsolutePath() {
 					if root && !inline {
 						idx.GetLogger().Debug("[bundler] skipping local root reference",
 							"ref", sequenced.Definition)


### PR DESCRIPTION
Exploded ref definition was matching against empty string, however full definition consists of [full path and a fragment](https://github.com/pb33f/libopenapi/blob/main/index/extract_refs.go#L219)

Fixes #238 