### PR TITLE
v0.16.9

### DIFF
--- a/datamodel/high/base/example.go
+++ b/datamodel/high/base/example.go
@@ -60,7 +60,9 @@ func (e *Example) MarshalYAML() (interface{}, error) {
 // MarshalJSON will marshal this into a JSON byte slice
 func (e *Example) MarshalJSON() ([]byte, error) {
 	var g map[string]any
-	e.Value.Decode(&g)
+	nb := high.NewNodeBuilder(e, e.low)
+	r := nb.Render()
+	r.Decode(&g)
 	return json.Marshal(g)
 }
 

--- a/datamodel/high/base/example.go
+++ b/datamodel/high/base/example.go
@@ -4,6 +4,7 @@
 package base
 
 import (
+	"encoding/json"
 	"github.com/pb33f/libopenapi/datamodel/high"
 	lowmodel "github.com/pb33f/libopenapi/datamodel/low"
 	low "github.com/pb33f/libopenapi/datamodel/low/base"
@@ -54,6 +55,13 @@ func (e *Example) Render() ([]byte, error) {
 func (e *Example) MarshalYAML() (interface{}, error) {
 	nb := high.NewNodeBuilder(e, e.low)
 	return nb.Render(), nil
+}
+
+// MarshalJSON will marshal this into a JSON byte slice
+func (e *Example) MarshalJSON() ([]byte, error) {
+	var g map[string]any
+	e.Value.Decode(&g)
+	return json.Marshal(g)
 }
 
 // ExtractExamples will convert a low-level example map, into a high level one that is simple to navigate.

--- a/datamodel/high/base/example_test.go
+++ b/datamodel/high/base/example_test.go
@@ -5,6 +5,7 @@ package base
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -53,6 +54,21 @@ x-hack: code`
 	// render the example as YAML
 	rendered, _ := highExample.Render()
 	assert.Equal(t, yml, strings.TrimSpace(string(rendered)))
+
+	// render the example as JSON
+	var err error
+	rendered, err = json.Marshal(highExample)
+	assert.NoError(t, err)
+
+	var j map[string]any
+	_ = json.Unmarshal(rendered, &j)
+
+	assert.Equal(t, "an example", j["summary"])
+	assert.Equal(t, "something more", j["description"])
+	assert.Equal(t, "https://pb33f.io", j["externalValue"])
+	assert.Equal(t, "code", j["x-hack"])
+	assert.Equal(t, "a thing", j["value"])
+
 }
 
 func TestExtractExamples(t *testing.T) {

--- a/datamodel/high/node_builder.go
+++ b/datamodel/high/node_builder.go
@@ -515,12 +515,14 @@ func (n *NodeBuilder) AddYAMLNode(parent *yaml.Node, entry *nodes.NodeEntry) *ya
 			}
 			if !encodeSkip {
 				var rawNode yaml.Node
-				err := rawNode.Encode(value)
-				if err != nil {
-					return parent
-				} else {
-					valueNode = &rawNode
-					valueNode.Line = line
+				if value != nil {
+					err := rawNode.Encode(value)
+					if err != nil {
+						return parent
+					} else {
+						valueNode = &rawNode
+						valueNode.Line = line
+					}
 				}
 			}
 		}

--- a/datamodel/high/node_builder.go
+++ b/datamodel/high/node_builder.go
@@ -394,7 +394,7 @@ func (n *NodeBuilder) AddYAMLNode(parent *yaml.Node, entry *nodes.NodeEntry) *ya
 			if entry.LowValue != nil {
 				if vnut, ok := entry.LowValue.(low.HasValueNodeUntyped); ok {
 					vn := vnut.GetValueNode()
-					if vn.Kind == yaml.SequenceNode {
+					if vn != nil && vn.Kind == yaml.SequenceNode {
 						for i := range vn.Content {
 							if len(rawNode.Content) > i {
 								rawNode.Content[i].Style = vn.Content[i].Style
@@ -516,6 +516,13 @@ func (n *NodeBuilder) AddYAMLNode(parent *yaml.Node, entry *nodes.NodeEntry) *ya
 			if !encodeSkip {
 				var rawNode yaml.Node
 				if value != nil {
+					// check if is a node and it's null
+					if v, ko := value.(*yaml.Node); ko {
+						if v.Tag == "!!null" {
+							return parent
+						}
+					}
+
 					err := rawNode.Encode(value)
 					if err != nil {
 						return parent

--- a/datamodel/high/v3/components.go
+++ b/datamodel/high/v3/components.go
@@ -147,6 +147,11 @@ func (c *Components) GoLow() *low.Components {
 	return c.low
 }
 
+// GoLowUntyped returns the low-level Components instance used to create the high-level one as an interface{}.
+func (c *Components) GoLowUntyped() any {
+	return c.low
+}
+
 // Render will return a YAML representation of the Components object as a byte slice.
 func (c *Components) Render() ([]byte, error) {
 	return yaml.Marshal(c)

--- a/datamodel/high/v3/components_test.go
+++ b/datamodel/high/v3/components_test.go
@@ -68,4 +68,5 @@ requestBodies:
 
 	dat, _ = r.Render()
 	assert.Equal(t, desired, strings.TrimSpace(string(dat)))
+	assert.NotNil(t, r.GoLowUntyped())
 }

--- a/datamodel/low/base/contact.go
+++ b/datamodel/low/base/contact.go
@@ -34,6 +34,16 @@ func (c *Contact) Build(_ context.Context, keyNode, root *yaml.Node, _ *index.Sp
 	return nil
 }
 
+// GetRootNode will return the root yaml node of the Contact object
+func (c *Contact) GetRootNode() *yaml.Node {
+	return c.RootNode
+}
+
+// GetKeyNode will return the key yaml node of the Contact object
+func (c *Contact) GetKeyNode() *yaml.Node {
+	return c.KeyNode
+}
+
 // Hash will return a consistent SHA256 Hash of the Contact object
 func (c *Contact) Hash() [32]byte {
 	var f []string

--- a/datamodel/low/base/contact_test.go
+++ b/datamodel/low/base/contact_test.go
@@ -31,4 +31,9 @@ email: buckaroo@pb33f.io`
 	_ = low.BuildModel(rNode.Content[0], &rDoc)
 
 	assert.Equal(t, lDoc.Hash(), rDoc.Hash())
+
+	c := Contact{}
+	c.Build(nil, &lNode, &rNode, nil)
+	assert.NotNil(t, c.GetRootNode())
+	assert.NotNil(t, c.GetKeyNode())
 }

--- a/datamodel/low/base/example.go
+++ b/datamodel/low/base/example.go
@@ -35,6 +35,16 @@ func (ex *Example) FindExtension(ext string) *low.ValueReference[*yaml.Node] {
 	return low.FindItemInOrderedMap[*yaml.Node](ext, ex.Extensions)
 }
 
+// GetRootNode will return the root yaml node of the Example object
+func (ex *Example) GetRootNode() *yaml.Node {
+	return ex.RootNode
+}
+
+// GetKeyNode will return the key yaml node of the Example object
+func (ex *Example) GetKeyNode() *yaml.Node {
+	return ex.KeyNode
+}
+
 // Hash will return a consistent SHA256 Hash of the Discriminator object
 func (ex *Example) Hash() [32]byte {
 	var f []string

--- a/datamodel/low/base/example_test.go
+++ b/datamodel/low/base/example_test.go
@@ -38,6 +38,8 @@ x-cake: hot`
 	var xCake string
 	_ = n.FindExtension("x-cake").Value.Decode(&xCake)
 	assert.Equal(t, "hot", xCake)
+	assert.NotNil(t, n.GetRootNode())
+	assert.Nil(t, n.GetKeyNode())
 }
 
 func TestExample_Build_Success_Simple(t *testing.T) {

--- a/datamodel/low/base/external_doc.go
+++ b/datamodel/low/base/external_doc.go
@@ -35,6 +35,16 @@ func (ex *ExternalDoc) FindExtension(ext string) *low.ValueReference[*yaml.Node]
 	return low.FindItemInOrderedMap[*yaml.Node](ext, ex.Extensions)
 }
 
+// GetRootNode will return the root yaml node of the ExternalDoc object
+func (ex *ExternalDoc) GetRootNode() *yaml.Node {
+	return ex.RootNode
+}
+
+// GetKeyNode will return the key yaml node of the ExternalDoc object
+func (ex *ExternalDoc) GetKeyNode() *yaml.Node {
+	return ex.KeyNode
+}
+
 // Build will extract extensions from the ExternalDoc instance.
 func (ex *ExternalDoc) Build(_ context.Context, keyNode, root *yaml.Node, idx *index.SpecIndex) error {
 	ex.KeyNode = keyNode

--- a/datamodel/low/base/external_doc_test.go
+++ b/datamodel/low/base/external_doc_test.go
@@ -32,6 +32,8 @@ func TestExternalDoc_FindExtension(t *testing.T) {
 	_ = n.FindExtension("x-fish").Value.Decode(&xFish)
 
 	assert.Equal(t, "cake", xFish)
+	assert.NotNil(t, n.GetRootNode())
+	assert.Nil(t, n.GetKeyNode())
 }
 
 func TestExternalDoc_Build(t *testing.T) {

--- a/datamodel/low/base/info.go
+++ b/datamodel/low/base/info.go
@@ -42,6 +42,16 @@ func (i *Info) FindExtension(ext string) *low.ValueReference[*yaml.Node] {
 	return low.FindItemInOrderedMap(ext, i.Extensions)
 }
 
+// GetRootNode will return the root yaml node of the Info object
+func (i *Info) GetRootNode() *yaml.Node {
+	return i.RootNode
+}
+
+// GetKeyNode will return the key yaml node of the Info object
+func (i *Info) GetKeyNode() *yaml.Node {
+	return i.KeyNode
+}
+
 // GetExtensions returns all extensions for Info
 func (i *Info) GetExtensions() *orderedmap.Map[low.KeyReference[string], low.ValueReference[*yaml.Node]] {
 	return i.Extensions

--- a/datamodel/low/base/info_test.go
+++ b/datamodel/low/base/info_test.go
@@ -60,6 +60,8 @@ x-cli-name: pizza cli`
 
 	assert.Equal(t, "pizza cli", xCliName)
 	assert.Equal(t, 1, orderedmap.Len(n.GetExtensions()))
+	assert.NotNil(t, n.GetRootNode())
+	assert.Nil(t, n.GetKeyNode())
 }
 
 func TestContact_Build(t *testing.T) {

--- a/datamodel/low/base/license.go
+++ b/datamodel/low/base/license.go
@@ -40,6 +40,16 @@ func (l *License) Build(ctx context.Context, keyNode, root *yaml.Node, idx *inde
 	return nil
 }
 
+// GetRootNode will return the root yaml node of the License object
+func (l *License) GetRootNode() *yaml.Node {
+	return l.RootNode
+}
+
+// GetKeyNode will return the key yaml node of the License object
+func (l *License) GetKeyNode() *yaml.Node {
+	return l.KeyNode
+}
+
 // Hash will return a consistent SHA256 Hash of the License object
 func (l *License) Hash() [32]byte {
 	var f []string

--- a/datamodel/low/base/license_test.go
+++ b/datamodel/low/base/license_test.go
@@ -31,6 +31,11 @@ description: the ranch`
 
 	assert.Equal(t, lDoc.Hash(), rDoc.Hash())
 
+	l := License{}
+	l.Build(nil, &lNode, &rNode, nil)
+	assert.NotNil(t, l.GetRootNode())
+	assert.NotNil(t, l.GetKeyNode())
+
 }
 
 func TestLicense_WithIdentifier_Hash(t *testing.T) {

--- a/datamodel/low/base/schema.go
+++ b/datamodel/low/base/schema.go
@@ -141,7 +141,8 @@ type Schema struct {
 	ParentProxy *SchemaProxy
 
 	// Index is a reference to the SpecIndex that was used to build this schema.
-	Index *index.SpecIndex
+	Index    *index.SpecIndex
+	RootNode *yaml.Node
 	*low.Reference
 }
 
@@ -433,6 +434,11 @@ func (s *Schema) GetExtensions() *orderedmap.Map[low.KeyReference[string], low.V
 	return s.Extensions
 }
 
+// GetRootNode will return the root yaml node of the Schema object
+func (s *Schema) GetRootNode() *yaml.Node {
+	return s.RootNode
+}
+
 // Build will perform a number of operations.
 // Extraction of the following happens in this method:
 //   - Extensions
@@ -465,6 +471,7 @@ func (s *Schema) Build(ctx context.Context, root *yaml.Node, idx *index.SpecInde
 	utils.CheckForMergeNodes(root)
 	s.Reference = new(low.Reference)
 	s.Index = idx
+	s.RootNode = root
 	if h, _, _ := utils.IsNodeRefValue(root); h {
 		ref, _, err, fctx := low.LocateRefNodeWithContext(ctx, root, idx)
 		if ref != nil {

--- a/datamodel/low/base/schema_proxy.go
+++ b/datamodel/low/base/schema_proxy.go
@@ -121,7 +121,7 @@ func (sp *SchemaProxy) GetKeyNode() *yaml.Node {
 	return sp.kn
 }
 
-// GetKeyNode will return the yaml.Node pointer that is a key for value node.
+// GetContext will return the context.Context object that was passed to the SchemaProxy during build.
 func (sp *SchemaProxy) GetContext() context.Context {
 	return sp.ctx
 }

--- a/datamodel/low/base/schema_test.go
+++ b/datamodel/low/base/schema_test.go
@@ -172,6 +172,7 @@ func Test_Schema(t *testing.T) {
 	assert.NoError(t, schErr)
 	assert.Equal(t, "something object", sch.Description.Value)
 	assert.True(t, sch.AdditionalProperties.Value.B)
+	assert.NotNil(t, sch.GetRootNode())
 
 	assert.Equal(t, 2, orderedmap.Len(sch.Properties.Value))
 	v := sch.FindProperty("somethingB")

--- a/datamodel/low/base/security_requirement.go
+++ b/datamodel/low/base/security_requirement.go
@@ -79,6 +79,16 @@ func (s *SecurityRequirement) Build(_ context.Context, keyNode, root *yaml.Node,
 	return nil
 }
 
+// GetRootNode will return the root yaml node of the SecurityRequirement object
+func (s *SecurityRequirement) GetRootNode() *yaml.Node {
+	return s.RootNode
+}
+
+// GetKeyNode will return the key yaml node of the SecurityRequirement object
+func (s *SecurityRequirement) GetKeyNode() *yaml.Node {
+	return s.KeyNode
+}
+
 // FindRequirement will attempt to locate a security requirement string from a supplied name.
 func (s *SecurityRequirement) FindRequirement(name string) []low.ValueReference[string] {
 	for pair := orderedmap.First(s.Requirements.Value); pair != nil; pair = pair.Next() {

--- a/datamodel/low/base/security_requirement_test.go
+++ b/datamodel/low/base/security_requirement_test.go
@@ -44,6 +44,8 @@ one:
 	assert.Len(t, sr.FindRequirement("one"), 2)
 	assert.Equal(t, sr.Hash(), sr2.Hash())
 	assert.Nil(t, sr.FindRequirement("i-do-not-exist"))
+	assert.NotNil(t, sr.GetRootNode())
+	assert.Nil(t, sr.GetKeyNode())
 }
 
 func TestSecurityRequirement_TestEmptyReq(t *testing.T) {

--- a/datamodel/low/base/tag.go
+++ b/datamodel/low/base/tag.go
@@ -36,6 +36,16 @@ func (t *Tag) FindExtension(ext string) *low.ValueReference[*yaml.Node] {
 	return low.FindItemInOrderedMap(ext, t.Extensions)
 }
 
+// GetRootNode returns the root yaml node of the Tag object
+func (t *Tag) GetRootNode() *yaml.Node {
+	return t.RootNode
+}
+
+// GetKeyNode returns the key yaml node of the Tag object
+func (t *Tag) GetKeyNode() *yaml.Node {
+	return t.KeyNode
+}
+
 // Build will extract extensions and external docs for the Tag.
 func (t *Tag) Build(ctx context.Context, keyNode, root *yaml.Node, idx *index.SpecIndex) error {
 	t.KeyNode = keyNode

--- a/datamodel/low/base/tag_test.go
+++ b/datamodel/low/base/tag_test.go
@@ -40,6 +40,8 @@ x-coffee: tasty`
 
 	assert.Equal(t, "tasty", xCoffee)
 	assert.Equal(t, 1, orderedmap.Len(n.GetExtensions()))
+	assert.NotNil(t, n.GetRootNode())
+	assert.Nil(t, n.GetKeyNode())
 }
 
 func TestTag_Build_Error(t *testing.T) {

--- a/datamodel/low/base/xml.go
+++ b/datamodel/low/base/xml.go
@@ -28,6 +28,7 @@ type XML struct {
 	Attribute  low.NodeReference[bool]
 	Wrapped    low.NodeReference[bool]
 	Extensions *orderedmap.Map[low.KeyReference[string], low.ValueReference[*yaml.Node]]
+	RootNode   *yaml.Node
 	*low.Reference
 }
 
@@ -35,6 +36,7 @@ type XML struct {
 func (x *XML) Build(root *yaml.Node, _ *index.SpecIndex) error {
 	root = utils.NodeAlias(root)
 	utils.CheckForMergeNodes(root)
+	x.RootNode = root
 	x.Reference = new(low.Reference)
 	x.Extensions = low.ExtractExtensions(root)
 	return nil

--- a/datamodel/low/low.go
+++ b/datamodel/low/low.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Princess B33f Heavy Industries / Dave Shanley
+// Copyright 2022-2004 Princess B33f Heavy Industries / Dave Shanley / Quobix
 // SPDX-License-Identifier: MIT
 
 // Package low contains a set of low-level models that represent OpenAPI 2 and 3 documents.
@@ -12,3 +12,11 @@
 // Navigating maps that use a KeyReference as a key is tricky, because there is no easy way to provide a lookup.
 // Convenience methods for lookup up properties in a low-level model have therefore been provided.
 package low
+
+import "gopkg.in/yaml.v3"
+
+// HasRootNode is an interface that is used to extract the root yaml.Node from a low-level model. The root node is
+// the top-level node that represents the entire object as represented in the original source file.
+type HasRootNode interface {
+	GetRootNode() *yaml.Node
+}

--- a/datamodel/low/v3/callback.go
+++ b/datamodel/low/v3/callback.go
@@ -36,6 +36,16 @@ func (cb *Callback) GetExtensions() *orderedmap.Map[low.KeyReference[string], lo
 	return cb.Extensions
 }
 
+// GetRootNode returns the root yaml node of the Callback object
+func (cb *Callback) GetRootNode() *yaml.Node {
+	return cb.RootNode
+}
+
+// GetKeyNode returns the key yaml node of the Callback object
+func (cb *Callback) GetKeyNode() *yaml.Node {
+	return cb.KeyNode
+}
+
 // FindExpression will locate a string expression and return a ValueReference containing the located PathItem
 func (cb *Callback) FindExpression(exp string) *low.ValueReference[*PathItem] {
 	return low.FindItemInOrderedMap(exp, cb.Expression)

--- a/datamodel/low/v3/callback_test.go
+++ b/datamodel/low/v3/callback_test.go
@@ -39,6 +39,8 @@ func TestCallback_Build_Success(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, 1, orderedmap.Len(n.Expression))
+	assert.NotNil(t, n.GetRootNode())
+	assert.Nil(t, n.GetKeyNode())
 }
 
 func TestCallback_Build_Error(t *testing.T) {

--- a/datamodel/low/v3/components_test.go
+++ b/datamodel/low/v3/components_test.go
@@ -79,7 +79,8 @@ func TestComponents_Build_Success(t *testing.T) {
 
 	err = n.Build(context.Background(), idxNode.Content[0], idx)
 	assert.NoError(t, err)
-
+	assert.NotNil(t, n.GetRootNode())
+	assert.NotNil(t, n.GetKeyNode())
 	assert.Equal(t, "one of many", n.FindSchema("one").Value.Schema().Description.Value)
 	assert.Equal(t, "two of many", n.FindSchema("two").Value.Schema().Description.Value)
 	assert.Equal(t, "three of many", n.FindResponse("three").Value.Description.Value)

--- a/datamodel/low/v3/encoding.go
+++ b/datamodel/low/v3/encoding.go
@@ -34,6 +34,16 @@ func (en *Encoding) FindHeader(hType string) *low.ValueReference[*Header] {
 	return low.FindItemInOrderedMap[*Header](hType, en.Headers.Value)
 }
 
+// GetRootNode returns the root yaml node of the Encoding object
+func (en *Encoding) GetRootNode() *yaml.Node {
+	return en.RootNode
+}
+
+// GetKeyNode returns the key yaml node of the Encoding object
+func (en *Encoding) GetKeyNode() *yaml.Node {
+	return en.KeyNode
+}
+
 // Hash will return a consistent SHA256 Hash of the Encoding object
 func (en *Encoding) Hash() [32]byte {
 	var f []string

--- a/datamodel/low/v3/encoding_test.go
+++ b/datamodel/low/v3/encoding_test.go
@@ -43,6 +43,8 @@ explode: true`
 	assert.Equal(t, "this is a header", header.Value.Description.Value)
 	assert.Equal(t, true, header.Value.Required.Value)
 	assert.Equal(t, true, header.Value.AllowEmptyValue.Value)
+	assert.NotNil(t, n.GetRootNode())
+	assert.Nil(t, n.GetKeyNode())
 }
 
 func TestEncoding_Build_Error(t *testing.T) {

--- a/datamodel/low/v3/header.go
+++ b/datamodel/low/v3/header.go
@@ -52,6 +52,16 @@ func (h *Header) FindContent(ext string) *low.ValueReference[*MediaType] {
 	return low.FindItemInOrderedMap[*MediaType](ext, h.Content.Value)
 }
 
+// GetRootNode returns the root yaml node of the Header object
+func (h *Header) GetRootNode() *yaml.Node {
+	return h.RootNode
+}
+
+// GetKeyNode returns the key yaml node of the Header object
+func (h *Header) GetKeyNode() *yaml.Node {
+	return h.KeyNode
+}
+
 // GetExtensions returns all Header extensions and satisfies the low.HasExtensions interface.
 func (h *Header) GetExtensions() *orderedmap.Map[low.KeyReference[string], low.ValueReference[*yaml.Node]] {
 	return h.Extensions

--- a/datamodel/low/v3/header_test.go
+++ b/datamodel/low/v3/header_test.go
@@ -59,6 +59,8 @@ content:
 
 	err = n.Build(context.Background(), nil, idxNode.Content[0], idx)
 	assert.NoError(t, err)
+	assert.NotNil(t, n.GetRootNode())
+	assert.Nil(t, n.GetKeyNode())
 	assert.Equal(t, "michelle, meddy and maddy", n.Description.Value)
 	assert.True(t, n.AllowReserved.Value)
 	assert.True(t, n.Explode.Value)

--- a/datamodel/low/v3/link.go
+++ b/datamodel/low/v3/link.go
@@ -55,11 +55,21 @@ func (l *Link) FindExtension(ext string) *low.ValueReference[*yaml.Node] {
 	return low.FindItemInOrderedMap(ext, l.Extensions)
 }
 
+// GetRootNode returns the root yaml node of the Link object
+func (l *Link) GetRootNode() *yaml.Node {
+	return l.RootNode
+}
+
+// GetKeyNode returns the key yaml node of the Link object
+func (l *Link) GetKeyNode() *yaml.Node {
+	return l.KeyNode
+}
+
 // Build will extract extensions and servers from the node.
 func (l *Link) Build(ctx context.Context, keyNode, root *yaml.Node, idx *index.SpecIndex) error {
 	l.KeyNode = keyNode
 	root = utils.NodeAlias(root)
-
+	l.RootNode = root
 	utils.CheckForMergeNodes(root)
 	l.Reference = new(low.Reference)
 	l.Extensions = low.ExtractExtensions(root)

--- a/datamodel/low/v3/link_test.go
+++ b/datamodel/low/v3/link_test.go
@@ -37,7 +37,8 @@ x-linky: slinky
 
 	err = n.Build(context.Background(), nil, idxNode.Content[0], idx)
 	assert.NoError(t, err)
-
+	assert.NotNil(t, n.GetRootNode())
+	assert.Nil(t, n.GetKeyNode())
 	assert.Equal(t, "#/someref", n.OperationRef.Value)
 	assert.Equal(t, "someId", n.OperationId.Value)
 	assert.Equal(t, "this is a link object.", n.Description.Value)

--- a/datamodel/low/v3/media_type.go
+++ b/datamodel/low/v3/media_type.go
@@ -56,6 +56,16 @@ func (mt *MediaType) GetAllExamples() *orderedmap.Map[low.KeyReference[string], 
 	return mt.Examples.Value
 }
 
+// GetRootNode returns the root yaml node of the MediaType object.
+func (mt *MediaType) GetRootNode() *yaml.Node {
+	return mt.RootNode
+}
+
+// GetKeyNode returns the key yaml node of the MediaType object.
+func (mt *MediaType) GetKeyNode() *yaml.Node {
+	return mt.KeyNode
+}
+
 // Build will extract examples, extensions, schema and encoding from node.
 func (mt *MediaType) Build(ctx context.Context, keyNode, root *yaml.Node, idx *index.SpecIndex) error {
 	mt.KeyNode = keyNode

--- a/datamodel/low/v3/media_type_test.go
+++ b/datamodel/low/v3/media_type_test.go
@@ -39,6 +39,9 @@ x-rock: and roll`
 	err = n.Build(context.Background(), nil, idxNode.Content[0], idx)
 	assert.NoError(t, err)
 
+	assert.NotNil(t, n.GetRootNode())
+	assert.Nil(t, n.GetKeyNode())
+
 	var xRock string
 	_ = n.FindExtension("x-rock").Value.Decode(&xRock)
 	assert.Equal(t, "and roll", xRock)

--- a/datamodel/low/v3/oauth_flows.go
+++ b/datamodel/low/v3/oauth_flows.go
@@ -39,6 +39,16 @@ func (o *OAuthFlows) FindExtension(ext string) *low.ValueReference[*yaml.Node] {
 	return low.FindItemInOrderedMap(ext, o.Extensions)
 }
 
+// GetRootNode returns the root yaml node of the OAuthFlows object.
+func (o *OAuthFlows) GetRootNode() *yaml.Node {
+	return o.RootNode
+}
+
+// GetKeyNode returns the key yaml node of the OAuthFlows object.
+func (o *OAuthFlows) GetKeyNode() *yaml.Node {
+	return o.KeyNode
+}
+
 // Build will extract extensions and all OAuthFlow types from the supplied node.
 func (o *OAuthFlows) Build(ctx context.Context, keyNode, root *yaml.Node, idx *index.SpecIndex) error {
 	o.KeyNode = keyNode
@@ -101,6 +111,7 @@ type OAuthFlow struct {
 	RefreshUrl       low.NodeReference[string]
 	Scopes           low.NodeReference[*orderedmap.Map[low.KeyReference[string], low.ValueReference[string]]]
 	Extensions       *orderedmap.Map[low.KeyReference[string], low.ValueReference[*yaml.Node]]
+	RootNode         *yaml.Node
 	*low.Reference
 }
 
@@ -119,10 +130,16 @@ func (o *OAuthFlow) FindExtension(ext string) *low.ValueReference[*yaml.Node] {
 	return low.FindItemInOrderedMap(ext, o.Extensions)
 }
 
+// GetRootNode returns the root yaml node of the OAuthFlow object.
+func (o *OAuthFlow) GetRootNode() *yaml.Node {
+	return o.RootNode
+}
+
 // Build will extract extensions from the node.
 func (o *OAuthFlow) Build(_ context.Context, _, root *yaml.Node, idx *index.SpecIndex) error {
 	o.Reference = new(low.Reference)
 	o.Extensions = low.ExtractExtensions(root)
+	o.RootNode = root
 	return nil
 }
 

--- a/datamodel/low/v3/oauth_flows_test.go
+++ b/datamodel/low/v3/oauth_flows_test.go
@@ -35,6 +35,8 @@ x-tasty: herbs
 	err = n.Build(context.Background(), nil, idxNode.Content[0], idx)
 	assert.NoError(t, err)
 
+	assert.NotNil(t, n.GetRootNode())
+
 	var xTasty string
 	_ = n.FindExtension("x-tasty").Value.Decode(&xTasty)
 	assert.Equal(t, "herbs", xTasty)
@@ -60,6 +62,9 @@ x-tasty: herbs`
 
 	err = n.Build(context.Background(), nil, idxNode.Content[0], idx)
 	assert.NoError(t, err)
+
+	assert.NotNil(t, n.GetRootNode())
+	assert.Nil(t, n.GetKeyNode())
 
 	var xTasty string
 	_ = n.FindExtension("x-tasty").GetValue().Decode(&xTasty)

--- a/datamodel/low/v3/operation.go
+++ b/datamodel/low/v3/operation.go
@@ -60,6 +60,16 @@ func (o *Operation) FindSecurityRequirement(name string) []low.ValueReference[st
 	return nil
 }
 
+// GetRootNode returns the root yaml node of the Operation object
+func (o *Operation) GetRootNode() *yaml.Node {
+	return o.RootNode
+}
+
+// GetKeyNode returns the key yaml node of the Operation object
+func (o *Operation) GetKeyNode() *yaml.Node {
+	return o.KeyNode
+}
+
 // Build will extract external docs, parameters, request body, responses, callbacks, security and servers.
 func (o *Operation) Build(ctx context.Context, keyNode, root *yaml.Node, idx *index.SpecIndex) error {
 	o.KeyNode = keyNode

--- a/datamodel/low/v3/operation_test.go
+++ b/datamodel/low/v3/operation_test.go
@@ -54,6 +54,8 @@ servers:
 
 	err = n.Build(context.Background(), nil, idxNode.Content[0], idx)
 	assert.NoError(t, err)
+	assert.NotNil(t, n.GetRootNode())
+	assert.Nil(t, n.GetKeyNode())
 
 	assert.Len(t, n.Tags.Value, 2)
 	assert.Equal(t, "building a business", n.Summary.Value)

--- a/datamodel/low/v3/parameter.go
+++ b/datamodel/low/v3/parameter.go
@@ -141,7 +141,7 @@ func (p *Parameter) Hash() [32]byte {
 	}
 	f = append(f, fmt.Sprint(p.Explode.Value))
 	f = append(f, fmt.Sprint(p.AllowReserved.Value))
-	if p.Schema.Value != nil {
+	if p.Schema.Value != nil && p.Schema.Value.Schema() != nil {
 		f = append(f, fmt.Sprintf("%x", p.Schema.Value.Schema().Hash()))
 	}
 	if p.Example.Value != nil && !p.Example.Value.IsZero() {

--- a/datamodel/low/v3/parameter.go
+++ b/datamodel/low/v3/parameter.go
@@ -41,6 +41,16 @@ type Parameter struct {
 	*low.Reference
 }
 
+// GetRootNode returns the root yaml node of the Parameter object.
+func (p *Parameter) GetRootNode() *yaml.Node {
+	return p.RootNode
+}
+
+// GetKeyNode returns the key yaml node of the Parameter object.
+func (p *Parameter) GetKeyNode() *yaml.Node {
+	return p.KeyNode
+}
+
 // FindContent will attempt to locate a MediaType instance using the specified name.
 func (p *Parameter) FindContent(cType string) *low.ValueReference[*MediaType] {
 	return low.FindItemInOrderedMap[*MediaType](cType, p.Content.Value)

--- a/datamodel/low/v3/parameter_test.go
+++ b/datamodel/low/v3/parameter_test.go
@@ -61,6 +61,8 @@ content:
 
 	err = n.Build(context.Background(), nil, idxNode.Content[0], idx)
 	assert.NoError(t, err)
+	assert.NotNil(t, n.GetRootNode())
+	assert.Nil(t, n.GetKeyNode())
 	assert.Equal(t, "michelle, meddy and maddy", n.Description.Value)
 	assert.True(t, n.AllowReserved.Value)
 	assert.True(t, n.Explode.Value)

--- a/datamodel/low/v3/path_item.go
+++ b/datamodel/low/v3/path_item.go
@@ -93,6 +93,16 @@ func (p *PathItem) Hash() [32]byte {
 	return sha256.Sum256([]byte(strings.Join(f, "|")))
 }
 
+// GetRootNode returns the root yaml node of the PathItem object
+func (p *PathItem) GetRootNode() *yaml.Node {
+	return p.RootNode
+}
+
+// GetKeyNode returns the key yaml node of the PathItem object
+func (p *PathItem) GetKeyNode() *yaml.Node {
+	return p.KeyNode
+}
+
 // FindExtension attempts to find an extension
 func (p *PathItem) FindExtension(ext string) *low.ValueReference[*yaml.Node] {
 	return low.FindItemInOrderedMap(ext, p.Extensions)

--- a/datamodel/low/v3/path_item_test.go
+++ b/datamodel/low/v3/path_item_test.go
@@ -82,4 +82,6 @@ summary: it's another path item`
 	// hash
 	assert.Equal(t, n.Hash(), n2.Hash())
 	assert.Equal(t, 1, orderedmap.Len(n.GetExtensions()))
+	assert.NotNil(t, n.GetRootNode())
+	assert.Nil(t, n.GetKeyNode())
 }

--- a/datamodel/low/v3/paths.go
+++ b/datamodel/low/v3/paths.go
@@ -32,6 +32,16 @@ type Paths struct {
 	*low.Reference
 }
 
+// GetRootNode returns the root yaml node of the Paths object.
+func (p *Paths) GetRootNode() *yaml.Node {
+	return p.RootNode
+}
+
+// GetKeyNode returns the key yaml node of the Paths object.
+func (p *Paths) GetKeyNode() *yaml.Node {
+	return p.KeyNode
+}
+
 // FindPath will attempt to locate a PathItem using the provided path string.
 func (p *Paths) FindPath(path string) (result *low.ValueReference[*PathItem]) {
 	for pair := orderedmap.First(p.PathItems); pair != nil; pair = pair.Next() {

--- a/datamodel/low/v3/paths_test.go
+++ b/datamodel/low/v3/paths_test.go
@@ -53,6 +53,8 @@ x-milk: cold`
 
 	err = n.Build(context.Background(), nil, idxNode.Content[0], idx)
 	assert.NoError(t, err)
+	assert.NotNil(t, n.GetRootNode())
+	assert.Nil(t, n.GetKeyNode())
 
 	path := n.FindPath("/some/path").Value
 	assert.NotNil(t, path)

--- a/datamodel/low/v3/request_body.go
+++ b/datamodel/low/v3/request_body.go
@@ -28,6 +28,16 @@ type RequestBody struct {
 	*low.Reference
 }
 
+// GetRootNode returns the root yaml node of the RequestBody object.
+func (rb *RequestBody) GetRootNode() *yaml.Node {
+	return rb.RootNode
+}
+
+// GetKeyNode returns the key yaml node of the RequestBody object.
+func (rb *RequestBody) GetKeyNode() *yaml.Node {
+	return rb.KeyNode
+}
+
 // FindExtension attempts to locate an extension using the provided name.
 func (rb *RequestBody) FindExtension(ext string) *low.ValueReference[*yaml.Node] {
 	return low.FindItemInOrderedMap(ext, rb.Extensions)

--- a/datamodel/low/v3/request_body_test.go
+++ b/datamodel/low/v3/request_body_test.go
@@ -31,6 +31,9 @@ x-requesto: presto`
 	assert.NoError(t, err)
 
 	err = n.Build(context.Background(), nil, idxNode.Content[0], idx)
+
+	assert.NotNil(t, n.GetRootNode())
+	assert.Nil(t, n.GetKeyNode())
 	assert.NoError(t, err)
 	assert.Equal(t, "a nice request", n.Description.Value)
 	assert.True(t, n.Required.Value)

--- a/datamodel/low/v3/response.go
+++ b/datamodel/low/v3/response.go
@@ -32,6 +32,16 @@ type Response struct {
 	*low.Reference
 }
 
+// GetRootNode returns the root yaml node of the Response object.
+func (r *Response) GetRootNode() *yaml.Node {
+	return r.RootNode
+}
+
+// GetKeyNode returns the key yaml node of the Response object.
+func (r *Response) GetKeyNode() *yaml.Node {
+	return r.KeyNode
+}
+
 // FindExtension will attempt to locate an extension using the supplied key
 func (r *Response) FindExtension(ext string) *low.ValueReference[*yaml.Node] {
 	return low.FindItemInOrderedMap(ext, r.Extensions)

--- a/datamodel/low/v3/response_test.go
+++ b/datamodel/low/v3/response_test.go
@@ -42,6 +42,10 @@ default:
 	assert.NoError(t, err)
 
 	err = n.Build(context.Background(), nil, idxNode.Content[0], idx)
+
+	assert.NotNil(t, n.GetRootNode())
+	assert.Nil(t, n.GetKeyNode())
+
 	assert.NoError(t, err)
 	assert.Equal(t, "default response", n.Default.Value.Description.Value)
 
@@ -227,6 +231,7 @@ func TestResponses_Build_AllowXPrefixHeader(t *testing.T) {
 
 	assert.Equal(t, "string",
 		n.FindResponseByCode("200").Value.FindHeader("x-header1").Value.Schema.Value.Schema().Type.Value.A)
+	assert.NotNil(t, n.FindResponseByCode("200").GetValue().GetRootNode())
 
 }
 

--- a/datamodel/low/v3/response_test.go
+++ b/datamodel/low/v3/response_test.go
@@ -52,6 +52,7 @@ default:
 	ok := n.FindResponseByCode("200")
 	assert.NotNil(t, ok.Value)
 	assert.Equal(t, "some response", ok.Value.Description.Value)
+	assert.NotNil(t, ok.Value.GetKeyNode())
 
 	var xGut string
 	_ = ok.Value.FindExtension("x-gut").Value.Decode(&xGut)

--- a/datamodel/low/v3/responses.go
+++ b/datamodel/low/v3/responses.go
@@ -43,6 +43,16 @@ type Responses struct {
 	*low.Reference
 }
 
+// GetRootNode returns the root yaml node of the Responses object.
+func (r *Responses) GetRootNode() *yaml.Node {
+	return r.RootNode
+}
+
+// GetKeyNode returns the key yaml node of the Responses object.
+func (r *Responses) GetKeyNode() *yaml.Node {
+	return r.KeyNode
+}
+
 // GetExtensions returns all Responses extensions and satisfies the low.HasExtensions interface.
 func (r *Responses) GetExtensions() *orderedmap.Map[low.KeyReference[string], low.ValueReference[*yaml.Node]] {
 	return r.Extensions

--- a/datamodel/low/v3/security_scheme.go
+++ b/datamodel/low/v3/security_scheme.go
@@ -40,6 +40,16 @@ type SecurityScheme struct {
 	*low.Reference
 }
 
+// GetRootNode returns the root yaml node of the SecurityScheme object.
+func (ss *SecurityScheme) GetRootNode() *yaml.Node {
+	return ss.RootNode
+}
+
+// GetKeyNode returns the key yaml node of the SecurityScheme object.
+func (ss *SecurityScheme) GetKeyNode() *yaml.Node {
+	return ss.KeyNode
+}
+
 // FindExtension attempts to locate an extension using the supplied key.
 func (ss *SecurityScheme) FindExtension(ext string) *low.ValueReference[*yaml.Node] {
 	return low.FindItemInOrderedMap(ext, ss.Extensions)

--- a/datamodel/low/v3/security_scheme_test.go
+++ b/datamodel/low/v3/security_scheme_test.go
@@ -60,6 +60,8 @@ x-milk: please`
 
 	err = n.Build(context.Background(), nil, idxNode.Content[0], idx)
 	assert.NoError(t, err)
+	assert.NotNil(t, n.GetRootNode())
+	assert.Nil(t, n.GetKeyNode())
 
 	assert.Equal(t, "306c5ee231d9854f21f03e909517c1fa8a8cb9431f11e8429a501eafaca31652",
 		low.GenerateHashString(&n))

--- a/datamodel/low/v3/server.go
+++ b/datamodel/low/v3/server.go
@@ -27,6 +27,11 @@ type Server struct {
 	*low.Reference
 }
 
+// GetRootNode returns the root yaml node of the Server object.
+func (s *Server) GetRootNode() *yaml.Node {
+	return s.RootNode
+}
+
 // GetExtensions returns all Paths extensions and satisfies the low.HasExtensions interface.
 func (s *Server) GetExtensions() *orderedmap.Map[low.KeyReference[string], low.ValueReference[*yaml.Node]] {
 	return s.Extensions

--- a/datamodel/low/v3/server_test.go
+++ b/datamodel/low/v3/server_test.go
@@ -31,10 +31,11 @@ variables:
 	var n Server
 	err := low.BuildModel(idxNode.Content[0], &n)
 	assert.NoError(t, err)
+	assert.Nil(t, n.GetRootNode())
 
 	err = n.Build(context.Background(), nil, idxNode.Content[0], idx)
 	assert.NoError(t, err)
-
+	assert.NotNil(t, n.GetRootNode())
 	assert.Equal(t, "25535d0a6dd30c609aeae6e08f9eaa82fef49df540fc048fe4adffbce7841c0b",
 		low.GenerateHashString(&n))
 

--- a/index/extract_refs.go
+++ b/index/extract_refs.go
@@ -430,7 +430,12 @@ func (index *SpecIndex) ExtractRefs(node, parent *yaml.Node, seenPath []string, 
 
 			if i%2 == 0 && n.Value != "$ref" && n.Value != "" {
 
-				loc := append(seenPath, n.Value)
+				v := n.Value
+				if strings.HasPrefix(v, "/") {
+					v = strings.Replace(v, "/", "~1", 1)
+				}
+
+				loc := append(seenPath, v)
 				definitionPath := fmt.Sprintf("#/%s", strings.Join(loc, "/"))
 				_, jsonPath := utils.ConvertComponentIdIntoFriendlyPathSearch(definitionPath)
 

--- a/index/spec_index_test.go
+++ b/index/spec_index_test.go
@@ -1249,15 +1249,15 @@ components:
 	if assert.Contains(t, params, "/") {
 		if assert.Contains(t, params["/"], "top") {
 			if assert.Contains(t, params["/"]["top"], "#/components/parameters/param1") {
-				assert.Equal(t, "$.components.parameters.param1", params["/"]["top"]["#/components/parameters/param1"][0].Path)
+				assert.Equal(t, "$.components.parameters['param1']", params["/"]["top"]["#/components/parameters/param1"][0].Path)
 			}
 			if assert.Contains(t, params["/"]["top"], "paramour.yaml#/components/parameters/param3") {
-				assert.Equal(t, "$.components.parameters.param3", params["/"]["top"]["paramour.yaml#/components/parameters/param3"][0].Path)
+				assert.Equal(t, "$.components.parameters['param3']", params["/"]["top"]["paramour.yaml#/components/parameters/param3"][0].Path)
 			}
 		}
 		if assert.Contains(t, params["/"], "get") {
 			if assert.Contains(t, params["/"]["get"], "#/components/parameters/param2") {
-				assert.Equal(t, "$.components.parameters.param2", params["/"]["get"]["#/components/parameters/param2"][0].Path)
+				assert.Equal(t, "$.components.parameters['param2']", params["/"]["get"]["#/components/parameters/param2"][0].Path)
 			}
 			if assert.Contains(t, params["/"]["get"], "test") {
 				assert.Equal(t, "$.paths['/'].get.parameters[2]", params["/"]["get"]["test"][0].Path)
@@ -1620,9 +1620,9 @@ paths:
 	idx := NewSpecIndexWithConfig(&rootNode, CreateOpenAPIIndexConfig())
 
 	schemas := idx.GetAllInlineSchemas()
-	assert.Equal(t, "$.paths['/test'].get.parameters.schema", schemas[0].Path)
-	assert.Equal(t, "$.paths['/test'].get.parameters.schema.properties.code", schemas[1].Path)
-	assert.Equal(t, "$.paths['/test'].get.parameters.schema.properties.message", schemas[2].Path)
+	assert.Equal(t, "$.paths['/test'].get.parameters['schema']", schemas[0].Path)
+	assert.Equal(t, "$.paths['/test'].get.parameters['schema'].properties['code']", schemas[1].Path)
+	assert.Equal(t, "$.paths['/test'].get.parameters['schema'].properties['message']", schemas[2].Path)
 }
 
 func TestSpecIndex_TestPathsAsRef(t *testing.T) {
@@ -1655,8 +1655,8 @@ components:
 
 	index := NewSpecIndexWithConfig(&rootNode, CreateOpenAPIIndexConfig())
 	params := index.GetOperationParameterReferences()
-	assert.Equal(t, "$.components.parameters.test-2", params["/test"]["top"]["#/components/parameters/test-2"][0].Path)
-	assert.Equal(t, "$.components.parameters.test-3", params["/test-2"]["get"]["#/components/parameters/test-3"][0].Path)
+	assert.Equal(t, "$.components.parameters['test-2']", params["/test"]["top"]["#/components/parameters/test-2"][0].Path)
+	assert.Equal(t, "$.components.parameters['test-3']", params["/test-2"]["get"]["#/components/parameters/test-3"][0].Path)
 	assert.Equal(t, "bing bong", params["/test"]["top"]["#/components/parameters/test-2"][0].Node.Content[5].Value)
 	assert.Equal(t, "ding a ling", params["/test"]["get"]["#/components/parameters/test-3"][0].Node.Content[5].Value)
 }

--- a/index/utility_methods.go
+++ b/index/utility_methods.go
@@ -425,7 +425,7 @@ func (index *SpecIndex) scanOperationParams(params []*yaml.Node, keyNode, pathIt
 
 				index.operationParamErrors = append(index.operationParamErrors, &IndexingError{
 					Err: fmt.Errorf("the `%s` operation parameter at path `%s`, "+
-						"index %d has a duplicate ref `%s`", method, pathItemNode.Value, i, paramRefName),
+						"index %d has a duplicate ref `%s`", strings.ToUpper(method), pathItemNode.Value, i, paramRefName),
 					Node: param,
 					Path: path,
 				})
@@ -449,8 +449,8 @@ func (index *SpecIndex) scanOperationParams(params []*yaml.Node, keyNode, pathIt
 
 			if vn == nil {
 				index.operationParamErrors = append(index.operationParamErrors, &IndexingError{
-					Err: fmt.Errorf("the '%s' operation parameter at path '%s', index %d has no 'name' value",
-						method, pathItemNode.Value, i),
+					Err: fmt.Errorf("the `%s` operation parameter at path `%s`, index %d has no `name` value",
+						strings.ToUpper(method), pathItemNode.Value, i),
 					Node: param,
 					Path: path,
 				})
@@ -494,7 +494,7 @@ func (index *SpecIndex) scanOperationParams(params []*yaml.Node, keyNode, pathIt
 
 						index.operationParamErrors = append(index.operationParamErrors, &IndexingError{
 							Err: fmt.Errorf("the `%s` operation parameter at path `%s`, "+
-								"index %d has a duplicate name `%s` and `in` type", method, pathItemNode.Value, i, vn.Value),
+								"index %d has a duplicate name `%s` and `in` type", strings.ToUpper(method), pathItemNode.Value, i, vn.Value),
 							Node: param,
 							Path: path,
 						})

--- a/renderer/schema_renderer.go
+++ b/renderer/schema_renderer.go
@@ -320,8 +320,13 @@ func (wr *SchemaRenderer) DiveIntoSchema(schema *base.Schema, key string, struct
 			for _, allOfSchema := range allOf {
 				allOfCompiled := allOfSchema.Schema()
 				wr.DiveIntoSchema(allOfCompiled, allOfType, allOfMap, depth+1)
-				for k, v := range allOfMap[allOfType].(map[string]any) {
-					propertyMap[k] = v
+				if m, ok := allOfMap[allOfType].(map[string]any); ok {
+					for k, v := range m {
+						propertyMap[k] = v
+					}
+				}
+				if m, ok := allOfMap[allOfType].(string); ok {
+					propertyMap[allOfType] = m
 				}
 			}
 		}
@@ -349,8 +354,13 @@ func (wr *SchemaRenderer) DiveIntoSchema(schema *base.Schema, key string, struct
 			oneOfMap := make(map[string]any)
 			oneOfCompiled := oneOf[0].Schema()
 			wr.DiveIntoSchema(oneOfCompiled, oneOfType, oneOfMap, depth+1)
-			for k, v := range oneOfMap[oneOfType].(map[string]any) {
-				propertyMap[k] = v
+			if m, ok := oneOfMap[oneOfType].(map[string]any); ok {
+				for k, v := range m {
+					propertyMap[k] = v
+				}
+			}
+			if m, ok := oneOfMap[oneOfType].(string); ok {
+				propertyMap[oneOfType] = m
 			}
 		}
 
@@ -360,8 +370,13 @@ func (wr *SchemaRenderer) DiveIntoSchema(schema *base.Schema, key string, struct
 			anyOfMap := make(map[string]any)
 			anyOfCompiled := anyOf[0].Schema()
 			wr.DiveIntoSchema(anyOfCompiled, anyOfType, anyOfMap, depth+1)
-			for k, v := range anyOfMap[anyOfType].(map[string]any) {
-				propertyMap[k] = v
+			if m, ok := anyOfMap[anyOfType].(map[string]any); ok {
+				for k, v := range m {
+					propertyMap[k] = v
+				}
+			}
+			if m, ok := anyOfMap[anyOfType].(string); ok {
+				propertyMap[anyOfType] = m
 			}
 		}
 		structure[key] = propertyMap

--- a/renderer/schema_renderer_test.go
+++ b/renderer/schema_renderer_test.go
@@ -659,6 +659,22 @@ dependentSchemas:
 	assert.True(t, journeyMap["pb33f"].(map[string]interface{})["fishCake"].(map[string]interface{})["bones"].(bool))
 }
 
+func TestRenderExample_String_AllOf(t *testing.T) {
+	testObject := `type: object
+allOf:
+  - type: string`
+
+	compiled := getSchema([]byte(testObject))
+
+	journeyMap := make(map[string]any)
+	wr := createSchemaRenderer()
+	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, 0)
+
+	assert.NotNil(t, journeyMap["pb33f"])
+	assert.Len(t, journeyMap["pb33f"], 1)
+	assert.Greater(t, len(journeyMap["pb33f"].(map[string]interface{})["allOf"].(string)), 0)
+}
+
 func TestRenderExample_Object_OneOf(t *testing.T) {
 	testObject := `type: object
 oneOf:
@@ -683,6 +699,22 @@ oneOf:
 	assert.Greater(t, len(journeyMap["pb33f"].(map[string]interface{})["bones"].(string)), 0)
 }
 
+func TestRenderExample_String_OneOf(t *testing.T) {
+	testObject := `type: object
+oneOf:
+  - type: string`
+
+	compiled := getSchema([]byte(testObject))
+
+	journeyMap := make(map[string]any)
+	wr := createSchemaRenderer()
+	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, 0)
+
+	assert.NotNil(t, journeyMap["pb33f"])
+	assert.Len(t, journeyMap["pb33f"], 1)
+	assert.Greater(t, len(journeyMap["pb33f"].(map[string]interface{})["oneOf"].(string)), 0)
+}
+
 func TestRenderExample_Object_AnyOf(t *testing.T) {
 	testObject := `type: object
 anyOf:
@@ -705,6 +737,22 @@ anyOf:
 	assert.NotNil(t, journeyMap["pb33f"])
 	assert.Len(t, journeyMap["pb33f"], 1)
 	assert.Greater(t, len(journeyMap["pb33f"].(map[string]interface{})["bones"].(string)), 0)
+}
+
+func TestRenderExample_String_AnyOf(t *testing.T) {
+	testObject := `type: object
+anyOf:
+  - type: string`
+
+	compiled := getSchema([]byte(testObject))
+
+	journeyMap := make(map[string]any)
+	wr := createSchemaRenderer()
+	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, 0)
+
+	assert.NotNil(t, journeyMap["pb33f"])
+	assert.Len(t, journeyMap["pb33f"], 1)
+	assert.Greater(t, len(journeyMap["pb33f"].(map[string]interface{})["anyOf"].(string)), 0)
 }
 
 func TestRenderExample_TestGiftshopProduct_UsingExamples(t *testing.T) {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -588,7 +588,7 @@ func IsHttpVerb(verb string) bool {
 
 // define bracket name expression
 var (
-	bracketNameExp = regexp.MustCompile(`^(\w+)\['?(\w+)'?]$`)
+	bracketNameExp = regexp.MustCompile(`^(\w+)\['?([\w/]+)'?]$`)
 	pathCharExp    = regexp.MustCompile(`[%=;~.]`)
 )
 
@@ -689,8 +689,12 @@ func ConvertComponentIdIntoPath(id string) (string, string) {
 
 		// if there are brackets, shift the path to encapsulate them correctly.
 		if len(brackets) > 0 {
+
+			//bracketNameExp/.
+			key := bracketNameExp.ReplaceAllString(segs[i], "$1")
+			val := strings.ReplaceAll(bracketNameExp.ReplaceAllString(segs[i], "$2"), "/", "~1")
 			cleaned = append(cleaned[:i],
-				append([]string{bracketNameExp.ReplaceAllString(segs[i], "$1/$2")}, cleaned[i:]...)...)
+				append([]string{fmt.Sprintf("%s/%s", key, val)}, cleaned[i:]...)...)
 			continue
 		}
 		cleaned = append(cleaned, segs[i])

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
-	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -589,8 +588,8 @@ func IsHttpVerb(verb string) bool {
 
 // define bracket name expression
 var (
-	bracketNameExp = regexp.MustCompile(`^(\w+)\['?(\w+)\'?]$`)
-	pathCharExp    = regexp.MustCompile(`[\\%=;~.]`)
+	bracketNameExp = regexp.MustCompile(`^(\w+)\['?(\w+)'?]$`)
+	pathCharExp    = regexp.MustCompile(`[%=;~.]`)
 )
 
 func ConvertComponentIdIntoFriendlyPathSearch(id string) (string, string) {
@@ -601,20 +600,20 @@ func ConvertComponentIdIntoFriendlyPathSearch(id string) (string, string) {
 	// check for strange spaces, chars and if found, wrap them up, clean them and create a new cleaned path.
 	for i := range segs {
 		if pathCharExp.Match([]byte(segs[i])) {
-
 			segs[i], _ = url.QueryUnescape(strings.ReplaceAll(segs[i], "~1", "/"))
-			// strip out any backslashes, but only on non-windows systems.
-			if runtime.GOOS != "windows" && strings.Contains(id, "#") && strings.Contains(segs[i], `\`) {
-				segs[i] = strings.ReplaceAll(segs[i], `\`, "")
-				cleaned = append(cleaned, segs[i])
-				continue
-			}
 			segs[i] = fmt.Sprintf("['%s']", segs[i])
 			if len(cleaned) > 0 {
 				cleaned[len(cleaned)-1] = fmt.Sprintf("%s%s", segs[i-1], segs[i])
 				continue
 			}
 		} else {
+
+			// strip out any backslashes
+			if strings.Contains(id, "#") && strings.Contains(segs[i], `\`) {
+				segs[i] = strings.ReplaceAll(segs[i], `\`, "")
+				cleaned = append(cleaned, segs[i])
+				continue
+			}
 
 			// check for brackets in the name, and if found, rewire the path to encapsulate them
 			// correctly. https://github.com/pb33f/libopenapi/issues/112

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -702,11 +702,6 @@ func ConvertComponentIdIntoPath(id string) (string, string) {
 	}
 	replaced := strings.ReplaceAll(strings.Join(cleaned, "/"), "$", "#")
 
-	if len(replaced) > 0 {
-		if replaced[0] != '#' {
-			replaced = fmt.Sprintf("#%s", replaced)
-		}
-	}
 	return name, replaced
 }
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -602,7 +603,8 @@ func ConvertComponentIdIntoFriendlyPathSearch(id string) (string, string) {
 		if pathCharExp.Match([]byte(segs[i])) {
 
 			segs[i], _ = url.QueryUnescape(strings.ReplaceAll(segs[i], "~1", "/"))
-			if strings.Contains(id, "#") && strings.Contains(segs[i], `\`) {
+			// strip out any backslashes, but only on non-windows systems.
+			if runtime.GOOS != "windows" && strings.Contains(id, "#") && strings.Contains(segs[i], `\`) {
 				segs[i] = strings.ReplaceAll(segs[i], `\`, "")
 				cleaned = append(cleaned, segs[i])
 				continue

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -697,7 +697,7 @@ func TestIsHttpVerb(t *testing.T) {
 
 func TestConvertComponentIdIntoFriendlyPathSearch(t *testing.T) {
 	segment, path := ConvertComponentIdIntoFriendlyPathSearch("#/chicken/chips/pizza/cake")
-	assert.Equal(t, "$.chicken.chips.pizza.cake", path)
+	assert.Equal(t, "$.chicken.chips['pizza'].cake", path)
 	assert.Equal(t, "cake", segment)
 }
 
@@ -708,15 +708,23 @@ func TestConvertComponentIdIntoFriendlyPathSearch_SuperCrazy(t *testing.T) {
 }
 
 func TestConvertComponentIdIntoFriendlyPathSearch_Crazy(t *testing.T) {
-	segment, path := ConvertComponentIdIntoFriendlyPathSearch("#/components/schemas/gpg-key/properties/subkeys/example/0/expires_at")
-	assert.Equal(t, "$.components.schemas.gpg-key.properties.subkeys.example[0].expires_at", path)
+	segment, path := ConvertComponentIdIntoFriendlyPathSearch("#/components/schemas/gpg-key/properties/subkeys/examples/0/expires_at")
+	assert.Equal(t, "$.components.schemas['gpg-key'].properties['subkeys'].examples[0].expires_at", path)
 	assert.Equal(t, "expires_at", segment)
 }
 
 func BenchmarkConvertComponentIdIntoFriendlyPathSearch_Crazy(t *testing.B) {
 	for n := 0; n < t.N; n++ {
-		segment, path := ConvertComponentIdIntoFriendlyPathSearch("#/components/schemas/gpg-key/properties/subkeys/example/0/expires_at")
-		assert.Equal(t, "$.components.schemas.gpg-key.properties.subkeys.example[0].expires_at", path)
+		segment, path := ConvertComponentIdIntoFriendlyPathSearch("#/components/schemas/gpg-key/properties/subkeys/examples/0/expires_at")
+		assert.Equal(t, "$.components.schemas.gpg-key.properties['subkeys'].examples[0].expires_at", path)
+		assert.Equal(t, "expires_at", segment)
+	}
+}
+
+func BenchmarkConvertComponentIdIntoFriendlyPathSearch_Plural(t *testing.B) {
+	for n := 0; n < t.N; n++ {
+		segment, path := ConvertComponentIdIntoFriendlyPathSearch("#/components/schemas/gpg-key/properties/subkeys/examples/0/expires_at")
+		assert.Equal(t, "$.components.schemas['gpg-key'].properties['subkeys'].examples[0].expires_at", path)
 		assert.Equal(t, "expires_at", segment)
 	}
 }
@@ -725,6 +733,12 @@ func TestConvertComponentIdIntoFriendlyPathSearch_Simple(t *testing.T) {
 	segment, path := ConvertComponentIdIntoFriendlyPathSearch("#/~1fresh~1pizza/get")
 	assert.Equal(t, "$['/fresh/pizza'].get", path)
 	assert.Equal(t, "get", segment)
+}
+
+func TestConvertComponentIdIntoFriendlyPathSearch_Plural(t *testing.T) {
+	segment, path := ConvertComponentIdIntoFriendlyPathSearch("#/components/schemas/FreshMan/properties/subkeys/examples/0/expires_at")
+	assert.Equal(t, "$.components.schemas['FreshMan'].properties['subkeys'].examples[0].expires_at", path)
+	assert.Equal(t, "expires_at", segment)
 }
 
 func TestConvertComponentIdIntoFriendlyPathSearch_Params(t *testing.T) {
@@ -776,9 +790,20 @@ func TestConvertComponentIdIntoFriendlyPathSearch_HTTPCode(t *testing.T) {
 }
 
 func TestConvertComponentIdIntoPath(t *testing.T) {
-	segment, path := ConvertComponentIdIntoPath("#/chicken/chips/pizza/cake")
-	assert.Equal(t, "$.chicken.chips.pizza.cake", path)
+	segment, path := ConvertComponentIdIntoPath("$.chicken.chips.pizza.cake")
+	assert.Equal(t, "#/chicken/chips/pizza/cake", path)
 	assert.Equal(t, "cake", segment)
+}
+
+func TestConvertComponentIdIntoPath_Alt1(t *testing.T) {
+	segment, path := ConvertComponentIdIntoPath("$.chicken.chips['pizza'].cakes[0].burgers[2]")
+	assert.Equal(t, "#/chicken/chips/pizza/cakes/0/burgers/2", path)
+	assert.Equal(t, "burgers[2]", segment)
+}
+
+func TestConvertComponentIdIntoPath_Alt2(t *testing.T) {
+	_, path := ConvertComponentIdIntoPath("chicken.chips['pizza'].cakes[0].burgers[2]")
+	assert.Equal(t, "#/chicken/chips/pizza/cakes/0/burgers/2", path)
 }
 
 func TestDetectCase(t *testing.T) {

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -817,6 +817,11 @@ func TestConvertComponentIdIntoPath_Alt2(t *testing.T) {
 	assert.Equal(t, "#/chicken/chips/pizza/cakes/0/burgers/2", path)
 }
 
+func TestConvertComponentIdIntoPath_Alt3(t *testing.T) {
+	_, path := ConvertComponentIdIntoPath("chicken.chips['/one/two/pizza'].cakes[0].burgers[2]")
+	assert.Equal(t, "#/chicken/chips/~1one~1two~1pizza/cakes/0/burgers/2", path)
+}
+
 func TestDetectCase(t *testing.T) {
 	assert.Equal(t, PascalCase, DetectCase("PizzaPie"))
 	assert.Equal(t, CamelCase, DetectCase("anyoneForTennis"))

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -783,6 +783,11 @@ func TestConvertComponentIdIntoFriendlyPathSearch_Array(t *testing.T) {
 	assert.Equal(t, "0", segment)
 }
 
+func TestConvertComponentIdIntoFriendlyPathSearch_Slashes(t *testing.T) {
+	_, path := ConvertComponentIdIntoFriendlyPathSearch(`#/nice/\rice/\and/\spice`)
+	assert.Equal(t, "$.nice.rice.and.spice", path)
+}
+
 func TestConvertComponentIdIntoFriendlyPathSearch_HTTPCode(t *testing.T) {
 	segment, path := ConvertComponentIdIntoFriendlyPathSearch("#/paths/~1crazy~1ass~1references/get/responses/404")
 	assert.Equal(t, "$.paths['/crazy/ass/references'].get.responses['404']", path)
@@ -791,6 +796,12 @@ func TestConvertComponentIdIntoFriendlyPathSearch_HTTPCode(t *testing.T) {
 
 func TestConvertComponentIdIntoPath(t *testing.T) {
 	segment, path := ConvertComponentIdIntoPath("$.chicken.chips.pizza.cake")
+	assert.Equal(t, "#/chicken/chips/pizza/cake", path)
+	assert.Equal(t, "cake", segment)
+}
+
+func TestConvertComponentIdIntoPath_NoHash(t *testing.T) {
+	segment, path := ConvertComponentIdIntoPath("chicken.chips.pizza.cake")
 	assert.Equal(t, "#/chicken/chips/pizza/cake", path)
 	assert.Equal(t, "cake", segment)
 }


### PR DESCRIPTION
Adds `GetKeyNode` and `GetRootNode` methods to low level models. Useful for interfaces in downstream applications.
A general tuneup in various places after hammering the library as part of a larger stack of applications. 

Addresses issues:

- #285

