### PR TITLE
fix: indexing of operations which are `$ref`s

### DIFF
--- a/index/rolodex_test.go
+++ b/index/rolodex_test.go
@@ -4,8 +4,6 @@
 package index
 
 import (
-	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
 	"io"
 	"io/fs"
 	"log/slog"
@@ -19,6 +17,9 @@ import (
 	"testing"
 	"testing/fstest"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
 )
 
 func TestRolodex_NewRolodex(t *testing.T) {
@@ -1540,15 +1541,16 @@ func TestRolodex_SimpleTest_OneDoc(t *testing.T) {
 
 	//assert.NotZero(t, rolo.GetIndexingDuration()) comes back as 0 on windows.
 	assert.NotNil(t, rolo.GetRootIndex())
-	assert.Len(t, rolo.GetIndexes(), 10)
-	assert.Len(t, rolo.GetAllReferences(), 8)
-	assert.Len(t, rolo.GetAllMappedReferences(), 8)
+	assert.Len(t, rolo.GetIndexes(), 11)
+	assert.Len(t, rolo.GetAllReferences(), 9)
+	assert.Len(t, rolo.GetAllMappedReferences(), 9)
+	assert.Len(t, rolo.GetRootIndex().GetAllPaths(), 3)
 
 	lineCount := rolo.GetFullLineCount()
-	assert.Equal(t, int64(167), lineCount, "total line count in the rolodex is wrong")
+	assert.Equal(t, int64(174), lineCount, "total line count in the rolodex is wrong")
 
 	assert.NoError(t, err)
-	assert.Len(t, rolo.indexes, 10)
+	assert.Len(t, rolo.indexes, 11)
 
 	// open components.yaml
 	f, rerr := rolo.Open("components.yaml")

--- a/index/rolodex_test_data/doc1.yaml
+++ b/index/rolodex_test_data/doc1.yaml
@@ -21,6 +21,8 @@ paths:
             application/json:
               schema:
                 $ref: 'components.yaml#/components/schemas/Ding'
+  /external_operation:
+    $ref: 'operations.yaml#/external_operation'
 components:
   schemas:
     Thing:

--- a/index/rolodex_test_data/operations.yaml
+++ b/index/rolodex_test_data/operations.yaml
@@ -1,0 +1,5 @@
+external_operation:
+  get:
+    responses:
+      200:
+        description: "OK"

--- a/index/spec_index.go
+++ b/index/spec_index.go
@@ -1000,6 +1000,14 @@ func (index *SpecIndex) GetOperationCount() int {
 				method = index.pathsNode.Content[x+1]
 			}
 
+			// is the path a ref?
+			if isRef, _, ref := utils.IsNodeRefValue(method); isRef {
+				pNode := seekRefEnd(index, ref)
+				if pNode != nil {
+					method = pNode.Node
+				}
+			}
+
 			// extract methods for later use.
 			for y, m := range method.Content {
 				if y%2 == 0 {


### PR DESCRIPTION
**Why**
We have a linting rule which checks for duplicate operation IDs / duplicate operations. This linting rule wasn't catching duplicates if the operations were living in an external $ref.

**What**
 Currently when building the index of operations we weren't checking for refs, this PR changes that.