### PR TITLE
Fix circular polymorfic ref

### DIFF
--- a/index/resolver.go
+++ b/index/resolver.go
@@ -369,7 +369,9 @@ func (resolver *Resolver) VisitReference(ref *Reference, seen map[string]bool, j
 						IsInfiniteLoop: isInfiniteLoop,
 					}
 
-					if resolver.IgnoreArray && isArray {
+					if resolver.IgnorePoly && !isArray {
+						resolver.ignoredPolyReferences = append(resolver.ignoredPolyReferences, circRef)
+					} else if resolver.IgnoreArray && isArray {
 						resolver.ignoredArrayReferences = append(resolver.ignoredArrayReferences, circRef)
 					} else {
 						if !resolver.circChecked {

--- a/index/resolver_test.go
+++ b/index/resolver_test.go
@@ -217,22 +217,36 @@ components:
 }
 
 func TestResolver_CheckForCircularReferences_IgnorePoly_Any(t *testing.T) {
-	circular := []byte(`openapi: 3.0.0
+	circular := []byte(`openapi: 3.1.0
+paths:
+  /one:
+    get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/One'
 components:
   schemas:
-    ProductCategory:
-      type: "object"
+    One:
       properties:
-        name:
-          type: "string"
-        children:
-          type: "object"
-          anyOf:
-            - $ref: "#/components/schemas/ProductCategory"
-          description: "Array of sub-categories in the same format."
+        thing:
+          oneOf:
+            - "$ref": "#/components/schemas/Two"
+            - "$ref": "#/components/schemas/Three"
       required:
-        - "name"
-        - "children"`)
+        - thing
+    Two:
+      description: "test two"
+      properties:
+        testThing:
+          "$ref": "#/components/schemas/One"
+    Three:
+      description: "test three"
+      properties:
+        testThing:
+          "$ref": "#/components/schemas/One"`)
 	var rootNode yaml.Node
 	_ = yaml.Unmarshal(circular, &rootNode)
 

--- a/index/rolodex_test.go
+++ b/index/rolodex_test.go
@@ -1441,8 +1441,8 @@ components:
 	rolodex.SetRootNode(&rootNode)
 
 	err := rolodex.IndexTheRolodex()
-	assert.Error(t, err)
-	assert.Len(t, rolodex.GetCaughtErrors(), 1)
+	assert.NoError(t, err)
+	assert.Len(t, rolodex.GetCaughtErrors(), 0)
 }
 
 func TestRolodex_IndexCircularLookup_ignorePoly(t *testing.T) {

--- a/index/spec_index_test.go
+++ b/index/spec_index_test.go
@@ -340,11 +340,10 @@ func TestSpecIndex_DigitalOcean_FullCheckoutLocalResolve_RecursiveLookup(t *test
 	rolo.CheckForCircularReferences()
 	assert.Len(t, rolo.GetCaughtErrors(), 0)
 	assert.Len(t, rolo.GetIgnoredCircularReferences(), 0)
-
-	if runtime.GOOS != "windows" {
-		assert.Equal(t, "1.21 MB", rolo.RolodexFileSizeAsString())
-	} else {
+	if runtime.GOOS == "windows" {
 		assert.Equal(t, "1.26 MB", rolo.RolodexFileSizeAsString())
+	} else {
+		assert.Equal(t, "1.22 MB", rolo.RolodexFileSizeAsString())
 	}
 	assert.Equal(t, 1685, rolo.RolodexTotalFiles())
 }


### PR DESCRIPTION
- Test case taken from [docs](https://pb33f.io/libopenapi/circular-references/#circular-reference-results)
- Applying fix for _TestResolver_CheckForCircularReferences_IgnorePoly_Any_ to pass
- Adjusting expectations for _TestRolodex_IndexCircularLookup_LookupHttpNoBaseURL_  because of **cf.IgnorePolymorphicCircularReferences = true**
