### PR TITLE
fix: improved handling of complex yaml in YAMLNodeToJSON

### DIFF
--- a/json/json_test.go
+++ b/json/json_test.go
@@ -85,3 +85,54 @@ func TestYAMLNodeToJSON_FromJSON(t *testing.T) {
 
 	assert.Equal(t, j, string(o))
 }
+
+func TestYAMLNodeWithAnchorsToJSON(t *testing.T) {
+	y := `examples:
+  someExample: &someExample
+    key1: scalar1
+    key2: scalar2
+someValue: *someExample`
+
+	var v yaml.Node
+
+	err := yaml.Unmarshal([]byte(y), &v)
+	require.NoError(t, err)
+
+	j, err := json.YAMLNodeToJSON(&v, "  ")
+	require.NoError(t, err)
+
+	assert.Equal(t, `{
+  "examples": {
+    "someExample": {
+      "key1": "scalar1",
+      "key2": "scalar2"
+    }
+  },
+  "someValue": {
+    "key1": "scalar1",
+    "key2": "scalar2"
+  }
+}`, string(j))
+}
+
+func TestYAMLNodeWithComplexKeysToJSON(t *testing.T) {
+	y := `someMapWithComplexKeys:
+  {key1: scalar1, key2: scalar2}: {key1: scalar1, key2: scalar2}`
+
+	var v yaml.Node
+
+	err := yaml.Unmarshal([]byte(y), &v)
+	require.NoError(t, err)
+
+	j, err := json.YAMLNodeToJSON(&v, "  ")
+	require.NoError(t, err)
+
+	assert.Equal(t, `{
+  "someMapWithComplexKeys": {
+    "{\"key1\":\"scalar1\",\"key2\":\"scalar2\"}": {
+      "key1": "scalar1",
+      "key2": "scalar2"
+    }
+  }
+}`, string(j))
+}

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -136,3 +136,11 @@ func TestYAMLNodeWithComplexKeysToJSON(t *testing.T) {
   }
 }`, string(j))
 }
+
+func TestYAMLNodeToJSONInvalidNode(t *testing.T) {
+	var v yaml.Node
+
+	j, err := json.YAMLNodeToJSON(&v, "  ")
+	assert.Nil(t, j)
+	assert.Error(t, err)
+}


### PR DESCRIPTION
Makes it possible to render yaml that uses anchors and complex map keys