### PR TITLE
v0.15.3

### DIFF
--- a/datamodel/high/base/security_requirement.go
+++ b/datamodel/high/base/security_requirement.go
@@ -22,6 +22,7 @@ import (
 //   - https://swagger.io/specification/v2/#securityDefinitionsObject
 type SecurityRequirement struct {
 	Requirements *orderedmap.Map[string, []string] `json:"-" yaml:"-"`
+	ContainsEmptyRequirement bool // if a requirement is empty (this means it's optional)
 	low          *base.SecurityRequirement
 }
 
@@ -39,6 +40,7 @@ func NewSecurityRequirement(req *base.SecurityRequirement) *SecurityRequirement 
 		values.Set(pair.Key().Value, vals)
 	}
 	r.Requirements = values
+	r.ContainsEmptyRequirement = req.ContainsEmptyRequirement
 	return r
 }
 

--- a/datamodel/low/base/security_requirement.go
+++ b/datamodel/low/base/security_requirement.go
@@ -26,9 +26,10 @@ import (
 //   - https://swagger.io/specification/v2/#securityDefinitionsObject
 //   - https://swagger.io/specification/#security-requirement-object
 type SecurityRequirement struct {
-	Requirements low.ValueReference[*orderedmap.Map[low.KeyReference[string], low.ValueReference[[]low.ValueReference[string]]]]
-	KeyNode      *yaml.Node
-	RootNode     *yaml.Node
+	Requirements             low.ValueReference[*orderedmap.Map[low.KeyReference[string], low.ValueReference[[]low.ValueReference[string]]]]
+	KeyNode                  *yaml.Node
+	RootNode                 *yaml.Node
+	ContainsEmptyRequirement bool // if a requirement is empty (this means it's optional)
 	*low.Reference
 }
 
@@ -49,6 +50,9 @@ func (s *SecurityRequirement) Build(_ context.Context, keyNode, root *yaml.Node,
 			continue
 		}
 		for j := range root.Content[i].Content {
+			if root.Content[i].Content[j].Value == "" {
+				s.ContainsEmptyRequirement = true
+			}
 			arr = append(arr, low.ValueReference[string]{
 				Value:     root.Content[i].Content[j].Value,
 				ValueNode: root.Content[i].Content[j],
@@ -64,6 +68,9 @@ func (s *SecurityRequirement) Build(_ context.Context, keyNode, root *yaml.Node,
 				ValueNode: root.Content[i],
 			},
 		)
+	}
+	if len(root.Content) == 0 {
+		s.ContainsEmptyRequirement = true
 	}
 	s.Requirements = low.ValueReference[*orderedmap.Map[low.KeyReference[string], low.ValueReference[[]low.ValueReference[string]]]]{
 		Value:     valueMap,

--- a/datamodel/low/base/security_requirement_test.go
+++ b/datamodel/low/base/security_requirement_test.go
@@ -45,3 +45,21 @@ one:
 	assert.Equal(t, sr.Hash(), sr2.Hash())
 	assert.Nil(t, sr.FindRequirement("i-do-not-exist"))
 }
+
+func TestSecurityRequirement_TestEmptyReq(t *testing.T) {
+
+	yml := `one:
+  - two
+  - {}`
+
+	var sr SecurityRequirement
+	var idxNode yaml.Node
+	_ = yaml.Unmarshal([]byte(yml), &idxNode)
+
+	_ = sr.Build(context.Background(), nil, idxNode.Content[0], nil)
+
+	assert.Equal(t, 1, orderedmap.Len(sr.Requirements.Value))
+	assert.Len(t, sr.GetKeys(), 1)
+	assert.True(t, sr.ContainsEmptyRequirement)
+
+}

--- a/datamodel/low/base/security_requirement_test.go
+++ b/datamodel/low/base/security_requirement_test.go
@@ -63,3 +63,10 @@ func TestSecurityRequirement_TestEmptyReq(t *testing.T) {
 	assert.True(t, sr.ContainsEmptyRequirement)
 
 }
+
+func TestSecurityRequirement_TestEmptyContent(t *testing.T) {
+	var sr SecurityRequirement
+	_ = sr.Build(context.Background(), nil, &yaml.Node{}, nil)
+	assert.True(t, sr.ContainsEmptyRequirement)
+
+}

--- a/index/spec_index_test.go
+++ b/index/spec_index_test.go
@@ -453,7 +453,7 @@ func TestSpecIndex_BaseURLError(t *testing.T) {
 	files := remoteFS.GetFiles()
 	fileLen := len(files)
 	assert.Equal(t, 0, fileLen)
-	assert.GreaterOrEqual(t, len(remoteFS.GetErrors()), 200)
+	assert.GreaterOrEqual(t, len(remoteFS.GetErrors()), 155)
 }
 
 func TestSpecIndex_k8s(t *testing.T) {

--- a/renderer/mock_generator.go
+++ b/renderer/mock_generator.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"strconv"
 
 	highbase "github.com/pb33f/libopenapi/datamodel/high/base"
 	"github.com/pb33f/libopenapi/orderedmap"
@@ -154,6 +155,27 @@ func (mg *MockGenerator) GenerateMock(mock any, name string) ([]byte, error) {
 	}
 
 	if schemaValue != nil {
+
+		// now lets check the schema for `Examples` and `Example` fields.
+		if schemaValue.Examples != nil {
+			if name != "" {
+				// try and convert the example to an integer
+				if i, err := strconv.Atoi(name); err == nil {
+					if i < len(schemaValue.Examples) {
+						return mg.renderMock(schemaValue.Examples[i]), nil
+					}
+				}
+			}
+			// if the name is empty, just return the first example
+			return mg.renderMock(schemaValue.Examples[0]), nil
+		}
+
+		// check the example field
+		if schemaValue.Example != nil {
+			return mg.renderMock(schemaValue.Example), nil
+		}
+
+		// render the schema as our last hope.
 		renderMap := mg.renderer.RenderSchema(schemaValue)
 		if renderMap != nil {
 			return mg.renderMock(renderMap), nil

--- a/renderer/mock_generator_test.go
+++ b/renderer/mock_generator_test.go
@@ -323,3 +323,94 @@ func TestMockGenerator_GenerateMock_YamlNode_Nil(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "hello", strings.TrimSpace(string(mock)))
 }
+
+func TestMockGenerator_GenerateJSONMock_Object_SchemaExamples(t *testing.T) {
+
+	yml := `type: object
+examples:
+  - name: happy days
+    description: a terrible show from a time that never existed.
+  - name: robocop
+    description: perhaps the best cyberpunk movie ever made.
+properties:
+  name:
+    type: string
+    example: nameExample
+  description:
+    type: string
+    example: descriptionExample`
+
+	fake := createFakeMock(yml, nil, nil)
+	mg := NewMockGenerator(YAML)
+	mock, err := mg.GenerateMock(fake, "")
+	assert.NoError(t, err)
+
+	// re-serialize back into a map and check the values
+	var m map[string]any
+	err = yaml.Unmarshal(mock, &m)
+	assert.NoError(t, err)
+
+	assert.Len(t, m, 2)
+	assert.Equal(t, "happy days", m["name"].(string))
+	assert.Equal(t, "a terrible show from a time that never existed.", m["description"].(string))
+}
+
+func TestMockGenerator_GenerateJSONMock_Object_SchemaExamples_Preferred(t *testing.T) {
+
+	yml := `type: object
+examples:
+  - name: happy days
+    description: a terrible show from a time that never existed.
+  - name: robocop
+    description: perhaps the best cyberpunk movie ever made.
+properties:
+  name:
+    type: string
+    example: nameExample
+  description:
+    type: string
+    example: descriptionExample`
+
+	fake := createFakeMock(yml, nil, nil)
+	mg := NewMockGenerator(YAML)
+	mock, err := mg.GenerateMock(fake, "1")
+	assert.NoError(t, err)
+
+	// re-serialize back into a map and check the values
+	var m map[string]any
+	err = yaml.Unmarshal(mock, &m)
+	assert.NoError(t, err)
+
+	assert.Len(t, m, 2)
+	assert.Equal(t, "robocop", m["name"].(string))
+	assert.Equal(t, "perhaps the best cyberpunk movie ever made.", m["description"].(string))
+}
+
+func TestMockGenerator_GenerateJSONMock_Object_SchemaExample(t *testing.T) {
+
+	yml := `type: object
+example:
+  name: robocop
+  description: perhaps the best cyberpunk movie ever made.
+properties:
+  name:
+    type: string
+    example: nameExample
+  description:
+    type: string
+    example: descriptionExample`
+
+	fake := createFakeMock(yml, nil, nil)
+	mg := NewMockGenerator(YAML)
+	mock, err := mg.GenerateMock(fake, "")
+	assert.NoError(t, err)
+
+	// re-serialize back into a map and check the values
+	var m map[string]any
+	err = yaml.Unmarshal(mock, &m)
+	assert.NoError(t, err)
+
+	assert.Len(t, m, 2)
+	assert.Equal(t, "robocop", m["name"].(string))
+	assert.Equal(t, "perhaps the best cyberpunk movie ever made.", m["description"].(string))
+}


### PR DESCRIPTION
Adds a new property `ContainsEmptyRequirement` to `SecurityRequirement` objects. This is set to true if an empty security requirement is provided, which acts as a null / empty value. This is used downstream by applications looking at the security of a spec and matching it against a spec. 

Also added better handling to the mock generator. Now it operates through the following stages: 

Examples > Example > Generate data

The `Preferred` header can now extract the index of `Examples` in a schema.