### PR TITLE
Fix: resolve remote relative refs correctly

### DIFF
--- a/bundler/bundler.go
+++ b/bundler/bundler.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/pb33f/libopenapi"
 	"github.com/pb33f/libopenapi/datamodel"
-	"github.com/pb33f/libopenapi/datamodel/high/v3"
+	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
 	"github.com/pb33f/libopenapi/index"
 )
 
@@ -56,6 +56,7 @@ func BundleDocument(model *v3.Document) ([]byte, error) {
 
 func bundle(model *v3.Document, inline bool) ([]byte, error) {
 	rolodex := model.Rolodex
+
 	compact := func(idx *index.SpecIndex, root bool) {
 		mappedReferences := idx.GetMappedReferences()
 		sequencedReferences := idx.GetRawReferencesSequenced()
@@ -78,6 +79,7 @@ func bundle(model *v3.Document, inline bool) ([]byte, error) {
 				sequenced.Node.Content = mappedReference.Node.Content
 				continue
 			}
+
 			if mappedReference != nil && mappedReference.Circular {
 				if idx.GetLogger() != nil {
 					idx.GetLogger().Warn("[bundler] skipping circular reference",

--- a/datamodel/document_config.go
+++ b/datamodel/document_config.go
@@ -4,11 +4,12 @@
 package datamodel
 
 import (
-	"github.com/pb33f/libopenapi/utils"
 	"io/fs"
 	"log/slog"
 	"net/url"
 	"os"
+
+	"github.com/pb33f/libopenapi/utils"
 )
 
 // DocumentConfiguration is used to configure the document creation process. It was added in v0.6.0 to allow
@@ -18,6 +19,8 @@ import (
 // any non-local (local being the specification, not the file system) references, will be ignored.
 type DocumentConfiguration struct {
 	// The BaseURL will be the root from which relative references will be resolved from if they can't be found locally.
+	// Make sure it does not point to a file as relative paths will be blindly added to the end of the
+	// BaseURL's path.
 	// Schema must be set to "http/https".
 	BaseURL *url.URL
 

--- a/datamodel/low/extraction_functions.go
+++ b/datamodel/low/extraction_functions.go
@@ -87,7 +87,6 @@ func LocateRefNodeWithContext(ctx context.Context, root *yaml.Node, idx *index.S
 		for _, collection := range collections {
 			found = collection()
 			if found != nil && found[rv] != nil {
-
 				// if this is a ref node, we need to keep diving
 				// until we hit something that isn't a ref.
 				if jh, _, _ := utils.IsNodeRefValue(found[rv].Node); jh {
@@ -147,7 +146,7 @@ func LocateRefNodeWithContext(ctx context.Context, root *yaml.Node, idx *index.S
 								u := *idx.GetConfig().BaseURL
 								p := ""
 								if u.Path != "" {
-									p = filepath.Dir(u.Path)
+									p = u.Path
 								}
 								u.Path = filepath.Join(p, explodedRefValue[0])
 								rv = fmt.Sprintf("%s#%s", u.String(), explodedRefValue[1])

--- a/datamodel/low/extraction_functions.go
+++ b/datamodel/low/extraction_functions.go
@@ -174,7 +174,7 @@ func LocateRefNodeWithContext(ctx context.Context, root *yaml.Node, idx *index.S
 									p = u.Path
 								}
 
-								u.Path = filepath.Join(p, explodedRefValue[0])
+								u.Path = utils.ReplaceWindowsDriveWithLinuxPath(filepath.Join(p, explodedRefValue[0]))
 								rv = fmt.Sprintf("%s#%s", u.String(), explodedRefValue[1])
 							}
 						}

--- a/datamodel/low/extraction_functions_test.go
+++ b/datamodel/low/extraction_functions_test.go
@@ -880,7 +880,7 @@ func TestExtractArray_BadRefPropsTupe(t *testing.T) {
 	assert.NoError(t, mErr)
 	idx := index.NewSpecIndexWithConfig(&idxNode, index.CreateClosedAPIIndexConfig())
 
-	yml = `limes: 
+	yml = `limes:
   $ref: '#/components/parameters/cakes'`
 
 	var cNode yaml.Node
@@ -1893,7 +1893,6 @@ func TestLocateRefNode_Explode_NoSpecPath(t *testing.T) {
 	assert.NotNil(t, i)
 	assert.NotNil(t, e)
 	assert.NotNil(t, c)
-	assert.ErrorContains(t, e, "http://smilfghfhfhfhfhes.com/bikes/components/schemas/thing.yaml#/components/schemas/thing")
 }
 
 func TestLocateRefNode_DoARealLookup(t *testing.T) {
@@ -2107,7 +2106,7 @@ func TestArray_NotRefNotArray(t *testing.T) {
 	assert.NoError(t, mErr)
 	idx := index.NewSpecIndexWithConfig(&idxNode, index.CreateClosedAPIIndexConfig())
 
-	yml = `limes: 
+	yml = `limes:
   not: array`
 
 	var cNode yaml.Node

--- a/datamodel/low/extraction_functions_test.go
+++ b/datamodel/low/extraction_functions_test.go
@@ -1867,6 +1867,35 @@ func TestLocateRefNode_NoExplode_NoSpecPath(t *testing.T) {
 	assert.NotNil(t, c)
 }
 
+func TestLocateRefNode_Explode_NoSpecPath(t *testing.T) {
+	no := yaml.Node{
+		Kind: yaml.MappingNode,
+		Content: []*yaml.Node{
+			{
+				Kind:  yaml.ScalarNode,
+				Value: "$ref",
+			},
+			{
+				Kind:  yaml.ScalarNode,
+				Value: "components/schemas/thing.yaml#/components/schemas/thing",
+			},
+		},
+	}
+
+	cf := index.CreateClosedAPIIndexConfig()
+	u, _ := url.Parse("http://smilfghfhfhfhfhes.com/bikes")
+	cf.BaseURL = u
+	idx := index.NewSpecIndexWithConfig(&no, cf)
+	ctx := context.Background()
+
+	n, i, e, c := LocateRefNodeWithContext(ctx, &no, idx)
+	assert.Nil(t, n)
+	assert.NotNil(t, i)
+	assert.NotNil(t, e)
+	assert.NotNil(t, c)
+	assert.ErrorContains(t, e, "http://smilfghfhfhfhfhes.com/bikes/components/schemas/thing.yaml#/components/schemas/thing")
+}
+
 func TestLocateRefNode_DoARealLookup(t *testing.T) {
 	lookup := "/root.yaml#/components/schemas/Burger"
 	if runtime.GOOS == "windows" {

--- a/datamodel/low/v3/create_document.go
+++ b/datamodel/low/v3/create_document.go
@@ -3,7 +3,9 @@ package v3
 import (
 	"context"
 	"errors"
+	"net/url"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -43,7 +45,7 @@ func createDocument(info *datamodel.SpecInfo, config *datamodel.DocumentConfigur
 	idxConfig.IgnoreArrayCircularReferences = config.IgnoreArrayCircularReferences
 	idxConfig.IgnorePolymorphicCircularReferences = config.IgnorePolymorphicCircularReferences
 	idxConfig.AvoidCircularReferenceCheck = true
-	idxConfig.BaseURL = config.BaseURL
+	idxConfig.BaseURL = urlWithoutTrailingSlash(config.BaseURL)
 	idxConfig.BasePath = config.BasePath
 	idxConfig.SpecFilePath = config.SpecFilePath
 	idxConfig.Logger = config.Logger
@@ -318,4 +320,14 @@ func extractWebhooks(ctx context.Context, info *datamodel.SpecInfo, doc *Documen
 		}
 	}
 	return nil
+}
+
+func urlWithoutTrailingSlash(u *url.URL) *url.URL {
+	if u == nil {
+		return nil
+	}
+
+	u.Path, _ = strings.CutSuffix(u.Path, "/")
+
+	return u
 }

--- a/datamodel/low/v3/create_document_test.go
+++ b/datamodel/low/v3/create_document_test.go
@@ -881,3 +881,48 @@ func ExampleCreateDocument() {
 	fmt.Print(document.Info.Value.Contact.Value.Email.Value)
 	// Output: apiteam@swagger.io
 }
+
+func TestURLWithoutTrailingSlash(t *testing.T) {
+	tc := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{
+			name: "url with no path",
+			url:  "https://example.com",
+			want: "https://example.com",
+		},
+		{
+			name: "nil pointer",
+			url:  "",
+		},
+		{
+			name: "URL with path not ending in slash",
+			url:  "https://example.com/some/path",
+			want: "https://example.com/some/path",
+		},
+		{
+			name: "URL with path ending in slash",
+			url:  "https://example.com/some/path/",
+			want: "https://example.com/some/path",
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			u, _ := url.Parse(tt.url)
+			if tt.url == "" {
+				u = nil
+			}
+
+			got := urlWithoutTrailingSlash(u)
+
+			if u == nil {
+				assert.Nil(t, got)
+				return
+			}
+			assert.Equal(t, tt.want, got.String())
+		})
+	}
+}

--- a/document.go
+++ b/document.go
@@ -335,6 +335,7 @@ func (d *document) BuildV3Model() (*DocumentModel[v3high.Document], []error) {
 		Model: *highDoc,
 		Index: lowDoc.Index,
 	}
+
 	return d.highOpenAPI3Model, errs
 }
 

--- a/document.go
+++ b/document.go
@@ -305,7 +305,9 @@ func (d *document) BuildV3Model() (*DocumentModel[v3high.Document], []error) {
 	if d.config == nil {
 		d.config = &datamodel.DocumentConfiguration{
 			AllowFileReferences:   false,
+			BasePath:              "",
 			AllowRemoteReferences: false,
+			BaseURL:               nil,
 		}
 	}
 

--- a/document_test.go
+++ b/document_test.go
@@ -6,11 +6,14 @@ import (
 	"bytes"
 	"fmt"
 	"log/slog"
+	"net/http"
+	"net/url"
 	"os"
 	"runtime"
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/pb33f/libopenapi/datamodel"
 	"github.com/pb33f/libopenapi/datamodel/high/base"
@@ -216,7 +219,7 @@ func TestDocument_RenderAndReload_ChangeCheck_Burgershop(t *testing.T) {
 	// compare documents
 	compReport, errs := CompareDocuments(doc, newDoc)
 
-	// should noth be nil.
+	// should not be nil.
 	assert.Nil(t, errs)
 	assert.Nil(t, errs)
 	assert.NotNil(t, rend)
@@ -450,7 +453,7 @@ func TestDocument_Render_ChangeCheck_Burgershop(t *testing.T) {
 	// compare documents
 	compReport, errs := CompareDocuments(doc, newDoc)
 
-	// should noth be nil.
+	// should not be nil.
 	assert.Nil(t, errs)
 	assert.NotNil(t, rend)
 	assert.Nil(t, compReport)
@@ -1352,6 +1355,44 @@ func TestDocument_TestNestedFiles(t *testing.T) {
 
 	_, errs := doc.BuildV3Model()
 	require.Empty(t, errs)
+}
+
+func TestDocument_MinimalRemoteRefs(t *testing.T) {
+	newRemoteHandlerFunc := func() utils.RemoteURLHandler {
+		c := &http.Client{
+			Timeout: time.Second * 120,
+		}
+
+		return func(url string) (*http.Response, error) {
+			resp, err := c.Get(url)
+			if err != nil {
+				return nil, fmt.Errorf("fetch remote ref: %v", err)
+			}
+
+			return resp, nil
+		}
+	}
+
+	spec, err := os.ReadFile("test_specs/minimal_remote_refs/openapi.yaml")
+	require.NoError(t, err)
+
+	baseURL, err := url.Parse("https://raw.githubusercontent.com/felixjung/libopenapi/authed-remote/test_specs/minimal_remote_refs")
+	require.NoError(t, err)
+
+	doc, err := NewDocumentWithConfiguration(spec, &datamodel.DocumentConfiguration{
+		BaseURL:               baseURL,
+		AllowFileReferences:   false,
+		AllowRemoteReferences: true,
+		RemoteURLHandler:      newRemoteHandlerFunc(),
+	})
+	require.NoError(t, err)
+
+	d, errs := doc.BuildV3Model()
+	require.Empty(t, errs)
+
+	o, err := d.Model.Render()
+	require.NoError(t, err)
+	fmt.Println(string(o))
 }
 
 func TestDocument_Issue264(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/stretchr/testify v1.9.0
 	github.com/vmware-labs/yaml-jsonpath v0.3.2
 	github.com/wk8/go-ordered-map/v2 v2.1.9-0.20240815153524-6ea36470d1bd
-	golang.org/x/net v0.0.0-20220225172249-27dd8689420f
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,6 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dprotaso/go-yit v0.0.0-20191028211022-135eb7262960/go.mod h1:9HQzr9D/0PGwMEbC3d5AB7oi67+h4TsQqItC1GVYG58=
-github.com/dprotaso/go-yit v0.0.0-20220510233725-9ba8df137936 h1:PRxIJD8XjimM5aTknUK9w6DHLDox2r2M3DI4i2pnd3w=
-github.com/dprotaso/go-yit v0.0.0-20220510233725-9ba8df137936/go.mod h1:ttYvX5qlB+mlV1okblJqcSMtR4c52UKxDiX9GRBS8+Q=
 github.com/dprotaso/go-yit v0.0.0-20240618133044-5a0af90af097 h1:f5nA5Ys8RXqFXtKc0XofVRiuwNTuJzPIwTmbjLz9vj8=
 github.com/dprotaso/go-yit v0.0.0-20240618133044-5a0af90af097/go.mod h1:FTAVyH6t+SlS97rv6EXRVuBDLkQqcIe/xQw9f4IFUI4=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
@@ -65,8 +63,6 @@ github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNX
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
-github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/vmware-labs/yaml-jsonpath v0.3.2 h1:/5QKeCBGdsInyDCyVNLbXyilb61MXGi9NP674f9Hobk=

--- a/index/extract_refs.go
+++ b/index/extract_refs.go
@@ -9,11 +9,11 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/pb33f/libopenapi/utils"
 	"gopkg.in/yaml.v3"
-	"slices"
 )
 
 // ExtractRefs will return a deduplicated slice of references for every unique ref found in the document.
@@ -56,6 +56,7 @@ func (index *SpecIndex) ExtractRefs(node, parent *yaml.Node, seenPath []string, 
 					fullDefinitionPath = fmt.Sprintf("%s#/%s", index.specAbsolutePath, strings.Join(loc, "/"))
 					_, jsonPath = utils.ConvertComponentIdIntoFriendlyPathSearch(definitionPath)
 				}
+
 				ref := &Reference{
 					ParentNode:     parent,
 					FullDefinition: fullDefinitionPath,

--- a/index/extract_refs.go
+++ b/index/extract_refs.go
@@ -246,6 +246,7 @@ func (index *SpecIndex) ExtractRefs(node, parent *yaml.Node, seenPath []string, 
 					var componentName string
 					var fullDefinitionPath string
 					if len(uri) == 2 {
+						// Check if we are dealing with a ref to a local definition.
 						if uri[0] == "" {
 							fullDefinitionPath = fmt.Sprintf("%s#/%s", index.specAbsolutePath, uri[1])
 							componentName = value
@@ -424,6 +425,7 @@ func (index *SpecIndex) ExtractRefs(node, parent *yaml.Node, seenPath []string, 
 						continue
 					}
 
+					// This sets the ref in the path using the full URL and sub-path.
 					index.allRefs[fullDefinitionPath] = ref
 					found = append(found, ref)
 				}
@@ -713,5 +715,6 @@ func (index *SpecIndex) ExtractComponentsFromRefs(refs []*Reference) []*Referenc
 			index.allMappedRefsSequenced = append(index.allMappedRefsSequenced, mappedRefsInSequence[m])
 		}
 	}
+
 	return found
 }

--- a/index/rolodex.go
+++ b/index/rolodex.go
@@ -6,7 +6,6 @@ package index
 import (
 	"errors"
 	"fmt"
-	"gopkg.in/yaml.v3"
 	"io"
 	"io/fs"
 	"log/slog"
@@ -19,6 +18,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"gopkg.in/yaml.v3"
 )
 
 // CanBeIndexed is an interface that allows a file to be indexed.
@@ -193,7 +194,8 @@ func (r *Rolodex) IndexTheRolodex() error {
 	var indexBuildQueue []*SpecIndex
 
 	indexRolodexFile := func(
-		location string, fs fs.FS,
+		location string,
+		fs fs.FS,
 		doneChan chan bool,
 		errChan chan error,
 		indexChan chan *SpecIndex) {
@@ -231,6 +233,7 @@ func (r *Rolodex) IndexTheRolodex() error {
 
 		if lfs, ok := fs.(RolodexFS); ok {
 			wait := false
+
 			for _, f := range lfs.GetFiles() {
 				if idxFile, ko := f.(CanBeIndexed); ko {
 					wg.Add(1)
@@ -306,7 +309,6 @@ func (r *Rolodex) IndexTheRolodex() error {
 		// if there is a base path but no SpecFilePath, then we need to set the root spec config to point to a theoretical root.yaml
 		// which does not exist, but is used to formulate the absolute path to root references correctly.
 		if r.indexConfig.BasePath != "" && r.indexConfig.BaseURL == nil {
-
 			basePath := r.indexConfig.BasePath
 			if !filepath.IsAbs(basePath) {
 				basePath, _ = filepath.Abs(basePath)

--- a/index/rolodex.go
+++ b/index/rolodex.go
@@ -160,6 +160,7 @@ func (r *Rolodex) SetRootNode(node *yaml.Node) {
 
 func (r *Rolodex) AddExternalIndex(idx *SpecIndex, location string) {
 	r.indexLock.Lock()
+	r.indexes = append(r.indexes, idx)
 	if r.indexMap[location] == nil {
 		r.indexMap[location] = idx
 	}
@@ -167,7 +168,6 @@ func (r *Rolodex) AddExternalIndex(idx *SpecIndex, location string) {
 }
 
 func (r *Rolodex) AddIndex(idx *SpecIndex) {
-	r.indexes = append(r.indexes, idx)
 	if idx != nil {
 		p := idx.specAbsolutePath
 		r.AddExternalIndex(idx, p)

--- a/index/rolodex.go
+++ b/index/rolodex.go
@@ -323,6 +323,8 @@ func (r *Rolodex) IndexTheRolodex() error {
 			}
 		}
 
+		// Here we take the root node and also build the index for it.
+		// This involves extracting references.
 		index := NewSpecIndexWithConfig(r.rootNode, r.indexConfig)
 		resolver := NewResolver(index)
 

--- a/index/rolodex_file_loader.go
+++ b/index/rolodex_file_loader.go
@@ -124,7 +124,6 @@ func (l *LocalFS) Open(name string) (fs.File, error) {
 					if idxError != nil && idx == nil {
 						extractedFile.readingErrors = append(l.readingErrors, idxError)
 					} else {
-
 						// for each index, we need a resolver
 						resolver := NewResolver(idx)
 						idx.resolver = resolver

--- a/index/rolodex_remote_loader.go
+++ b/index/rolodex_remote_loader.go
@@ -14,12 +14,12 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/pb33f/libopenapi/datamodel"
 	"github.com/pb33f/libopenapi/utils"
 	"gopkg.in/yaml.v3"
-	"sync"
 )
 
 const (

--- a/index/rolodex_remote_loader.go
+++ b/index/rolodex_remote_loader.go
@@ -441,11 +441,6 @@ func (i *RemoteFS) Open(remoteURL string) (fs.File, error) {
 		i.logger.Debug("[rolodex remote loaded] successfully loaded file", "file", absolutePath)
 	}
 
-	processingWaiter.file = remoteFile
-	processingWaiter.done = true
-
-	// remove from processing
-	i.ProcessingFiles.Delete(remoteParsedURL.Path)
 	i.Files.Store(absolutePath, remoteFile)
 
 	idx, idxError := remoteFile.Index(&copiedCfg)
@@ -462,5 +457,10 @@ func (i *RemoteFS) Open(remoteURL string) (fs.File, error) {
 			i.rolodex.AddExternalIndex(idx, remoteParsedURL.String())
 		}
 	}
+
+	// remove from processing
+	processingWaiter.file = remoteFile
+	processingWaiter.done = true
+	i.ProcessingFiles.Delete(remoteParsedURL.Path)
 	return remoteFile, errors.Join(i.remoteErrors...)
 }

--- a/orderedmap/orderedmap_test.go
+++ b/orderedmap/orderedmap_test.go
@@ -271,6 +271,11 @@ func TestFirst(t *testing.T) {
 		require.Nil(t, pair)
 	})
 
+	t.Run("Nil map", func(t *testing.T) {
+		var m orderedmap.Map[string, int]
+		require.Nil(t, m.First())
+	})
+
 	t.Run("Single item", func(t *testing.T) {
 		m := orderedmap.New[string, int]()
 		m.Set("key", 1)

--- a/test_specs/minimal_remote_refs/openapi.yaml
+++ b/test_specs/minimal_remote_refs/openapi.yaml
@@ -1,0 +1,36 @@
+---
+openapi: 3.1.0
+info:
+  description: Example API spec
+  version: v1
+  title: Example
+  contact:
+    name: Example
+    email: example@example.com
+    url: www.example.com
+  license:
+    name: Example
+    url: www.example.com
+tags:
+  - name: Account
+    description: Account
+servers:
+  - url: https://<hidden>
+paths:
+  /api/v1/Accounts:
+    get:
+      summary: TODO
+      description: TODO
+      security:
+        - BearerAuth: []
+      tags:
+        - Account
+      operationId: listAccounts
+      responses:
+        "200":
+          $ref: ./schemas/components.openapi.yaml#/components/responses/ListAccounts
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer

--- a/test_specs/minimal_remote_refs/schemas/components.openapi.yaml
+++ b/test_specs/minimal_remote_refs/schemas/components.openapi.yaml
@@ -1,0 +1,39 @@
+---
+openapi: 3.1.0
+info:
+  description: Example API component definitions
+  version: v1
+  title: Example
+  contact:
+    name: Example
+    email: example@example.com
+    url: www.example.com
+  license:
+    name: Example
+    url: www.example.com
+components:
+  schemas:
+    Account:
+      type: object
+      properties:
+        name:
+          type: string
+          description: >
+            Name of the account
+  responses:
+    ListAccounts:
+      description: List all accounts.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              items:
+                type: array
+                items:
+                  description: >
+                    The accounts.
+                  $ref: "#/components/schemas/Account"
+              total:
+                type: integer
+                description: Total number of accounts.


### PR DESCRIPTION
Thanks for working on all these tools for OpenAPI. 👏 

I've run into issues with vacuum/libopenapi supporting resolving of relative remote refs. I'm trying to fix this, but I have to admit I get completely lost in the code of this project.

I've added a test case to debug the issue. One thing I notice and that I think it should never happen, is that `libopenapi` tries to load a file that's not referenced anywhere. The log output says the following:


```
{"time":"2024-09-03T22:46:30.36193+02:00","level":"ERROR","msg":"unable to fetch remote document","file":"/felixjung/libopenapi/authed-remote/test_specs/schemas/components.openapi.yaml","status":404,"resp":"404: Not Found"}
{"time":"2024-09-03T22:46:30.362202+02:00","level":"ERROR","msg":"unable to locate reference anywhere in the rolodex","reference":"https://raw.githubusercontent.com/felixjung/libopenapi/authed-remote/test_specs/schemas/components.openapi.yaml#/components/responses/ListAccounts"}
{"time":"2024-09-03T22:46:30.362272+02:00","level":"ERROR","msg":"error building path item: map build failed: reference cannot be found: reference 'https://raw.githubusercontent.com/felixjung/libopenapi/authed-remote/test_specs/schemas/components.openapi.yaml#/components/responses/ListAccounts' at line 31, column 11 was not found"}
```

Instead of

```
https://raw.githubusercontent.com/felixjung/libopenapi/authed-remote/test_specs/schemas/components.openapi.yaml#/components/responses/ListAccounts
```

it should only ever try to resolve

```
https://raw.githubusercontent.com/felixjung/libopenapi/authed-remote/test_specs/minimal_remote_refs/schemas/components.openapi.yaml#/components/responses/ListAccounts
```

When I call a Render method on the document's model, components are missing and refs have not been resolved (maybe I'm using it incorrectly).

To run the test do

```
go test -count 1 -v -run TestDocument_MinimalRemoteRefs .
```

I'd be very appreciative for any hints as to what might be going wrong.