### PR TITLE
v0.16.7

### DIFF
--- a/datamodel/high/node_builder.go
+++ b/datamodel/high/node_builder.go
@@ -193,7 +193,9 @@ func (n *NodeBuilder) add(key string, i int) {
 			sort.Slice(lines, func(i, j int) bool {
 				return lines[i] < lines[j]
 			})
-			nodeEntry.Line = lines[0]
+			if len(lines) > 0 {
+				nodeEntry.Line = lines[0]
+			}
 		case reflect.Struct:
 			y := value.Interface()
 			nodeEntry.Line = 9999 + i

--- a/datamodel/high/node_builder.go
+++ b/datamodel/high/node_builder.go
@@ -394,7 +394,9 @@ func (n *NodeBuilder) AddYAMLNode(parent *yaml.Node, entry *nodes.NodeEntry) *ya
 					vn := vnut.GetValueNode()
 					if vn.Kind == yaml.SequenceNode {
 						for i := range vn.Content {
-							rawNode.Content[i].Style = vn.Content[i].Style
+							if len(rawNode.Content) > i {
+								rawNode.Content[i].Style = vn.Content[i].Style
+							}
 						}
 					}
 				}

--- a/datamodel/high/node_builder_test.go
+++ b/datamodel/high/node_builder_test.go
@@ -720,7 +720,7 @@ func TestNewNodeBuilder_SliceRef_InlineNull(t *testing.T) {
 
 	data, _ := yaml.Marshal(node)
 
-	desired := `throg:`
+	desired := "throg:\n    - pizza"
 
 	assert.Equal(t, desired, strings.TrimSpace(string(data)))
 }

--- a/datamodel/spec_info.go
+++ b/datamodel/spec_info.go
@@ -114,6 +114,7 @@ func ExtractSpecInfoWithDocumentCheck(spec []byte, bypass bool) (*SpecInfo, erro
 			case "3.1.0", "3.1":
 				specInfo.VersionNumeric = 3.1
 				specInfo.APISchema = OpenAPI31SchemaData
+				specInfo.SpecFormat = OAS31
 			default:
 				specInfo.VersionNumeric = 3.0
 				specInfo.APISchema = OpenAPI3SchemaData

--- a/document.go
+++ b/document.go
@@ -296,7 +296,7 @@ func (d *document) BuildV3Model() (*DocumentModel[v3high.Document], []error) {
 		errs = append(errs, fmt.Errorf("unable to build document, no specification has been loaded"))
 		return nil, errs
 	}
-	if d.info.SpecFormat != datamodel.OAS3 {
+	if d.info.SpecFormat != datamodel.OAS3 && d.info.SpecFormat != datamodel.OAS31 {
 		errs = append(errs, fmt.Errorf("unable to build openapi document, "+
 			"supplied spec is a different version (%v). Try 'BuildV2Model()'", d.info.SpecFormat))
 		return nil, errs

--- a/index/spec_index_test.go
+++ b/index/spec_index_test.go
@@ -190,7 +190,7 @@ func TestSpecIndex_DigitalOcean(t *testing.T) {
 	// get all the files!
 	files := remoteFS.GetFiles()
 	fileLen := len(files)
-	assert.Equal(t, 1654, fileLen)
+	assert.Equal(t, 1658, fileLen)
 	assert.Len(t, remoteFS.GetErrors(), 0)
 
 	// check circular references


### PR DESCRIPTION
Fixes a glitch where the spec format was not being set correctly when being parsed for 3.1. Also adds a small length check to prevent the node builder from throwing a panic with a mismatched index.