### PR TITLE
fix: a parameter in the rolodex should be evaluated using the index that the node is in

### DIFF
--- a/index/extract_refs.go
+++ b/index/extract_refs.go
@@ -640,7 +640,16 @@ func (index *SpecIndex) ExtractComponentsFromRefs(refs []*Reference) []*Referenc
 			index.refLock.Unlock()
 		} else {
 			index.refLock.Unlock()
+			// If it's local, this is safe to do unlocked
+			uri := strings.Split(ref.FullDefinition, "#/")
+			unsafeAsync := len(uri) == 2 && len(uri[0]) > 0
+			if unsafeAsync {
+				index.refLock.Lock()
+			}
 			located := index.FindComponent(ref.FullDefinition)
+			if unsafeAsync {
+				index.refLock.Unlock()
+			}
 			if located != nil {
 
 				// have we already mapped this?

--- a/index/rolodex_test.go
+++ b/index/rolodex_test.go
@@ -1564,7 +1564,7 @@ func TestRolodex_SimpleTest_OneDoc(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		assert.Equal(t, int64(448), f.Size())
 	} else {
-		assert.Equal(t, int64(460), f.Size())
+		assert.Equal(t, int64(467), f.Size())
 	}
 	assert.False(t, f.IsDir())
 	assert.Nil(t, f.Sys())

--- a/index/rolodex_test.go
+++ b/index/rolodex_test.go
@@ -1541,11 +1541,11 @@ func TestRolodex_SimpleTest_OneDoc(t *testing.T) {
 	//assert.NotZero(t, rolo.GetIndexingDuration()) comes back as 0 on windows.
 	assert.NotNil(t, rolo.GetRootIndex())
 	assert.Len(t, rolo.GetIndexes(), 10)
-	assert.Len(t, rolo.GetAllReferences(), 7)
-	assert.Len(t, rolo.GetAllMappedReferences(), 7)
+	assert.Len(t, rolo.GetAllReferences(), 8)
+	assert.Len(t, rolo.GetAllMappedReferences(), 8)
 
 	lineCount := rolo.GetFullLineCount()
-	assert.Equal(t, int64(158), lineCount, "total line count in the rolodex is wrong")
+	assert.Equal(t, int64(167), lineCount, "total line count in the rolodex is wrong")
 
 	assert.NoError(t, err)
 	assert.Len(t, rolo.indexes, 10)
@@ -1562,10 +1562,9 @@ func TestRolodex_SimpleTest_OneDoc(t *testing.T) {
 	assert.True(t, strings.HasSuffix(f.GetFullPath(), "rolodex_test_data"+string(os.PathSeparator)+"components.yaml"))
 	assert.NotNil(t, f.ModTime())
 	if runtime.GOOS != "windows" {
-		assert.Equal(t, int64(283), f.Size())
+		assert.Equal(t, int64(448), f.Size())
 	} else {
-		assert.Equal(t, int64(295), f.Size())
-
+		assert.Equal(t, int64(460), f.Size())
 	}
 	assert.False(t, f.IsDir())
 	assert.Nil(t, f.Sys())

--- a/index/rolodex_test_data/components.yaml
+++ b/index/rolodex_test_data/components.yaml
@@ -3,6 +3,13 @@ info:
   title: Rolodex Test Data
   version: 1.0.0
 components:
+  parameters:
+    SomeParam:
+      name: someParam
+      in: query
+      description: A parameter that does nothing. Ding a ling!
+      schema:
+        type: string
   schemas:
     Ding:
       type: object

--- a/index/rolodex_test_data/paths/paths.yaml
+++ b/index/rolodex_test_data/paths/paths.yaml
@@ -1,5 +1,7 @@
 /some/path:
   get:
+    parameters:
+      - $ref: '../components.yaml#/components/parameters/SomeParam'
     responses:
       '200':
         description: OK

--- a/index/search_rolodex_test.go
+++ b/index/search_rolodex_test.go
@@ -132,9 +132,9 @@ func TestSpecIndex_TestPathsAsRefWithFiles(t *testing.T) {
 
 	yml := `paths:
   /test:
-    $ref: 'rolodex_test_data/paths/paths.yaml'
+    $ref: 'rolodex_test_data/paths/paths.yaml#/~1some~1path'
   /test-2:
-    $ref: './rolodex_test_data/paths/paths.yaml'
+    $ref: './rolodex_test_data/paths/paths.yaml#/~1some~1path'
 `
 
 	baseDir := "."
@@ -166,4 +166,15 @@ func TestSpecIndex_TestPathsAsRefWithFiles(t *testing.T) {
 	assert.Len(t, rolo.indexes, 2)
 	assert.Len(t, rolo.GetCaughtErrors(), 0)
 
+	params := rolo.rootIndex.GetAllParametersFromOperations()
+	assert.Len(t, params, 2)
+	lookupPath, ok := params["/test"]
+	assert.True(t, ok)
+	lookupOperation, ok := lookupPath["get"]
+	assert.True(t, ok)
+	assert.Len(t, lookupOperation, 1)
+	lookupRef, ok := lookupOperation["../components.yaml#/components/parameters/SomeParam"]
+	assert.True(t, ok)
+	assert.Len(t, lookupRef, 1)
+	assert.Equal(t, lookupRef[0].Name, "SomeParam")
 }

--- a/index/utility_methods.go
+++ b/index/utility_methods.go
@@ -397,7 +397,8 @@ func (index *SpecIndex) scanOperationParams(params []*yaml.Node, keyNode, pathIt
 			paramRef := index.allMappedRefs[paramRefName]
 			if paramRef == nil {
 				// could be in the rolodex
-				ref := seekRefEnd(index, paramRefName)
+				searchInIndex := findIndex(index, param.Content[1])
+				ref := seekRefEnd(searchInIndex, paramRefName)
 				if ref != nil {
 					paramRef = ref
 					if strings.Contains(paramRefName, "%") {
@@ -508,6 +509,25 @@ func (index *SpecIndex) scanOperationParams(params []*yaml.Node, keyNode, pathIt
 			continue
 		}
 	}
+}
+
+func findIndex(index *SpecIndex, i *yaml.Node) *SpecIndex {
+	allIndexes := index.GetRolodex().GetIndexes()
+	for _, searchIndex := range allIndexes {
+		nodeMap := searchIndex.GetNodeMap()
+		line, ok := nodeMap[i.Line]
+		if !ok {
+			continue
+		}
+		node, ok := line[i.Column]
+		if !ok {
+			continue
+		}
+		if node == i {
+			return searchIndex
+		}
+	}
+	return index
 }
 
 func runIndexFunction(funcs []func() int, wg *sync.WaitGroup) {

--- a/index/utility_methods.go
+++ b/index/utility_methods.go
@@ -512,7 +512,11 @@ func (index *SpecIndex) scanOperationParams(params []*yaml.Node, keyNode, pathIt
 }
 
 func findIndex(index *SpecIndex, i *yaml.Node) *SpecIndex {
-	allIndexes := index.GetRolodex().GetIndexes()
+	rolodex := index.GetRolodex()
+	if rolodex == nil {
+		return index
+	}
+	allIndexes := rolodex.GetIndexes()
 	for _, searchIndex := range allIndexes {
 		nodeMap := searchIndex.GetNodeMap()
 		line, ok := nodeMap[i.Line]


### PR DESCRIPTION
This fixes vacuum rules that lookup operations in the index where:

1. The original spec (root.yaml) has an external reference to a file in a different directory `./paths/mypath.yaml`
2. In that location, there is a relative reference to a path-item in a nearby file, e.g. `./components.yaml#/path-item`

What was previously happening in [2] is that the `./components.yaml` was being resolved in `./components.yaml` (the parent directory) instead of `./paths/components.yaml` (the right directory). This resulted in a failure to evaluate path item references and unexpected linting failures. 

This changes adjusts the lookup to search through the index's nodeMap to find the location of the YAML `$ref` node value that's been evaluated.  Once we find it, we lookup the associated index of that file and do a seek in that specific index.

We also fix a race condition with resolving the specification asyncronously -- if we are going to an external ref we must do it sequentially as otherwise an index might be added multiple times during an async `FindComponent` call. This latent bug was exposed as we tested this.