### PR TITLE
Pin DigitalOcean spec index test to a specific commit hash

### DIFF
--- a/index/spec_index_test.go
+++ b/index/spec_index_test.go
@@ -142,7 +142,7 @@ func TestSpecIndex_DigitalOcean(t *testing.T) {
 	var rootNode yaml.Node
 	_ = yaml.Unmarshal(do, &rootNode)
 
-	location := "https://raw.githubusercontent.com/digitalocean/openapi/main/specification"
+	location := "https://raw.githubusercontent.com/digitalocean/openapi/8ce96ef186fe938bdce26fb2f5d63ac53ca9d06f/specification"
 	baseURL, _ := url.Parse(location)
 
 	// create a new config that allows remote lookups.
@@ -190,7 +190,7 @@ func TestSpecIndex_DigitalOcean(t *testing.T) {
 	// get all the files!
 	files := remoteFS.GetFiles()
 	fileLen := len(files)
-	assert.Equal(t, 1658, fileLen)
+	assert.Equal(t, 1660, fileLen)
 	assert.Len(t, remoteFS.GetErrors(), 0)
 
 	// check circular references


### PR DESCRIPTION
This PR addresses a failing test caused by changes in the upstream repository [`digitalocean/openapi`](https://github.com/digitalocean/openapi/pull/878). The test depended on the number of files in the `specification` directory, causing it to break whenever files were added or removed. This fix pins the DigitalOcean spec index test to a specific commit hash to ensure consistent test results.

#### Impact
- **Stability**: Tests will no longer break due to changes in the number of files in the upstream repository.
- **Reliability**: Ensures consistent and predictable test outcomes.