### PR TITLE
fix: fixed extraction of top level named examples to not extract schema level examples

### DIFF
--- a/datamodel/high/v3/media_type_test.go
+++ b/datamodel/high/v3/media_type_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pb33f/libopenapi/datamodel/low"
 	v3 "github.com/pb33f/libopenapi/datamodel/low/v3"
 	"github.com/pb33f/libopenapi/index"
+	"github.com/pb33f/libopenapi/orderedmap"
 	"github.com/pb33f/libopenapi/utils"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"
@@ -162,6 +163,29 @@ func TestMediaType_Examples(t *testing.T) {
 
 	r := NewMediaType(&n)
 
+	assert.Equal(t, 2, orderedmap.Len(r.Examples))
+
 	rend, _ := r.Render()
 	assert.Len(t, rend, 290)
+}
+
+func TestMediaType_Examples_NotFromSchema(t *testing.T) {
+	yml := `schema:
+  type: string
+  examples:
+    - example 1
+    - example 2
+    - example 3`
+
+	var idxNode yaml.Node
+	_ = yaml.Unmarshal([]byte(yml), &idxNode)
+	idx := index.NewSpecIndexWithConfig(&idxNode, index.CreateOpenAPIIndexConfig())
+
+	var n v3.MediaType
+	_ = low.BuildModel(idxNode.Content[0], &n)
+	_ = n.Build(context.Background(), nil, idxNode.Content[0], idx)
+
+	r := NewMediaType(&n)
+
+	assert.Equal(t, 0, orderedmap.Len(r.Examples))
 }

--- a/datamodel/low/v3/media_type.go
+++ b/datamodel/low/v3/media_type.go
@@ -6,6 +6,7 @@ package v3
 import (
 	"context"
 	"crypto/sha256"
+	"slices"
 	"strings"
 
 	"github.com/pb33f/libopenapi/datamodel/low"
@@ -95,7 +96,7 @@ func (mt *MediaType) Build(ctx context.Context, keyNode, root *yaml.Node, idx *i
 	if eErr != nil {
 		return eErr
 	}
-	if exps != nil {
+	if exps != nil && slices.Contains(root.Content, expsL) {
 		mt.Examples = low.NodeReference[*orderedmap.Map[low.KeyReference[string], low.ValueReference[*base.Example]]]{
 			Value:     exps,
 			KeyNode:   expsL,

--- a/datamodel/low/v3/media_type_test.go
+++ b/datamodel/low/v3/media_type_test.go
@@ -158,3 +158,46 @@ example: a thing`
 	assert.Equal(t, n.Hash(), n2.Hash())
 	assert.Equal(t, 1, orderedmap.Len(n.GetExtensions()))
 }
+
+func TestMediaType_Examples(t *testing.T) {
+	yml := `examples:
+    pbjBurger:
+        summary: A horrible, nutty, sticky mess.
+        value:
+            name: Peanut And Jelly
+            numPatties: 3
+    cakeBurger:
+        summary: A sickly, sweet, atrocity
+        value:
+            name: Chocolate Cake Burger
+            numPatties: 5`
+
+	var idxNode yaml.Node
+	_ = yaml.Unmarshal([]byte(yml), &idxNode)
+	idx := index.NewSpecIndex(&idxNode)
+
+	var n MediaType
+	_ = low.BuildModel(idxNode.Content[0], &n)
+	_ = n.Build(context.Background(), nil, idxNode.Content[0], idx)
+
+	assert.Equal(t, 2, orderedmap.Len(n.Examples.Value))
+}
+
+func TestMediaType_Examples_NotFromSchema(t *testing.T) {
+	yml := `schema:
+  type: string
+  examples:
+    - example 1
+    - example 2
+    - example 3`
+
+	var idxNode yaml.Node
+	_ = yaml.Unmarshal([]byte(yml), &idxNode)
+	idx := index.NewSpecIndex(&idxNode)
+
+	var n MediaType
+	_ = low.BuildModel(idxNode.Content[0], &n)
+	_ = n.Build(context.Background(), nil, idxNode.Content[0], idx)
+
+	assert.Equal(t, 0, orderedmap.Len(n.Examples.Value))
+}

--- a/datamodel/low/v3/parameter.go
+++ b/datamodel/low/v3/parameter.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/pb33f/libopenapi/datamodel/low"
@@ -100,7 +101,8 @@ func (p *Parameter) Build(ctx context.Context, keyNode, root *yaml.Node, idx *in
 	if eErr != nil {
 		return eErr
 	}
-	if exps != nil {
+	// Only consider examples if they are defined in the root node.
+	if exps != nil && slices.Contains(root.Content, expsL) {
 		p.Examples = low.NodeReference[*orderedmap.Map[low.KeyReference[string], low.ValueReference[*base.Example]]]{
 			Value:     exps,
 			KeyNode:   expsL,

--- a/datamodel/low/v3/parameter_test.go
+++ b/datamodel/low/v3/parameter_test.go
@@ -288,3 +288,46 @@ content:
 	assert.Equal(t, 2, orderedmap.Cast[low.KeyReference[string], low.ValueReference[*base.Example]](n.GetExamples().Value).Len())
 	assert.Equal(t, 1, orderedmap.Cast[low.KeyReference[string], low.ValueReference[*MediaType]](n.GetContent().Value).Len())
 }
+
+func TestParameter_Examples(t *testing.T) {
+	yml := `examples:
+    pbjBurger:
+        summary: A horrible, nutty, sticky mess.
+        value:
+            name: Peanut And Jelly
+            numPatties: 3
+    cakeBurger:
+        summary: A sickly, sweet, atrocity
+        value:
+            name: Chocolate Cake Burger
+            numPatties: 5`
+
+	var idxNode yaml.Node
+	_ = yaml.Unmarshal([]byte(yml), &idxNode)
+	idx := index.NewSpecIndex(&idxNode)
+
+	var n Parameter
+	_ = low.BuildModel(idxNode.Content[0], &n)
+	_ = n.Build(context.Background(), nil, idxNode.Content[0], idx)
+
+	assert.Equal(t, 2, orderedmap.Len(n.Examples.Value))
+}
+
+func TestParameter_Examples_NotFromSchema(t *testing.T) {
+	yml := `schema:
+  type: string
+  examples:
+    - example 1
+    - example 2
+    - example 3`
+
+	var idxNode yaml.Node
+	_ = yaml.Unmarshal([]byte(yml), &idxNode)
+	idx := index.NewSpecIndex(&idxNode)
+
+	var n Parameter
+	_ = low.BuildModel(idxNode.Content[0], &n)
+	_ = n.Build(context.Background(), nil, idxNode.Content[0], idx)
+
+	assert.Equal(t, 0, orderedmap.Len(n.Examples.Value))
+}


### PR DESCRIPTION
This fixes an issues where the schema level examples were wrongly being extracted and didn't properly match the shape of the top level named examples.

This PR ensures only the right examples are extracted