### PR TITLE
v0.15.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ See all the documentation at https://pb33f.io/libopenapi/
 - [The Resolver](https://pb33f.io/libopenapi/resolver/)
 - [The Rolodex](https://pb33f.io/libopenapi/rolodex/)
 - [Circular References](https://pb33f.io/libopenapi/circular-references/)
+- [Bundling Specs](https://pb33f.io/libopenapi/bundling/)
 - [What Changed / Diff Engine](https://pb33f.io/libopenapi/what-changed/)
 - [FAQ](https://pb33f.io/libopenapi/faq/)
 - [About libopenapi](https://pb33f.io/libopenapi/about/)

--- a/datamodel/high/v3/document_test.go
+++ b/datamodel/high/v3/document_test.go
@@ -491,7 +491,7 @@ func TestDigitalOceanAsDocViaCheckout(t *testing.T) {
 		AllowRemoteReferences: true,
 		BasePath:              basePath,
 		Logger: slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
-			Level: slog.LevelDebug,
+			Level: slog.LevelError,
 		})),
 	}
 

--- a/datamodel/low/base/schema.go
+++ b/datamodel/low/base/schema.go
@@ -458,6 +458,9 @@ func (s *Schema) GetExtensions() *orderedmap.Map[low.KeyReference[string], low.V
 //   - UnevaluatedProperties
 //   - Anchor
 func (s *Schema) Build(ctx context.Context, root *yaml.Node, idx *index.SpecIndex) error {
+	if root == nil {
+		return fmt.Errorf("cannot build schema from a nil node")
+	}
 	root = utils.NodeAlias(root)
 	utils.CheckForMergeNodes(root)
 	s.Reference = new(low.Reference)

--- a/datamodel/low/base/schema_proxy.go
+++ b/datamodel/low/base/schema_proxy.go
@@ -6,6 +6,7 @@ package base
 import (
 	"context"
 	"crypto/sha256"
+	"log/slog"
 
 	"github.com/pb33f/libopenapi/datamodel/low"
 	"github.com/pb33f/libopenapi/index"
@@ -144,7 +145,10 @@ func (sp *SchemaProxy) Hash() [32]byte {
 			if sch != nil {
 				return sch.Hash()
 			}
-			logger := sp.idx.GetLogger()
+			var logger *slog.Logger
+			if sp.idx != nil {
+				logger = sp.idx.GetLogger()
+			}
 			if logger != nil {
 				logger.Warn("SchemaProxy.Hash() failed to resolve schema, returning empty hash", "error", sp.GetBuildError().Error())
 			}

--- a/datamodel/low/base/schema_proxy.go
+++ b/datamodel/low/base/schema_proxy.go
@@ -141,7 +141,14 @@ func (sp *SchemaProxy) Hash() [32]byte {
 			// only resolve this proxy if it's not a ref.
 			sch := sp.Schema()
 			sp.rendered = sch
-			return sch.Hash()
+			if sch != nil {
+				return sch.Hash()
+			}
+			logger := sp.idx.GetLogger()
+			if logger != nil {
+				logger.Warn("SchemaProxy.Hash() failed to resolve schema, returning empty hash", "error", sp.GetBuildError().Error())
+			}
+			return [32]byte{}
 		}
 	}
 	// hash reference value only, do not resolve!

--- a/datamodel/low/base/schema_proxy_test.go
+++ b/datamodel/low/base/schema_proxy_test.go
@@ -157,3 +157,10 @@ properties:
 	origin = schC.GetSchemaReferenceLocation()
 	assert.Nil(t, origin)
 }
+
+func TestSchemaProxy_Build_HashFail(t *testing.T) {
+
+	sp := new(SchemaProxy)
+	v := sp.Hash()
+	assert.Equal(t, [32]byte{}, v)
+}

--- a/datamodel/low/base/schema_proxy_test.go
+++ b/datamodel/low/base/schema_proxy_test.go
@@ -5,6 +5,8 @@ package base
 
 import (
 	"context"
+	"log/slog"
+	"os"
 	"testing"
 
 	"github.com/pb33f/libopenapi/datamodel/low"
@@ -161,6 +163,9 @@ properties:
 func TestSchemaProxy_Build_HashFail(t *testing.T) {
 
 	sp := new(SchemaProxy)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	idx := index.NewSpecIndexWithConfig(nil, &index.SpecIndexConfig{Logger: logger})
+	sp.idx = idx
 	v := sp.Hash()
 	assert.Equal(t, [32]byte{}, v)
 }

--- a/datamodel/low/extraction_functions.go
+++ b/datamodel/low/extraction_functions.go
@@ -608,8 +608,6 @@ type mappingResult[T any] struct {
 type buildInput struct {
 	label *yaml.Node
 	value *yaml.Node
-	ctx   context.Context
-	idx   *index.SpecIndex
 }
 
 // ExtractMapExtensions will extract a map of KeyReference and ValueReference from a root yaml.Node. The 'label' is
@@ -826,6 +824,9 @@ func ExtractMap[PT Buildable[N], N any](
 //	int64, float64, bool, string
 func ExtractExtensions(root *yaml.Node) *orderedmap.Map[KeyReference[string], ValueReference[*yaml.Node]] {
 	root = utils.NodeAlias(root)
+	if root == nil {
+		return nil
+	}
 	extensions := utils.FindExtensionNodes(root.Content)
 	extensionMap := orderedmap.New[KeyReference[string], ValueReference[*yaml.Node]]()
 	for _, ext := range extensions {

--- a/datamodel/low/extraction_functions_test.go
+++ b/datamodel/low/extraction_functions_test.go
@@ -2171,3 +2171,8 @@ func TestValueToString(t *testing.T) {
 		})
 	}
 }
+
+func TestExtractExtensions_Nill(t *testing.T) {
+	err := ExtractExtensions(nil)
+	assert.Nil(t, err)
+}

--- a/datamodel/low/extraction_functions_test.go
+++ b/datamodel/low/extraction_functions_test.go
@@ -1613,6 +1613,31 @@ func TestLocateRefNode_CurrentPathKey_HttpLink(t *testing.T) {
 	assert.NotNil(t, c)
 }
 
+func TestLocateRefNode_CurrentPathKey_RootLookup(t *testing.T) {
+	no := yaml.Node{
+		Kind: yaml.MappingNode,
+		Content: []*yaml.Node{
+			{
+				Kind:  yaml.ScalarNode,
+				Value: "$ref",
+			},
+			{
+				Kind:  yaml.ScalarNode,
+				Value: "#/components/pizza/cake",
+			},
+		},
+	}
+
+	ctx := context.WithValue(context.Background(), index.CurrentPathKey, "files/cakes.yaml")
+
+	idx := index.NewSpecIndexWithConfig(&no, index.CreateClosedAPIIndexConfig())
+	n, i, e, c := LocateRefNodeWithContext(ctx, &no, idx)
+	assert.Nil(t, n)
+	assert.NotNil(t, i)
+	assert.NotNil(t, e)
+	assert.NotNil(t, c)
+}
+
 func TestLocateRefNode_CurrentPathKey_HttpLink_Local(t *testing.T) {
 	no := yaml.Node{
 		Kind: yaml.MappingNode,

--- a/document_examples_test.go
+++ b/document_examples_test.go
@@ -6,6 +6,7 @@ package libopenapi
 import (
 	"bytes"
 	"fmt"
+	what_changed "github.com/pb33f/libopenapi/what-changed"
 	"log/slog"
 	"net/url"
 	"os"
@@ -127,7 +128,7 @@ func ExampleNewDocument_fromWithDocumentConfigurationSuccess() {
 		panic(fmt.Sprintf("cannot create new document: %e", err))
 	}
 
-	_, errors := doc.BuildV3Model()
+	m, errors := doc.BuildV3Model()
 
 	// if anything went wrong when building the v3 model, a slice of errors will be returned
 	if len(errors) > 0 {
@@ -135,6 +136,10 @@ func ExampleNewDocument_fromWithDocumentConfigurationSuccess() {
 	} else {
 		fmt.Println("Digital Ocean spec built successfully")
 	}
+
+	// running this through a change detection, will render out the entire model and
+	// any stage two rendering for the model will be caught.
+	what_changed.CompareOpenAPIDocuments(m.Model.GoLow(), m.Model.GoLow())
 	// Output: Digital Ocean spec built successfully
 }
 

--- a/index/resolver.go
+++ b/index/resolver.go
@@ -398,9 +398,6 @@ func (resolver *Resolver) VisitReference(ref *Reference, seen map[string]bool, j
 			if foundRef != nil {
 				original = foundRef
 			}
-			if original == nil {
-				panic("help")
-			}
 			resolved := resolver.VisitReference(original, seen, journey, resolve)
 			if resolve && !original.Circular {
 				ref.Resolved = true

--- a/index/resolver.go
+++ b/index/resolver.go
@@ -489,7 +489,12 @@ func (resolver *Resolver) extractRelatives(ref *Reference, node, parent *yaml.No
 	var found []*Reference
 
 	if len(node.Content) > 0 {
+		skip := false
 		for i, n := range node.Content {
+			if skip {
+				skip = false
+				continue
+			}
 			if utils.IsNodeMap(n) || utils.IsNodeArray(n) {
 				depth++
 
@@ -790,7 +795,8 @@ func (resolver *Resolver) extractRelatives(ref *Reference, node, parent *yaml.No
 							}
 						}
 					}
-					break
+					skip = true
+					continue
 				}
 			}
 		}

--- a/index/resolver.go
+++ b/index/resolver.go
@@ -529,9 +529,7 @@ func (resolver *Resolver) extractRelatives(ref *Reference, node, parent *yaml.No
 				if len(exp) == 2 {
 					definition = fmt.Sprintf("#/%s", exp[1])
 					if exp[0] != "" {
-						if strings.HasPrefix(exp[0], "http") {
-							fullDef = value
-						} else {
+						if !strings.HasPrefix(exp[0], "http") {
 
 							if strings.HasPrefix(ref.FullDefinition, "http") {
 

--- a/index/rolodex.go
+++ b/index/rolodex.go
@@ -320,7 +320,7 @@ func (r *Rolodex) IndexTheRolodex() error {
 		if r.indexConfig.IgnorePolymorphicCircularReferences {
 			resolver.IgnorePolymorphicCircularReferences()
 		}
-
+		r.rootIndex = index
 		r.logger.Debug("[rolodex] starting root index build")
 		index.BuildIndex()
 		r.logger.Debug("[rolodex] root index build completed")
@@ -338,7 +338,7 @@ func (r *Rolodex) IndexTheRolodex() error {
 				r.ignoredCircularReferences = append(r.ignoredCircularReferences, resolver.GetIgnoredCircularArrayReferences()...)
 			}
 		}
-		r.rootIndex = index
+
 		if len(index.refErrors) > 0 {
 			caughtErrors = append(caughtErrors, index.refErrors...)
 		}

--- a/index/rolodex_remote_loader.go
+++ b/index/rolodex_remote_loader.go
@@ -397,7 +397,8 @@ func (i *RemoteFS) Open(remoteURL string) (fs.File, error) {
 
 		i.logger.Error("unable to fetch remote document",
 			"file", remoteParsedURL.Path, "status", response.StatusCode, "resp", string(responseBytes))
-		return nil, fmt.Errorf("unable to fetch remote document: %s", string(responseBytes))
+		return nil, fmt.Errorf("unable to fetch remote document '%s' (error %d)", remoteParsedURL.String(),
+			response.StatusCode)
 	}
 
 	absolutePath := remoteParsedURL.Path

--- a/index/rolodex_remote_loader.go
+++ b/index/rolodex_remote_loader.go
@@ -420,7 +420,7 @@ func (i *RemoteFS) Open(remoteURL string) (fs.File, error) {
 		name:         remoteParsedURL.Path,
 		extension:    fileExt,
 		data:         responseBytes,
-		fullPath:     absolutePath,
+		fullPath:     remoteParsedURL.String(),
 		URL:          remoteParsedURL,
 		lastModified: lastModifiedTime,
 	}

--- a/index/rolodex_remote_loader_test.go
+++ b/index/rolodex_remote_loader_test.go
@@ -192,7 +192,7 @@ func TestNewRemoteFS_BasicCheck_Relative_Deeper(t *testing.T) {
 	assert.Equal(t, YAML, file.(*RemoteFile).GetFileExtension())
 	assert.NotNil(t, file.(*RemoteFile).GetLastModified())
 	assert.Len(t, file.(*RemoteFile).GetErrors(), 0)
-	assert.Equal(t, "/deeper/even_deeper/file3.yaml", file.(*RemoteFile).GetFullPath())
+	assert.Contains(t, file.(*RemoteFile).GetFullPath(), "/deeper/even_deeper/file3.yaml")
 	assert.False(t, file.(*RemoteFile).IsDir())
 	assert.Nil(t, file.(*RemoteFile).Sys())
 	assert.Nil(t, file.(*RemoteFile).Close())

--- a/index/rolodex_test.go
+++ b/index/rolodex_test.go
@@ -1233,13 +1233,13 @@ components:
 	tmp := "tmp-g"
 	_ = os.Mkdir(tmp, 0755)
 
-	firstFile, fErr = os.CreateTemp(tmp, "*-first.yaml")
+	firstFile, fErr = os.CreateTemp(tmp, "first-*.yaml")
 	assert.NoError(t, fErr)
 
-	secondFile, fErr = os.CreateTemp(tmp, "*-second.yaml")
+	secondFile, fErr = os.CreateTemp(tmp, "second-*.yaml")
 	assert.NoError(t, fErr)
 
-	thirdFile, fErr = os.CreateTemp(tmp, "*-third.yaml")
+	thirdFile, fErr = os.CreateTemp(tmp, "third-*.yaml")
 	assert.NoError(t, fErr)
 
 	first = strings.ReplaceAll(first, "$2", secondFile.Name())
@@ -1257,6 +1257,7 @@ components:
 
 	cf := CreateOpenAPIIndexConfig()
 	cf.IgnorePolymorphicCircularReferences = true
+	cf.ExtractRefsSequentially = true
 	rolodex := NewRolodex(cf)
 
 	baseDir := tmp

--- a/index/rolodex_test.go
+++ b/index/rolodex_test.go
@@ -1172,7 +1172,6 @@ components:
 	assert.Len(t, rolodex.GetCaughtErrors(), 0)
 
 	assert.GreaterOrEqual(t, len(rolodex.GetIgnoredCircularReferences()), 1)
-	assert.Equal(t, 174, rolodex.GetRootIndex().GetResolver().GetIndexesVisited())
 
 }
 

--- a/index/search_index.go
+++ b/index/search_index.go
@@ -158,8 +158,6 @@ func (index *SpecIndex) SearchIndexForReferenceByReferenceWithContext(ctx contex
 					}
 					index.cache.Store(ref, r)
 					return r, rFile.GetIndex(), context.WithValue(ctx, CurrentPathKey, rFile.GetFullPath())
-				} else {
-					return nil, index, ctx
 				}
 			}
 

--- a/index/spec_index.go
+++ b/index/spec_index.go
@@ -36,9 +36,6 @@ func NewSpecIndexWithConfig(rootNode *yaml.Node, config *SpecIndexConfig) *SpecI
 	index.rolodex = config.Rolodex
 	index.uri = config.uri
 	index.specAbsolutePath = config.SpecAbsolutePath
-	if rootNode == nil || len(rootNode.Content) <= 0 {
-		return index
-	}
 	if config.Logger != nil {
 		index.logger = config.Logger
 	} else {
@@ -46,7 +43,9 @@ func NewSpecIndexWithConfig(rootNode *yaml.Node, config *SpecIndexConfig) *SpecI
 			Level: slog.LevelError,
 		}))
 	}
-
+	if rootNode == nil || len(rootNode.Content) <= 0 {
+		return index
+	}
 	index.root = rootNode
 	return createNewIndex(rootNode, index, config.AvoidBuildIndex)
 }

--- a/what-changed/model/change_types.go
+++ b/what-changed/model/change_types.go
@@ -4,6 +4,7 @@
 package model
 
 import (
+	"encoding/json"
 	"gopkg.in/yaml.v3"
 )
 
@@ -90,6 +91,33 @@ type Change struct {
 
 	// NewObject represents the new object that has been modified.
 	NewObject any `json:"-" yaml:"-"`
+}
+
+// MarshalJSON is a custom JSON marshaller for the Change object.
+func (c *Change) MarshalJSON() ([]byte, error) {
+	changeType := ""
+	switch c.ChangeType {
+	case Modified:
+		changeType = "modified"
+	case PropertyAdded:
+		changeType = "property_added"
+	case ObjectAdded:
+		changeType = "object_added"
+	case ObjectRemoved:
+		changeType = "object_removed"
+	case PropertyRemoved:
+		changeType = "property_removed"
+	}
+	data := map[string]interface{}{
+		"change":     c.ChangeType,
+		"changeText": changeType,
+		"context":    c.Context,
+		"property":   c.Property,
+		"original":   c.Original,
+		"new":        c.New,
+		"breaking":   c.Breaking,
+	}
+	return json.Marshal(data)
 }
 
 // PropertyChanges holds a slice of Change pointers

--- a/what-changed/model/change_types_test.go
+++ b/what-changed/model/change_types_test.go
@@ -1,0 +1,59 @@
+// Copyright 2023-2024 Princess Beef Heavy Industries, LLC / Dave Shanley
+// https://pb33f.io
+
+package model
+
+import (
+	"encoding/json"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestChange_MarshalJSON(t *testing.T) {
+
+	rinseAndRepeat := func(ch *Change) map[string]any {
+		b, err := ch.MarshalJSON()
+		assert.NoError(t, err)
+
+		var rebuilt map[string]any
+		err = json.Unmarshal(b, &rebuilt)
+		assert.NoError(t, err)
+		return rebuilt
+	}
+
+	change := Change{
+		ChangeType: Modified,
+	}
+	rebuilt := rinseAndRepeat(&change)
+	assert.Equal(t, "modified", rebuilt["changeText"])
+	assert.Equal(t, float64(1), rebuilt["change"])
+
+	change = Change{
+		ChangeType: ObjectAdded,
+	}
+	rebuilt = rinseAndRepeat(&change)
+	assert.Equal(t, "object_added", rebuilt["changeText"])
+	assert.Equal(t, float64(3), rebuilt["change"])
+
+	change = Change{
+		ChangeType: ObjectRemoved,
+	}
+	rebuilt = rinseAndRepeat(&change)
+	assert.Equal(t, "object_removed", rebuilt["changeText"])
+	assert.Equal(t, float64(4), rebuilt["change"])
+
+	change = Change{
+		ChangeType: PropertyAdded,
+	}
+	rebuilt = rinseAndRepeat(&change)
+	assert.Equal(t, "property_added", rebuilt["changeText"])
+	assert.Equal(t, float64(2), rebuilt["change"])
+
+	change = Change{
+		ChangeType: PropertyRemoved,
+	}
+	rebuilt = rinseAndRepeat(&change)
+	assert.Equal(t, "property_removed", rebuilt["changeText"])
+	assert.Equal(t, float64(5), rebuilt["change"])
+
+}

--- a/what-changed/model/document_flat.go
+++ b/what-changed/model/document_flat.go
@@ -1,0 +1,17 @@
+// Copyright 2023-2024 Princess Beef Heavy Industries, LLC / Dave Shanley
+// https://pb33f.io
+
+package model
+
+type DocumentChangesFlat struct {
+	*PropertyChanges
+	InfoChanges                []*Change `json:"info,omitempty" yaml:"info,omitempty"`
+	PathsChanges               []*Change `json:"paths,omitempty" yaml:"paths,omitempty"`
+	TagChanges                 []*Change `json:"tags,omitempty" yaml:"tags,omitempty"`
+	ExternalDocChanges         []*Change `json:"externalDoc,omitempty" yaml:"externalDoc,omitempty"`
+	WebhookChanges             []*Change `json:"webhooks,omitempty" yaml:"webhooks,omitempty"`
+	ServerChanges              []*Change `json:"servers,omitempty" yaml:"servers,omitempty"`
+	SecurityRequirementChanges []*Change `json:"securityRequirements,omitempty" yaml:"securityRequirements,omitempty"`
+	ComponentsChanges          []*Change `json:"components,omitempty" yaml:"components,omitempty"`
+	ExtensionChanges           []*Change `json:"extensions,omitempty" yaml:"extensions,omitempty"`
+}


### PR DESCRIPTION
Contains fixes for resolving, discovered during stress testing. Knocking out those last few gremlins after the re-architecture. It also means we can undo a temporary patch put into the last release.

Also adds a new flat document model for change detections. It's a flat render of all changes, instead of being a tree. 