### PR TITLE
Fix panic when ref is mis-used

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -503,7 +503,9 @@ func IsNodeRefValue(node *yaml.Node) (bool, *yaml.Node, string) {
 	for i, r := range n.Content {
 		if i%2 == 0 {
 			if r.Value == "$ref" {
-				return true, r, n.Content[i+1].Value
+				if i+1 < len(n.Content) {
+					return true, r, n.Content[i+1].Value
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Adds length check to prevent a panic if a $ref is mis-used. 