### PR TITLE
Add RW Lock to allComponentSchemas to Prevent Data Race Error

### DIFF
--- a/index/index_model.go
+++ b/index/index_model.go
@@ -254,7 +254,8 @@ type SpecIndex struct {
 	allComponentSchemaDefinitions       *sync.Map                                     // all schemas found in components (openapi) or definitions (swagger).
 	securitySchemesNode                 *yaml.Node                                    // components/securitySchemes node
 	allSecuritySchemes                  map[string]*Reference                         // all security schemes / definitions.
-	allComponentSchemas                 map[string]*Reference                         // all component schemas
+	allComponentSchemas                 map[string]*Reference                         // all component schema definitions
+	allComponentSchemasLock             sync.RWMutex                                  // prevent concurrent read writes to the schema file which causes a race condition
 	requestBodiesNode                   *yaml.Node                                    // components/requestBodies node
 	allRequestBodies                    map[string]*Reference                         // all request bodies
 	responsesNode                       *yaml.Node                                    // components/responses node

--- a/index/spec_index.go
+++ b/index/spec_index.go
@@ -327,7 +327,6 @@ func (index *SpecIndex) GetAllReferenceSchemas() []*Reference {
 }
 
 // GetAllComponentSchemas will return all schemas defined in the components section of the document.
-// GetAllComponentSchemas returns all schemas defined in the components section of the document.
 func (index *SpecIndex) GetAllComponentSchemas() map[string]*Reference {
 	if index == nil {
 		return nil
@@ -336,7 +335,6 @@ func (index *SpecIndex) GetAllComponentSchemas() map[string]*Reference {
 	// Acquire read lock
 	index.allComponentSchemasLock.RLock()
 	if index.allComponentSchemas != nil {
-		// Make sure to defer the lock release
 		defer index.allComponentSchemasLock.RUnlock()
 		return index.allComponentSchemas
 	}

--- a/index/spec_index_test.go
+++ b/index/spec_index_test.go
@@ -1860,7 +1860,7 @@ components:
 }
 
 func TestSpecIndex_GetAllComponentSchemas_NilIndex(t *testing.T) {
-	index := &SpecIndex{}
+	var index *SpecIndex
 	schemas := index.GetAllComponentSchemas()
 	assert.Nil(t, schemas, "Expected GetAllComponentSchemas to return nil when index is nil")
 }


### PR DESCRIPTION
- solves issue #333 
- Accessing GetAllComponentSchemas causes a race condition error during usage. 
- Adds a RWLock to ensure that the map object is safely created across go routines. This pattern is used for other similar fields