### PR TITLE
Addressed invalid polymorphic circular reference issue.

### DIFF
--- a/index/rolodex_test.go
+++ b/index/rolodex_test.go
@@ -1183,7 +1183,7 @@ components:
 	assert.Len(t, rolodex.GetCaughtErrors(), 0)
 
 	assert.GreaterOrEqual(t, len(rolodex.GetIgnoredCircularReferences()), 1)
-	assert.Equal(t, rolodex.GetRootIndex().GetResolver().GetIndexesVisited(), 11)
+	assert.Equal(t, rolodex.GetRootIndex().GetResolver().GetIndexesVisited(), 13)
 
 }
 


### PR DESCRIPTION
If a polymorphic type was used incorrectly (as a map and not an array) then the logic was getting a little upset. This fixes that issue and adds some tests to validate correct handling.