### PR TITLE
v0.16.5

### DIFF
--- a/renderer/schema_renderer_test.go
+++ b/renderer/schema_renderer_test.go
@@ -1082,6 +1082,35 @@ properties:
 	assert.Equal(t, `{"args":{"arrParam":"test,test2","arrParamExploded":["1","2"]}}`, string(rendered))
 }
 
+// https://github.com/pb33f/wiretap/issues/93
+func TestRenderSchema_NonStandard_Format(t *testing.T) {
+	testObject := `type: object
+properties:
+  bigint:
+    type: integer
+    format: bigint
+    example: 8821239038968084
+  bigintStr:
+    type: string
+    format: bigint
+    example: "9223372036854775808"
+  decimal:
+    type: number
+    format: decimal
+    example: 3.141592653589793
+  decimalStr:
+    type: string
+    format: decimal
+    example: "3.14159265358979344719667586"`
+
+	compiled := getSchema([]byte(testObject))
+	schema := make(map[string]any)
+	wr := createSchemaRenderer()
+	wr.DiveIntoSchema(compiled, "pb33f", schema, 0)
+	rendered, _ := json.Marshal(schema["pb33f"])
+	assert.Equal(t, `{"bigint":8821239038968084,"bigintStr":"9223372036854775808","decimal":3.141592653589793,"decimalStr":"3.14159265358979344719667586"}`, string(rendered))
+}
+
 func TestCreateRendererUsingDefaultDictionary(t *testing.T) {
 	assert.NotNil(t, CreateRendererUsingDefaultDictionary())
 }

--- a/renderer/schema_renderer_test.go
+++ b/renderer/schema_renderer_test.go
@@ -1034,6 +1034,54 @@ properties:
 	assert.Equal(t, `{"count":9934}`, string(rendered))
 }
 
+func TestRenderSchema_Items_WithExample(t *testing.T) {
+	testObject := `type: object
+properties:
+  args:
+    type: object
+    properties:
+      arrParam:
+        type: string
+        example: test,test2
+      arrParamExploded:
+        type: array
+        items:
+          type: string
+          example: "1"`
+
+	compiled := getSchema([]byte(testObject))
+	schema := make(map[string]any)
+	wr := createSchemaRenderer()
+	wr.DiveIntoSchema(compiled, "pb33f", schema, 0)
+	rendered, _ := json.Marshal(schema["pb33f"])
+	assert.Equal(t, `{"args":{"arrParam":"test,test2","arrParamExploded":["1"]}}`, string(rendered))
+}
+
+func TestRenderSchema_Items_WithExamples(t *testing.T) {
+	testObject := `type: object
+properties:
+  args:
+    type: object
+    properties:
+      arrParam:
+        type: string
+        example: test,test2
+      arrParamExploded:
+        type: array
+        items:
+          type: string
+          examples:
+            - 1
+            - 2`
+
+	compiled := getSchema([]byte(testObject))
+	schema := make(map[string]any)
+	wr := createSchemaRenderer()
+	wr.DiveIntoSchema(compiled, "pb33f", schema, 0)
+	rendered, _ := json.Marshal(schema["pb33f"])
+	assert.Equal(t, `{"args":{"arrParam":"test,test2","arrParamExploded":["1","2"]}}`, string(rendered))
+}
+
 func TestCreateRendererUsingDefaultDictionary(t *testing.T) {
 	assert.NotNil(t, CreateRendererUsingDefaultDictionary())
 }


### PR DESCRIPTION
- Adds support for rendering examples when they are nested in `items` (array) based schemas
- Adds support for non-standard `bigint` and  standard `decimal` formats when rendering schemas.