### PR TITLE
fix: fixed MediaType example being populated from wrong source

### DIFF
--- a/datamodel/low/v3/media_type.go
+++ b/datamodel/low/v3/media_type.go
@@ -66,7 +66,7 @@ func (mt *MediaType) Build(ctx context.Context, keyNode, root *yaml.Node, idx *i
 	mt.Extensions = low.ExtractExtensions(root)
 
 	// handle example if set.
-	_, expLabel, expNode := utils.FindKeyNodeFull(base.ExampleLabel, root.Content)
+	_, expLabel, expNode := utils.FindKeyNodeFullTop(base.ExampleLabel, root.Content)
 	if expNode != nil {
 		mt.Example = low.NodeReference[*yaml.Node]{Value: expNode, KeyNode: expLabel, ValueNode: expNode}
 	}


### PR DESCRIPTION
@daveshanley this fixes an issue where the `MediaType.Example` field was being populated when it shouldn't.

It was basically searching down into the schema and other places as well to find an example where it should have only been searching the top level node