### PR TITLE
fix bundler panic when BuildV3Model fail

### DIFF
--- a/bundler/bundler.go
+++ b/bundler/bundler.go
@@ -14,6 +14,9 @@ import (
 	"github.com/pb33f/libopenapi/index"
 )
 
+// ErrInvalidModel is returned when the model is not usable.
+var ErrInvalidModel = errors.New("invalid model")
+
 // BundleBytes will take a byte slice of an OpenAPI specification and return a bundled version of it.
 // This is useful for when you want to take a specification with external references, and you want to bundle it
 // into a single document.
@@ -29,8 +32,9 @@ func BundleBytes(bytes []byte, configuration *datamodel.DocumentConfiguration) (
 	}
 
 	v3Doc, errs := doc.BuildV3Model()
-	if len(errs) > 0 {
-		return nil, errors.Join(errs...)
+	err = errors.Join(errs...)
+	if v3Doc == nil {
+		return nil, errors.Join(ErrInvalidModel, err)
 	}
 
 	bundledBytes, e := bundle(&v3Doc.Model, configuration.BundleInlineRefs)

--- a/bundler/bundler.go
+++ b/bundler/bundler.go
@@ -6,11 +6,12 @@ package bundler
 
 import (
 	"errors"
+	"strings"
+
 	"github.com/pb33f/libopenapi"
 	"github.com/pb33f/libopenapi/datamodel"
 	"github.com/pb33f/libopenapi/datamodel/high/v3"
 	"github.com/pb33f/libopenapi/index"
-	"strings"
 )
 
 // BundleBytes will take a byte slice of an OpenAPI specification and return a bundled version of it.
@@ -28,7 +29,9 @@ func BundleBytes(bytes []byte, configuration *datamodel.DocumentConfiguration) (
 	}
 
 	v3Doc, errs := doc.BuildV3Model()
-	err = errors.Join(errs...)
+	if len(errs) > 0 {
+		return nil, errors.Join(errs...)
+	}
 
 	bundledBytes, e := bundle(&v3Doc.Model, configuration.BundleInlineRefs)
 	return bundledBytes, errors.Join(err, e)
@@ -55,7 +58,7 @@ func bundle(model *v3.Document, inline bool) ([]byte, error) {
 		for _, sequenced := range sequencedReferences {
 			mappedReference := mappedReferences[sequenced.FullDefinition]
 
-			//if we're in the root document, don't bundle anything.
+			// if we're in the root document, don't bundle anything.
 			refExp := strings.Split(sequenced.FullDefinition, "#/")
 			if len(refExp) == 2 {
 				if refExp[0] == sequenced.Index.GetSpecAbsolutePath() || refExp[0] == "" {


### PR DESCRIPTION
in some cases, `BuildV3Model` will return a nil first parameter and an error which result in a panic in the next call, this PR aims to fix this behavior.