### PR TITLE
v0.15.8

### DIFF
--- a/index/find_component.go
+++ b/index/find_component.go
@@ -122,6 +122,9 @@ func (index *SpecIndex) lookupRolodex(uri []string) *Reference {
 
 					// consider the file local
 					dir := filepath.Dir(index.config.SpecAbsolutePath)
+					if !strings.HasPrefix(file, ".") {
+						file = fmt.Sprintf("./%s", file)
+					}
 					absoluteFileLocation, _ = filepath.Abs(filepath.Join(dir, file))
 				}
 			}

--- a/index/rolodex_test.go
+++ b/index/rolodex_test.go
@@ -1537,10 +1537,10 @@ func TestRolodex_SimpleTest_OneDoc(t *testing.T) {
 
 	//assert.NotZero(t, rolo.GetIndexingDuration()) comes back as 0 on windows.
 	assert.Nil(t, rolo.GetRootIndex())
-	assert.Len(t, rolo.GetIndexes(), 9)
+	assert.Len(t, rolo.GetIndexes(), 10)
 
 	assert.NoError(t, err)
-	assert.Len(t, rolo.indexes, 9)
+	assert.Len(t, rolo.indexes, 10)
 
 	// open components.yaml
 	f, rerr := rolo.Open("components.yaml")

--- a/index/rolodex_test_data/doc2.yaml
+++ b/index/rolodex_test_data/doc2.yaml
@@ -3,42 +3,6 @@ info:
   title: Rolodex Test Data
   version: 1.0.0
 paths:
-#  /one/local:
-#    get:
-#      responses:
-#        '200':
-#          description: OK
-#          content:
-#            application/json:
-#              schema:
-#                $ref: '#/components/schemas/Thing'
-#  /one/file:
-#    get:
-#      responses:
-#        '200':
-#          description: OK
-#          content:
-#            application/json:
-#              schema:
-#                $ref: 'components.yaml#/components/schemas/Ding'
-#  /nested/files1:
-#    get:
-#      responses:
-#        '200':
-#          description: OK
-#          content:
-#            application/json:
-#              schema:
-#                $ref: 'dir1/components.yaml#/components/schemas/GlobalComponent'
-#  /nested/files2:
-#    get:
-#      responses:
-#        '200':
-#          description: OK
-#          content:
-#            application/json:
-#              schema:
-#                $ref: 'dir2/components.yaml#/components/schemas/GlobalComponent'
   /nested/files3:
     get:
       responses:

--- a/index/rolodex_test_data/paths/paths.yaml
+++ b/index/rolodex_test_data/paths/paths.yaml
@@ -1,0 +1,9 @@
+/some/path:
+  get:
+    responses:
+      '200':
+        description: OK
+        content:
+          application/json:
+            schema:
+              $ref: '../components.yaml#/components/schemas/Ding'

--- a/index/search_index.go
+++ b/index/search_index.go
@@ -132,6 +132,32 @@ func (index *SpecIndex) SearchIndexForReferenceByReferenceWithContext(ctx contex
 
 		// extract the index from the rolodex file.
 		if rFile != nil {
+
+			n := rFile.GetFullPath()
+			refParsed := ref
+
+			// do we have a relative reference and an exact match on the suffix?
+			if strings.HasPrefix(ref, "./") {
+				refParsed = strings.ReplaceAll(ref, "./", "")
+			}
+
+			if strings.HasSuffix(n, refParsed) {
+				node, _ := rFile.GetContentAsYAMLNode()
+				if node != nil {
+					return &Reference{
+						FullDefinition: n,
+						Definition:     n,
+						IsRemote:       true,
+						RemoteLocation: n,
+						Index:          index,
+						Node:           node.Content[0],
+						ParentNode:     node,
+					}, index, ctx
+				} else {
+					return nil, index, ctx
+				}
+			}
+
 			idx := rFile.GetIndex()
 			if index.resolver != nil {
 				index.resolver.indexesVisited++


### PR DESCRIPTION
Resolution for https://github.com/pb33f/libopenapi/issues/248

A new codepath created a double dip into the index, which skews the working path. A short circuit is required, and a new block of code catches it.