### PR TITLE
Added a high level cache.

### DIFF
--- a/datamodel/low/base/schema_proxy.go
+++ b/datamodel/low/base/schema_proxy.go
@@ -179,3 +179,8 @@ func (sp *SchemaProxy) AddNode(key int, node *yaml.Node) {
 		sp.Nodes.Store(key, node)
 	}
 }
+
+// GetIndex will return the index.SpecIndex pointer that was passed to the SchemaProxy during build.
+func (sp *SchemaProxy) GetIndex() *index.SpecIndex {
+	return sp.idx
+}

--- a/datamodel/low/base/schema_proxy_test.go
+++ b/datamodel/low/base/schema_proxy_test.go
@@ -46,6 +46,7 @@ description: something`
 		low.GenerateHashString(&sch))
 
 	assert.Equal(t, 1, orderedmap.Len(sch.Schema().GetExtensions()))
+	assert.Nil(t, sch.GetIndex())
 }
 
 func TestSchemaProxy_Build_CheckRef(t *testing.T) {

--- a/index/cache.go
+++ b/index/cache.go
@@ -3,38 +3,136 @@
 
 package index
 
-import "sync"
+import (
+	"sync"
+	"sync/atomic"
+)
 
+// SetCache sets a sync map as a temporary cache for the index.
+// TODO: this needs to be moved to the Cache interface.
 func (index *SpecIndex) SetCache(sync *sync.Map) {
 	index.cache = sync
 }
 
 // HighCacheHit increments the counter of high cache hits by one, and returns the current value of hits.
 func (index *SpecIndex) HighCacheHit() uint64 {
-	index.highModelCacheHits.Add(1)
-	return index.highModelCacheHits.Load()
+	index.highModelCache.AddHit()
+	return index.highModelCache.GetHits()
 }
 
 // HighCacheMiss increments the counter of high cache misses by one, and returns the current value of misses.
 func (index *SpecIndex) HighCacheMiss() uint64 {
-	index.highModelCacheMisses.Add(1)
-	return index.highModelCacheMisses.Load()
+	index.highModelCache.AddMiss()
+	return index.highModelCache.GetMisses()
 }
 
 // GetHighCacheHits returns the number of hits on the high model cache.
 func (index *SpecIndex) GetHighCacheHits() uint64 {
-	return index.highModelCacheHits.Load()
+	return index.highModelCache.GetHits()
 }
 
 // GetHighCacheMisses returns the number of misses on the high model cache.
 func (index *SpecIndex) GetHighCacheMisses() uint64 {
-	return index.highModelCacheMisses.Load()
+	return index.highModelCache.GetMisses()
 }
 
 // GetHighCache returns the high model cache for this index.
-func (index *SpecIndex) GetHighCache() *sync.Map {
+func (index *SpecIndex) GetHighCache() Cache {
 	if index.highModelCache == nil {
-		index.highModelCache = &sync.Map{}
+		index.highModelCache = CreateNewCache()
 	}
 	return index.highModelCache
+}
+
+// SetHighCache sets the high model cache for this index.
+func (index *SpecIndex) SetHighCache(cache *SimpleCache) {
+	index.highModelCache = cache
+}
+
+// Cache is an interface for a simple cache that can be used by any consumer.
+type Cache interface {
+	SetStore(*sync.Map)
+	GetStore() *sync.Map
+	AddHit() uint64
+	AddMiss() uint64
+	SetHits(uint64) uint64
+	SetMisses(uint64) uint64
+	GetHits() uint64
+	GetMisses() uint64
+	Clear()
+	Load(any) (any, bool)
+	Store(any, any)
+}
+
+// Below is an implementation of Cache called SimpleCache.
+
+// SimpleCache is a simple cache for the index, or any other consumer that needs it.
+type SimpleCache struct {
+	store  *sync.Map
+	hits   atomic.Uint64
+	misses atomic.Uint64
+}
+
+// CreateNewCache creates a new simple cache with a sync.Map store.
+func CreateNewCache() Cache {
+	return &SimpleCache{store: &sync.Map{}}
+}
+
+// SetStore sets the store for the cache.
+func (c *SimpleCache) SetStore(store *sync.Map) {
+	c.store = store
+}
+
+// GetStore returns the store for the cache.
+func (c *SimpleCache) GetStore() *sync.Map {
+	return c.store
+}
+
+// Load retrieves a value from the cache.
+func (c *SimpleCache) Load(key any) (value any, ok bool) {
+	return c.store.Load(key)
+}
+
+// Store stores a key-value pair in the cache.
+func (c *SimpleCache) Store(key, value any) {
+	c.store.Store(key, value)
+}
+
+// AddHit increments the hit counter by one, and returns the current value of hits.
+func (c *SimpleCache) AddHit() uint64 {
+	c.hits.Add(1)
+	return c.hits.Load()
+}
+
+// AddMiss increments the miss counter by one, and returns the current value of misses.
+func (c *SimpleCache) AddMiss() uint64 {
+	c.misses.Add(1)
+	return c.hits.Load()
+}
+
+// SetHits sets the hit counter to the provided value, and returns the current value of hits.
+func (c *SimpleCache) SetHits(hits uint64) uint64 {
+	c.hits.Add(hits)
+	return c.hits.Load()
+}
+
+// SetMisses sets the miss counter to the provided value, and returns the current value of misses.
+func (c *SimpleCache) SetMisses(misses uint64) uint64 {
+	c.misses.Add(misses)
+	return c.misses.Load()
+}
+
+// GetHits returns the current value of hits.
+func (c *SimpleCache) GetHits() uint64 {
+	return c.hits.Load()
+}
+
+// GetMisses returns the current value of misses.
+func (c *SimpleCache) GetMisses() uint64 {
+	return c.misses.Load()
+}
+
+// Clear clears the cache.
+func (c *SimpleCache) Clear() {
+	c.store.Clear()
 }

--- a/index/cache.go
+++ b/index/cache.go
@@ -1,0 +1,40 @@
+// Copyright 2023-2024 Princess Beef Heavy Industries, LLC / Dave Shanley
+// https://pb33f.io
+
+package index
+
+import "sync"
+
+func (index *SpecIndex) SetCache(sync *sync.Map) {
+	index.cache = sync
+}
+
+// HighCacheHit increments the counter of high cache hits by one, and returns the current value of hits.
+func (index *SpecIndex) HighCacheHit() uint64 {
+	index.highModelCacheHits.Add(1)
+	return index.highModelCacheHits.Load()
+}
+
+// HighCacheMiss increments the counter of high cache misses by one, and returns the current value of misses.
+func (index *SpecIndex) HighCacheMiss() uint64 {
+	index.highModelCacheMisses.Add(1)
+	return index.highModelCacheMisses.Load()
+}
+
+// GetHighCacheHits returns the number of hits on the high model cache.
+func (index *SpecIndex) GetHighCacheHits() uint64 {
+	return index.highModelCacheHits.Load()
+}
+
+// GetHighCacheMisses returns the number of misses on the high model cache.
+func (index *SpecIndex) GetHighCacheMisses() uint64 {
+	return index.highModelCacheMisses.Load()
+}
+
+// GetHighCache returns the high model cache for this index.
+func (index *SpecIndex) GetHighCache() *sync.Map {
+	if index.highModelCache == nil {
+		index.highModelCache = &sync.Map{}
+	}
+	return index.highModelCache
+}

--- a/index/cache_test.go
+++ b/index/cache_test.go
@@ -1,0 +1,116 @@
+// Copyright 2023-2024 Princess Beef Heavy Industries, LLC / Dave Shanley
+// https://pb33f.io
+
+package index
+
+import (
+	"github.com/stretchr/testify/assert"
+	"sync"
+	"testing"
+)
+
+// SimpleCache struct and methods are assumed to be imported from the respective package
+
+// TestCreateNewCache tests that a new cache is correctly created.
+func TestCreateNewCache(t *testing.T) {
+	cache := CreateNewCache()
+	assert.NotNil(t, cache)
+	assert.NotNil(t, cache.GetStore())
+}
+
+// TestSetAndGetStore tests that the store is correctly set and retrieved.
+func TestSetAndGetStore(t *testing.T) {
+	cache := CreateNewCache()
+	newStore := &sync.Map{}
+	cache.SetStore(newStore)
+	assert.Equal(t, newStore, cache.GetStore())
+}
+
+// TestLoadAndStore tests that a value can be stored and loaded from the cache.
+func TestLoadAndStore(t *testing.T) {
+	cache := CreateNewCache()
+	key, value := "key", "value"
+	cache.Store(key, value)
+
+	loadedValue, ok := cache.Load(key)
+	assert.True(t, ok)
+	assert.Equal(t, value, loadedValue)
+
+	// Test for a key that doesn't exist
+	_, ok = cache.Load("non-existent")
+	assert.False(t, ok)
+}
+
+// TestAddHit tests that hits are incremented correctly.
+func TestAddHit(t *testing.T) {
+	cache := CreateNewCache()
+	initialHits := cache.GetHits()
+
+	cache.AddHit()
+	newHits := cache.GetHits()
+	assert.Equal(t, initialHits+1, newHits)
+}
+
+// TestAddMiss tests that misses are incremented correctly.
+func TestAddMiss(t *testing.T) {
+	cache := CreateNewCache()
+	initialMisses := cache.GetMisses()
+
+	cache.AddMiss()
+	newMisses := cache.GetMisses()
+	assert.Equal(t, initialMisses+1, newMisses)
+}
+
+// TestSetHits tests that the hit counter is correctly set.
+func TestSetHits(t *testing.T) {
+	cache := CreateNewCache()
+	cache.SetHits(10)
+	assert.Equal(t, uint64(10), cache.GetHits())
+}
+
+// TestSetMisses tests that the miss counter is correctly set.
+func TestSetMisses(t *testing.T) {
+	cache := CreateNewCache()
+	cache.SetMisses(5)
+	assert.Equal(t, uint64(5), cache.GetMisses())
+}
+
+// TestClear tests that the cache is correctly cleared.
+func TestClear(t *testing.T) {
+	cache := CreateNewCache()
+	key, value := "key", "value"
+	cache.Store(key, value)
+	cache.Clear()
+
+	_, ok := cache.Load(key)
+	assert.False(t, ok)
+}
+
+// TestConcurrentAccess tests that the cache supports concurrent access.
+func TestConcurrentAccess(t *testing.T) {
+	cache := CreateNewCache()
+	var wg sync.WaitGroup
+
+	// Run 1000 concurrent Store operations
+	for i := 0; i < 1000; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			cache.Store(i, i)
+		}(i)
+	}
+
+	// Run 1000 concurrent Load operations
+	for i := 0; i < 1000; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			cache.Load(i)
+		}(i)
+	}
+
+	wg.Wait()
+	// Check for consistency in hits/misses
+	assert.True(t, cache.GetHits() >= 0)
+	assert.True(t, cache.GetMisses() >= 0)
+}

--- a/index/cache_test/docusign_test.go
+++ b/index/cache_test/docusign_test.go
@@ -50,12 +50,10 @@ func runTest(t *testing.T, specLocation string) {
 	}
 
 	for _, pathItem := range m.Model.Paths.PathItems.FromOldest() {
-
 		iterateOperations(t, pathItem.GetOperations())
 	}
 
 	for _, pathItem := range m.Model.Webhooks.FromOldest() {
-
 		iterateOperations(t, pathItem.GetOperations())
 	}
 

--- a/index/cache_test/docusign_test.go
+++ b/index/cache_test/docusign_test.go
@@ -1,0 +1,306 @@
+package libopenapi
+
+import (
+	"github.com/pb33f/libopenapi"
+	"os"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/pb33f/libopenapi/datamodel"
+	"github.com/pb33f/libopenapi/datamodel/high/base"
+	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
+	"github.com/pb33f/libopenapi/orderedmap"
+	"github.com/stretchr/testify/require"
+)
+
+type loopFrame struct {
+	Type       string
+	Restricted bool
+}
+
+type context struct {
+	visited []string
+	stack   []loopFrame
+}
+
+func Test_Docusign_Document_Iteration(t *testing.T) {
+	runTest(t, "../../test_specs/docusignv3.1.json")
+}
+
+func runTest(t *testing.T, specLocation string) {
+	spec, err := os.ReadFile(specLocation)
+	if t != nil {
+		require.NoError(t, err)
+	}
+
+	doc, err := libopenapi.NewDocumentWithConfiguration(spec, &datamodel.DocumentConfiguration{
+		BasePath:                            "../../test_specs",
+		IgnorePolymorphicCircularReferences: true,
+		IgnoreArrayCircularReferences:       true,
+		AllowFileReferences:                 true,
+	})
+	if t != nil {
+		require.NoError(t, err)
+	}
+
+	m, errs := doc.BuildV3Model()
+	if t != nil {
+		require.Empty(t, errs)
+	}
+
+	for _, pathItem := range m.Model.Paths.PathItems.FromOldest() {
+
+		iterateOperations(t, pathItem.GetOperations())
+	}
+
+	for _, pathItem := range m.Model.Webhooks.FromOldest() {
+
+		iterateOperations(t, pathItem.GetOperations())
+	}
+
+	for _, schemaProxy := range m.Model.Components.Schemas.FromOldest() {
+		handleSchema(t, schemaProxy, context{})
+	}
+
+	require.Equal(t, uint64(1008), m.Index.GetHighCacheMisses())
+	require.Equal(t, uint64(4049727), m.Index.GetHighCacheHits())
+}
+
+func iterateOperations(t *testing.T, ops *orderedmap.Map[string, *v3.Operation]) {
+	for _, op := range ops.FromOldest() {
+
+		for _, param := range op.Parameters {
+
+			if param.Schema != nil {
+				handleSchema(t, param.Schema, context{})
+			}
+		}
+
+		if op.RequestBody != nil {
+
+			for _, mediaType := range op.RequestBody.Content.FromOldest() {
+
+				if mediaType.Schema != nil {
+					handleSchema(t, mediaType.Schema, context{})
+				}
+			}
+		}
+
+		if orderedmap.Len(op.Responses.Codes) > 0 {
+		}
+
+		for _, response := range op.Responses.Codes.FromOldest() {
+
+			for _, mediaType := range response.Content.FromOldest() {
+
+				if mediaType.Schema != nil {
+					handleSchema(t, mediaType.Schema, context{})
+				}
+			}
+		}
+
+		if orderedmap.Len(op.Responses.Codes) > 0 {
+
+		}
+
+		for _, callback := range op.Callbacks.FromOldest() {
+
+			for _, pathItem := range callback.Expression.FromOldest() {
+
+				iterateOperations(t, pathItem.GetOperations())
+			}
+		}
+	}
+}
+
+func handleSchema(t *testing.T, schProxy *base.SchemaProxy, ctx context) {
+	if checkCircularReference(t, &ctx, schProxy) {
+		return
+	}
+
+	sch, err := schProxy.BuildSchema()
+	if t != nil {
+		require.NoError(t, err)
+	}
+
+	typ, subTypes := getResolvedType(sch)
+
+	if len(sch.Enum) > 0 {
+		switch typ {
+		case "string":
+			return
+		case "integer":
+			return
+		default:
+			// handle as base type
+		}
+	}
+
+	switch typ {
+	case "allOf":
+		fallthrough
+	case "anyOf":
+		fallthrough
+	case "oneOf":
+		if len(subTypes) > 0 {
+			return
+		}
+
+		handleAllOfAnyOfOneOf(t, sch, ctx)
+	case "array":
+		handleArray(t, sch, ctx)
+	case "object":
+		handleObject(t, sch, ctx)
+	default:
+		return
+	}
+}
+
+func getResolvedType(sch *base.Schema) (string, []string) {
+	subTypes := []string{}
+
+	for _, t := range sch.Type {
+		if t == "" { // treat empty type as any
+			subTypes = append(subTypes, "any")
+		} else if t != "null" {
+			subTypes = append(subTypes, t)
+		}
+	}
+
+	if len(sch.AllOf) > 0 {
+		return "allOf", nil
+	}
+
+	if len(sch.AnyOf) > 0 {
+		return "anyOf", nil
+	}
+
+	if len(sch.OneOf) > 0 {
+		return "oneOf", nil
+	}
+
+	if len(subTypes) == 0 {
+		if len(sch.Enum) > 0 {
+			return "string", nil
+		}
+
+		if orderedmap.Len(sch.Properties) > 0 {
+			return "object", nil
+		}
+
+		if sch.AdditionalProperties != nil {
+			return "object", nil
+		}
+
+		if sch.Items != nil {
+			return "array", nil
+		}
+
+		return "any", nil
+	}
+
+	if len(subTypes) == 1 {
+		return subTypes[0], nil
+	}
+
+	return "oneOf", subTypes
+}
+
+func handleAllOfAnyOfOneOf(t *testing.T, sch *base.Schema, ctx context) {
+	var schemas []*base.SchemaProxy
+
+	switch {
+	case len(sch.AllOf) > 0:
+		schemas = sch.AllOf
+	case len(sch.AnyOf) > 0:
+		schemas = sch.AnyOf
+		ctx.stack = append(ctx.stack, loopFrame{Type: "anyOf", Restricted: len(sch.AnyOf) == 1})
+	case len(sch.OneOf) > 0:
+		schemas = sch.OneOf
+		ctx.stack = append(ctx.stack, loopFrame{Type: "oneOf", Restricted: len(sch.OneOf) == 1})
+	}
+
+	for _, s := range schemas {
+		handleSchema(t, s, ctx)
+	}
+}
+
+func handleArray(t *testing.T, sch *base.Schema, ctx context) {
+	ctx.stack = append(ctx.stack, loopFrame{Type: "array", Restricted: sch.MinItems != nil && *sch.MinItems > 0})
+
+	if sch.Items != nil && sch.Items.IsA() {
+		handleSchema(t, sch.Items.A, ctx)
+	}
+
+	if sch.Contains != nil {
+		handleSchema(t, sch.Contains, ctx)
+	}
+
+	if sch.PrefixItems != nil {
+		for _, s := range sch.PrefixItems {
+			handleSchema(t, s, ctx)
+		}
+	}
+}
+
+func handleObject(t *testing.T, sch *base.Schema, ctx context) {
+	for name, schemaProxy := range sch.Properties.FromOldest() {
+		ctx.stack = append(ctx.stack, loopFrame{Type: "object", Restricted: slices.Contains(sch.Required, name)})
+		handleSchema(t, schemaProxy, ctx)
+	}
+
+	if sch.AdditionalProperties != nil && sch.AdditionalProperties.IsA() {
+		handleSchema(t, sch.AdditionalProperties.A, ctx)
+	}
+}
+
+func checkCircularReference(t *testing.T, ctx *context, schProxy *base.SchemaProxy) bool {
+	loopRef := getSimplifiedRef(schProxy.GetReference())
+
+	if loopRef != "" {
+		if slices.Contains(ctx.visited, loopRef) {
+			isRestricted := true
+			containsObject := false
+
+			for _, v := range ctx.stack {
+				if v.Type == "object" {
+					containsObject = true
+				}
+
+				if v.Type == "array" && !v.Restricted {
+					isRestricted = false
+				} else if !v.Restricted {
+					isRestricted = false
+				}
+			}
+
+			if !containsObject {
+				isRestricted = true
+			}
+
+			if t != nil {
+				require.False(t, isRestricted, "circular reference: %s", append(ctx.visited, loopRef))
+			}
+			return true
+		}
+
+		ctx.visited = append(ctx.visited, loopRef)
+	}
+
+	return false
+}
+
+// getSimplifiedRef will return the reference without the preceding file path
+// caveat is that if a spec has the same ref in two different files they include this may identify them incorrectly
+// but currently a problem anyway as libopenapi when returning references from an external file won't include the file path
+// for a local reference with that file and so we might fail to distinguish between them that way.
+// The fix needed is for libopenapi to also track which file the reference is in so we can always prefix them with the file path
+func getSimplifiedRef(ref string) string {
+	if ref == "" {
+		return ""
+	}
+
+	refParts := strings.Split(ref, "#/")
+	return "#/" + refParts[len(refParts)-1]
+}

--- a/index/index_model.go
+++ b/index/index_model.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 
 	"github.com/pb33f/libopenapi/datamodel"
 
@@ -296,6 +297,9 @@ type SpecIndex struct {
 	nodeMap                             map[int]map[int]*yaml.Node
 	nodeMapCompleted                    chan bool
 	pendingResolve                      []refMap
+	highModelCache                      *sync.Map
+	highModelCacheHits                  atomic.Uint64
+	highModelCacheMisses                atomic.Uint64
 }
 
 // GetResolver returns the resolver for this index.
@@ -306,10 +310,6 @@ func (index *SpecIndex) GetResolver() *Resolver {
 // GetConfig returns the SpecIndexConfig for this index.
 func (index *SpecIndex) GetConfig() *SpecIndexConfig {
 	return index.config
-}
-
-func (index *SpecIndex) SetCache(sync *sync.Map) {
-	index.cache = sync
 }
 
 func (index *SpecIndex) GetNodeMap() map[int]map[int]*yaml.Node {

--- a/index/index_model.go
+++ b/index/index_model.go
@@ -4,15 +4,13 @@
 package index
 
 import (
+	"github.com/pb33f/libopenapi/datamodel"
 	"io/fs"
 	"log/slog"
 	"net/http"
 	"net/url"
 	"path/filepath"
 	"sync"
-	"sync/atomic"
-
-	"github.com/pb33f/libopenapi/datamodel"
 
 	"gopkg.in/yaml.v3"
 )
@@ -297,9 +295,7 @@ type SpecIndex struct {
 	nodeMap                             map[int]map[int]*yaml.Node
 	nodeMapCompleted                    chan bool
 	pendingResolve                      []refMap
-	highModelCache                      *sync.Map
-	highModelCacheHits                  atomic.Uint64
-	highModelCacheMisses                atomic.Uint64
+	highModelCache                      Cache
 }
 
 // GetResolver returns the resolver for this index.

--- a/index/rolodex.go
+++ b/index/rolodex.go
@@ -677,3 +677,10 @@ func (r *Rolodex) GetFullLineCount() int64 {
 	}
 	return lineCount
 }
+
+func (r *Rolodex) ClearIndexCaches() {
+	r.rootIndex.GetHighCache().Clear()
+	for _, idx := range r.indexes {
+		idx.GetHighCache().Clear()
+	}
+}

--- a/index/rolodex.go
+++ b/index/rolodex.go
@@ -679,7 +679,9 @@ func (r *Rolodex) GetFullLineCount() int64 {
 }
 
 func (r *Rolodex) ClearIndexCaches() {
-	r.rootIndex.GetHighCache().Clear()
+	if r.rootIndex != nil {
+		r.rootIndex.GetHighCache().Clear()
+	}
 	for _, idx := range r.indexes {
 		idx.GetHighCache().Clear()
 	}

--- a/index/rolodex_test.go
+++ b/index/rolodex_test.go
@@ -35,7 +35,7 @@ func TestRolodex_NewRolodex(t *testing.T) {
 	assert.Len(t, rolo.GetIndexes(), 0)
 	assert.Len(t, rolo.GetCaughtErrors(), 0)
 	assert.NotNil(t, rolo.GetConfig())
-	rolo.ClearIndexCaches()
+
 }
 
 func TestRolodex_NoFS(t *testing.T) {
@@ -89,6 +89,9 @@ func TestRolodex_LocalNativeFS(t *testing.T) {
 	f, rerr := rolo.Open("spec.yaml")
 	assert.NoError(t, rerr)
 	assert.Equal(t, "hip", f.GetContent())
+	rolo.rootIndex = &SpecIndex{}
+	rolo.indexes = append(rolo.indexes, rolo.rootIndex)
+	rolo.ClearIndexCaches()
 
 }
 

--- a/index/rolodex_test.go
+++ b/index/rolodex_test.go
@@ -35,6 +35,7 @@ func TestRolodex_NewRolodex(t *testing.T) {
 	assert.Len(t, rolo.GetIndexes(), 0)
 	assert.Len(t, rolo.GetCaughtErrors(), 0)
 	assert.NotNil(t, rolo.GetConfig())
+	rolo.ClearIndexCaches()
 }
 
 func TestRolodex_NoFS(t *testing.T) {

--- a/index/spec_index_test.go
+++ b/index/spec_index_test.go
@@ -1808,3 +1808,14 @@ func Test_GetAllComponentSchemas(t *testing.T) {
 	index := SpecIndex{}
 	assert.Nil(t, index.GetAllComponentSchemas())
 }
+
+func TestSpecIndex_Cache(t *testing.T) {
+
+	idx := new(SpecIndex)
+	assert.NotNil(t, idx.GetHighCache())
+	assert.NotNil(t, uint(1), idx.HighCacheHit())
+	assert.NotNil(t, uint(1), idx.HighCacheMiss())
+	assert.NotNil(t, uint(1), idx.GetHighCacheHits())
+	assert.NotNil(t, uint(1), idx.GetHighCacheMisses())
+
+}

--- a/index/spec_index_test.go
+++ b/index/spec_index_test.go
@@ -1817,5 +1817,7 @@ func TestSpecIndex_Cache(t *testing.T) {
 	assert.NotNil(t, uint(1), idx.HighCacheMiss())
 	assert.NotNil(t, uint(1), idx.GetHighCacheHits())
 	assert.NotNil(t, uint(1), idx.GetHighCacheMisses())
+	idx.SetHighCache(nil)
+	assert.Nil(t, idx.GetHighCache())
 
 }


### PR DESCRIPTION
high memory use is a problem in libopenapi, this change moves us a step closer to fixing that. Very reference heavy specs can create an ungodly number of schema proxy calls when the model is being walked.

For example the docusign spec (which has been added to the test suite) creates 4m proxy calls. This is not required as it’s the same ref being called over and over and we already have it after it’s been done once. This change adds a high level cache to prevent the over production of schemas.