### PR TITLE
v0.15.13

### DIFF
--- a/datamodel/translate_test.go
+++ b/datamodel/translate_test.go
@@ -541,6 +541,7 @@ func TestTranslatePipeline(t *testing.T) {
 				case <-doneChan:
 					// test passed
 				}
+				time.Sleep(1 * time.Second)
 			})
 		})
 	}

--- a/index/resolver.go
+++ b/index/resolver.go
@@ -498,16 +498,15 @@ func (resolver *Resolver) extractRelatives(ref *Reference, node, parent *yaml.No
 			if utils.IsNodeMap(n) || utils.IsNodeArray(n) {
 				depth++
 
-				//refIsRef, _, _ := utils.IsNodeRefValue(ref.Node)
 				var foundRef *Reference
-				//if refIsRef {
 				foundRef, _ = resolver.specIndex.SearchIndexForReferenceByReference(ref)
 				if foundRef != nil && !foundRef.Circular {
 					found = append(found, resolver.extractRelatives(foundRef, n, node, foundRelatives, journey, seen, resolve, depth)...)
+					depth--
 				}
-				//	}
 				if foundRef == nil {
 					found = append(found, resolver.extractRelatives(ref, n, node, foundRelatives, journey, seen, resolve, depth)...)
+					depth--
 				}
 
 			}


### PR DESCRIPTION
When resolving complex, recursive and deep references, The depth counter was being artificially inflated with highly complex recursive designs, this fixes the depth counter permanently and makes sure that after the resolver is done exploring a branch, it decrements the counter correctly, instead of just inflating it over and over. 

Fixes issue: https://github.com/pb33f/libopenapi/issues/256