### PR TITLE
fix: render empty scalar nodes

### DIFF
--- a/datamodel/high/node_builder.go
+++ b/datamodel/high/node_builder.go
@@ -500,6 +500,13 @@ func (n *NodeBuilder) AddYAMLNode(parent *yaml.Node, entry *nodes.NodeEntry) *ya
 					valueNode.Line = line
 				}
 			}
+			if b, bok := value.(*yaml.Node); bok {
+				if b.Kind == yaml.ScalarNode && b.Tag == "!!null" {
+					encodeSkip = true
+					valueNode = utils.CreateEmptyScalarNode()
+					valueNode.Line = line
+				}
+			}
 			if !encodeSkip {
 				var rawNode yaml.Node
 				err := rawNode.Encode(value)

--- a/datamodel/high/node_builder.go
+++ b/datamodel/high/node_builder.go
@@ -500,12 +500,10 @@ func (n *NodeBuilder) AddYAMLNode(parent *yaml.Node, entry *nodes.NodeEntry) *ya
 					valueNode.Line = line
 				}
 			}
-			if b, bok := value.(*yaml.Node); bok {
-				if b.Kind == yaml.ScalarNode && b.Tag == "!!null" {
-					encodeSkip = true
-					valueNode = utils.CreateEmptyScalarNode()
-					valueNode.Line = line
-				}
+			if b, bok := value.(*yaml.Node); bok && b.Kind == yaml.ScalarNode && b.Tag == "!!null" {
+				encodeSkip = true
+				valueNode = utils.CreateEmptyScalarNode()
+				valueNode.Line = line
 			}
 			if !encodeSkip {
 				var rawNode yaml.Node

--- a/datamodel/high/v3/document_test.go
+++ b/datamodel/high/v3/document_test.go
@@ -635,6 +635,25 @@ func TestDocument_MarshalIndention(t *testing.T) {
 	}
 }
 
+func TestDocument_Nullable_Example(t *testing.T) {
+	data, _ := os.ReadFile("../../../test_specs/nullable-examples.openapi.yaml")
+	info, _ := datamodel.ExtractSpecInfo(data)
+
+	lowDoc, _ = lowv3.CreateDocumentFromConfig(info, datamodel.NewDocumentConfiguration())
+
+	highDoc := NewDocument(lowDoc)
+	rendered := highDoc.RenderWithIndention(2)
+
+	if runtime.GOOS != "windows" {
+		assert.Equal(t, string(data), strings.TrimSpace(string(rendered)))
+	}
+
+	rendered = highDoc.RenderWithIndention(4)
+	if runtime.GOOS != "windows" {
+		assert.NotEqual(t, string(data), strings.TrimSpace(string(rendered)))
+	}
+}
+
 func TestDocument_MarshalIndention_Error(t *testing.T) {
 	data, _ := os.ReadFile("../../../test_specs/single-definition.yaml")
 	info, _ := datamodel.ExtractSpecInfo(data)

--- a/test_specs/nullable-examples.openapi.yaml
+++ b/test_specs/nullable-examples.openapi.yaml
@@ -1,0 +1,14 @@
+openapi: 3.1.0
+components:
+  schemas:
+    Thing:
+      type: object
+      description: A nullable example.
+      properties:
+        target:
+          nullable: true
+          type: string
+          enum:
+            - staging
+            - production
+          example:

--- a/utils/nodes.go
+++ b/utils/nodes.go
@@ -67,6 +67,15 @@ func CreateIntNode(str string) *yaml.Node {
 	return n
 }
 
+func CreateEmptyScalarNode() *yaml.Node {
+	n := &yaml.Node{
+		Kind:  yaml.ScalarNode,
+		Tag:   "!!null",
+		Value: "",
+	}
+	return n
+}
+
 func CreateFloatNode(str string) *yaml.Node {
 	n := &yaml.Node{
 		Kind:  yaml.ScalarNode,

--- a/utils/nodes_test.go
+++ b/utils/nodes_test.go
@@ -27,6 +27,12 @@ func TestCreateEmptySequenceNode(t *testing.T) {
 	assert.Len(t, s.Content, 0)
 }
 
+func TestCreateEmptyScalarNode(t *testing.T) {
+	s := CreateEmptyScalarNode()
+	assert.Equal(t, "!!null", s.Tag)
+	assert.Equal(t, "", s.Value)
+}
+
 func TestCreateFloatNode(t *testing.T) {
 	f := CreateFloatNode("3.14")
 	assert.Equal(t, "!!float", f.Tag)


### PR DESCRIPTION
Fixes https://github.com/pb33f/libopenapi/issues/301.

TL;DR go-yaml currently panics when trying to render the test case. So we've got to short-circuit the "empty node" to not use `Encode` to copy across the empty scalar node, but just set the value explicitly