### PR TITLE
[fix] Support OAS 3.1X

### DIFF
--- a/datamodel/spec_info.go
+++ b/datamodel/spec_info.go
@@ -117,8 +117,13 @@ func ExtractSpecInfoWithDocumentCheck(spec []byte, bypass bool) (*SpecInfo, erro
 		specInfo.Version = version
 		specInfo.SpecFormat = OAS3
 
-		switch specInfo.Version {
-		case "3.1.0", "3.1":
+		// Extract the prefix version
+		prefixVersion := specInfo.Version
+		if len(specInfo.Version) >= 3 {
+			prefixVersion = specInfo.Version[:3]
+		}
+		switch prefixVersion {
+		case "3.1":
 			specInfo.VersionNumeric = 3.1
 			specInfo.APISchema = OpenAPI31SchemaData
 			specInfo.SpecFormat = OAS31


### PR DESCRIPTION
Update spec_info.go , handle version prefix