### PR TITLE
[fix] support of 3.1.1 by handling prefix 3.1X

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,7 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": []
+}

--- a/datamodel/spec_info.go
+++ b/datamodel/spec_info.go
@@ -7,10 +7,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/pb33f/libopenapi/utils"
-	"gopkg.in/yaml.v3"
 	"strings"
 	"time"
+
+	"github.com/pb33f/libopenapi/utils"
+	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -114,8 +115,14 @@ func ExtractSpecInfoWithDocumentCheck(spec []byte, bypass bool) (*SpecInfo, erro
 			specInfo.Version = version
 			specInfo.SpecFormat = OAS3
 
-			switch specInfo.Version {
-			case "3.1.0", "3.1":
+			// Extract the prefix version
+			prefixVersion := specInfo.Version
+			if len(specInfo.Version) >= 3 {
+				prefixVersion = specInfo.Version[:3]
+			}
+
+			switch prefixVersion {
+			case "3.1":
 				specInfo.VersionNumeric = 3.1
 				specInfo.APISchema = OpenAPI31SchemaData
 				specInfo.SpecFormat = OAS31


### PR DESCRIPTION
support of 3.1.1 by changing the parsing of the spec info 
no more leverage on an list of string but on a prefix
could be enhanced by having a definitive version structure 

currently it make the jobs , and have similar behavior 
this will fix https://github.com/daveshanley/vacuum/issues/579 