### PR TITLE
Add `nil` check on Document Render to avoid panic

### DIFF
--- a/document.go
+++ b/document.go
@@ -217,8 +217,15 @@ func (d *document) RenderAndReload() ([]byte, Document, *DocumentModel[v3high.Do
 }
 
 func (d *document) Render() ([]byte, error) {
-	if d.highSwaggerModel != nil && d.highOpenAPI3Model == nil {
-		return nil, errors.New("this method only supports OpenAPI 3 documents, not Swagger")
+	if d.highOpenAPI3Model == nil {
+		// check for Swagger model first, to give a more helpful error message.
+		if d.highSwaggerModel != nil {
+			return nil, errors.New("this method only supports OpenAPI 3 documents, not Swagger")
+		}
+		return nil, errors.New("unable to render, no openapi model has been built for the document")
+	}
+	if d.info == nil {
+		return nil, errors.New("unable to render, no specification (info) has been loaded")
 	}
 
 	var newBytes []byte

--- a/document.go
+++ b/document.go
@@ -225,7 +225,7 @@ func (d *document) Render() ([]byte, error) {
 		return nil, errors.New("unable to render, no openapi model has been built for the document")
 	}
 	if d.info == nil {
-		return nil, errors.New("unable to render, no specification (info) has been loaded")
+		return nil, errors.New("unable to render, no specification has been loaded")
 	}
 
 	var newBytes []byte

--- a/document_test.go
+++ b/document_test.go
@@ -427,7 +427,7 @@ func TestDocument_Render(t *testing.T) {
 		h.Components.SecuritySchemes.GetOrZero("petstore_auth").Flows.Implicit.AuthorizationUrl)
 }
 
-func TestDocument_Render_WithError(t *testing.T) {
+func TestDocument_Render_Missing_Model_Error(t *testing.T) {
 	// load an OpenAPI 3 specification from bytes
 	petstore, _ := os.ReadFile("test_specs/petstorev3.json")
 
@@ -438,6 +438,19 @@ func TestDocument_Render_WithError(t *testing.T) {
 	// instead of building the model, we will render the doc immediately - therefore no underlying v3 model exists on render
 	_, e := doc.Render()
 	assert.Error(t, e)
+	assert.Equal(t, "unable to render, no openapi model has been built for the document", e.Error())
+}
+
+func TestDocument_Render_Missing_Info_Error(t *testing.T) {
+	doc := &document{
+		// set the highOpenAPI3Model to a non-nil model to mock an existing model
+		highOpenAPI3Model: &DocumentModel[v3high.Document]{},
+		// do not set the info property
+		info: nil,
+	}
+	_, e := doc.Render()
+	assert.Error(t, e)
+	assert.Equal(t, "unable to render, no specification has been loaded", e.Error())
 }
 
 func TestDocument_RenderWithLargeIndention(t *testing.T) {

--- a/document_test.go
+++ b/document_test.go
@@ -433,12 +433,9 @@ func TestDocument_Render_WithError(t *testing.T) {
 
 	// create a new document from specification bytes
 	doc, err := NewDocument(petstore)
-	// if anything went wrong, an error is thrown
-	if err != nil {
-		panic(fmt.Sprintf("cannot create new document: %e", err))
-	}
+	assert.NoError(t, err)
 
-	// instead of building the model, we will render it directly - therefore no underlying v3 model exists on render
+	// instead of building the model, we will render the doc immediately - therefore no underlying v3 model exists on render
 	_, e := doc.Render()
 	assert.Error(t, e)
 }

--- a/document_test.go
+++ b/document_test.go
@@ -427,6 +427,22 @@ func TestDocument_Render(t *testing.T) {
 		h.Components.SecuritySchemes.GetOrZero("petstore_auth").Flows.Implicit.AuthorizationUrl)
 }
 
+func TestDocument_Render_WithError(t *testing.T) {
+	// load an OpenAPI 3 specification from bytes
+	petstore, _ := os.ReadFile("test_specs/petstorev3.json")
+
+	// create a new document from specification bytes
+	doc, err := NewDocument(petstore)
+	// if anything went wrong, an error is thrown
+	if err != nil {
+		panic(fmt.Sprintf("cannot create new document: %e", err))
+	}
+
+	// instead of building the model, we will render it directly - therefore no underlying v3 model exists on render
+	_, e := doc.Render()
+	assert.Error(t, e)
+}
+
 func TestDocument_RenderWithLargeIndention(t *testing.T) {
 	json := `{
       "openapi": "3.0"


### PR DESCRIPTION
- Expanded the existing check during `Render` to generally check for a `nil` `highOpenAPI3Model`, with more specific error message depending on if it's Swagger or not.
- Also added a check for the `info` which is a pointer, so could _technically_ be `nil`.
- Added a test case to ensure we error. Without my changes the test panics which we're trying to avoid.

Context: I've previously hit a `panic` while learning about & implementing the library. It took me a while to figure out why and got me a bit spooked to have this in a long-running cluster/container. I added a `recover` in my end, but handling it here cleanly is nicer.