### PR TITLE
fix: Add error handling when parsing JSON/YAML spec

### DIFF
--- a/datamodel/spec_info.go
+++ b/datamodel/spec_info.go
@@ -137,8 +137,7 @@ func ExtractSpecInfoWithDocumentCheck(spec []byte, bypass bool) (*SpecInfo, erro
 			}
 
 			// parse JSON
-			err := parseJSON(spec, specInfo, &parsedSpec)
-			if err != nil {
+			if err := parseJSON(spec, specInfo, &parsedSpec); err != nil {
 				return nil, err
 			}
 
@@ -162,8 +161,7 @@ func ExtractSpecInfoWithDocumentCheck(spec []byte, bypass bool) (*SpecInfo, erro
 			specInfo.APISchema = OpenAPI2SchemaData
 
 			// parse JSON
-			err := parseJSON(spec, specInfo, &parsedSpec)
-			if err != nil {
+			if err := parseJSON(spec, specInfo, &parsedSpec); err != nil {
 				return nil, err
 			}
 
@@ -184,8 +182,7 @@ func ExtractSpecInfoWithDocumentCheck(spec []byte, bypass bool) (*SpecInfo, erro
 			// TODO: format for AsyncAPI.
 
 			// parse JSON
-			err := parseJSON(spec, specInfo, &parsedSpec)
-			if err != nil {
+			if err := parseJSON(spec, specInfo, &parsedSpec); err != nil {
 				return nil, err
 			}
 
@@ -198,8 +195,7 @@ func ExtractSpecInfoWithDocumentCheck(spec []byte, bypass bool) (*SpecInfo, erro
 
 		if specInfo.SpecType == "" {
 			// parse JSON
-			err := parseJSON(spec, specInfo, &parsedSpec)
-			if err != nil {
+			if err := parseJSON(spec, specInfo, &parsedSpec); err != nil {
 				return nil, err
 			}
 			specInfo.Error = errors.New("spec type not supported by libopenapi, sorry")

--- a/datamodel/spec_info.go
+++ b/datamodel/spec_info.go
@@ -140,7 +140,7 @@ func ExtractSpecInfoWithDocumentCheck(spec []byte, bypass bool) (*SpecInfo, erro
 		}
 
 		// parse JSON
-		if err := parseJSON(spec, specInfo, &parsedSpec); err != nil {
+		if err := parseJSON(spec, specInfo, &parsedSpec); err != nil && !bypass {
 			return nil, err
 		}
 		parsed = true
@@ -169,7 +169,7 @@ func ExtractSpecInfoWithDocumentCheck(spec []byte, bypass bool) (*SpecInfo, erro
 		specInfo.APISchema = OpenAPI2SchemaData
 
 		// parse JSON
-		if err := parseJSON(spec, specInfo, &parsedSpec); err != nil {
+		if err := parseJSON(spec, specInfo, &parsedSpec); err != nil && !bypass {
 			return nil, err
 		}
 		parsed = true
@@ -195,7 +195,7 @@ func ExtractSpecInfoWithDocumentCheck(spec []byte, bypass bool) (*SpecInfo, erro
 		// TODO: format for AsyncAPI.
 
 		// parse JSON
-		if err := parseJSON(spec, specInfo, &parsedSpec); err != nil {
+		if err := parseJSON(spec, specInfo, &parsedSpec); err != nil && !bypass {
 			return nil, err
 		}
 		parsed = true
@@ -226,7 +226,9 @@ func ExtractSpecInfoWithDocumentCheck(spec []byte, bypass bool) (*SpecInfo, erro
 	//}
 
 	if !parsed {
-		_ = parseJSON(spec, specInfo, &parsedSpec)
+		if err := parseJSON(spec, specInfo, &parsedSpec); err != nil && !bypass {
+			return nil, err
+		}
 	}
 
 	// detect the original whitespace indentation

--- a/datamodel/spec_info_test.go
+++ b/datamodel/spec_info_test.go
@@ -5,10 +5,10 @@ package datamodel
 
 import (
 	"fmt"
+	"github.com/pb33f/libopenapi/utils"
 	"os"
 	"testing"
 
-	"github.com/pb33f/libopenapi/utils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -74,6 +74,23 @@ tags:
 servers:
   - url: https://quobix.com/api`
 
+// This is a bad yaml file, where the second openapi path is indented incorrectly,
+// causing its 'get' operation to be on the same indent level as the first path's 'get' operation, so it's a duplicate key and would fail decoding.
+var BadYAML2 = `openapi: 3.0.1
+info:
+  title: Test API
+paths:
+  /test:
+    get:
+      responses:
+        '200':
+          description: OK
+    /test2:
+    get:
+      responses:
+        '200':
+          description: OK`
+
 var OpenApi2Spec = `swagger: 2.0.1
 info:
   title: Test API
@@ -134,6 +151,11 @@ func TestExtractSpecInfo_InvalidYAML(t *testing.T) {
 	assert.Error(t, e)
 }
 
+func TestExtractSpecInfo_InvalidYAML2(t *testing.T) {
+	_, e := ExtractSpecInfo([]byte(BadYAML2))
+	assert.Error(t, e)
+}
+
 func TestExtractSpecInfo_InvalidOpenAPIVersion(t *testing.T) {
 	_, e := ExtractSpecInfo([]byte(OpenApiOne))
 	assert.Error(t, e)
@@ -166,10 +188,10 @@ func TestExtractSpecInfo_OpenAPI31(t *testing.T) {
 func TestExtractSpecInfo_AnyDocument(t *testing.T) {
 	random := `something: yeah
 nothing:
-  - one
-  - two
+ - one
+ - two
 why:
-  yes: no`
+ yes: no`
 
 	r, e := ExtractSpecInfoWithDocumentCheck([]byte(random), true)
 	assert.Nil(t, e)
@@ -181,10 +203,10 @@ why:
 func TestExtractSpecInfo_AnyDocument_Sync(t *testing.T) {
 	random := `something: yeah
 nothing:
-  - one
-  - two
+ - one
+ - two
 why:
-  yes: no`
+ yes: no`
 
 	r, e := ExtractSpecInfoWithDocumentCheckSync([]byte(random), true)
 	assert.Nil(t, e)
@@ -206,10 +228,10 @@ func TestExtractSpecInfo_AnyDocument_JSON(t *testing.T) {
 func TestExtractSpecInfo_AnyDocumentFromConfig(t *testing.T) {
 	random := `something: yeah
 nothing:
-  - one
-  - two
+ - one
+ - two
 why:
-  yes: no`
+ yes: no`
 
 	r, e := ExtractSpecInfoWithConfig([]byte(random), &DocumentConfiguration{
 		BypassDocumentCheck: true,
@@ -259,7 +281,7 @@ func TestExtractSpecInfo_AsyncAPI_OddVersion(t *testing.T) {
 
 func TestExtractSpecInfo_BadVersion_OpenAPI3(t *testing.T) {
 	yml := `openapi:
- should: fail`
+should: fail`
 
 	_, err := ExtractSpecInfo([]byte(yml))
 	assert.Error(t, err)
@@ -267,7 +289,7 @@ func TestExtractSpecInfo_BadVersion_OpenAPI3(t *testing.T) {
 
 func TestExtractSpecInfo_BadVersion_Swagger(t *testing.T) {
 	yml := `swagger:
- should: fail`
+should: fail`
 
 	_, err := ExtractSpecInfo([]byte(yml))
 	assert.Error(t, err)
@@ -275,7 +297,7 @@ func TestExtractSpecInfo_BadVersion_Swagger(t *testing.T) {
 
 func TestExtractSpecInfo_BadVersion_AsyncAPI(t *testing.T) {
 	yml := `asyncapi:
- should: fail`
+should: fail`
 
 	_, err := ExtractSpecInfo([]byte(yml))
 	assert.Error(t, err)

--- a/datamodel/spec_info_test.go
+++ b/datamodel/spec_info_test.go
@@ -188,10 +188,10 @@ func TestExtractSpecInfo_OpenAPI31(t *testing.T) {
 func TestExtractSpecInfo_AnyDocument(t *testing.T) {
 	random := `something: yeah
 nothing:
- - one
- - two
+  - one
+  - two
 why:
- yes: no`
+  yes: no`
 
 	r, e := ExtractSpecInfoWithDocumentCheck([]byte(random), true)
 	assert.Nil(t, e)
@@ -203,10 +203,10 @@ why:
 func TestExtractSpecInfo_AnyDocument_Sync(t *testing.T) {
 	random := `something: yeah
 nothing:
- - one
- - two
+  - one
+  - two
 why:
- yes: no`
+  yes: no`
 
 	r, e := ExtractSpecInfoWithDocumentCheckSync([]byte(random), true)
 	assert.Nil(t, e)
@@ -228,10 +228,10 @@ func TestExtractSpecInfo_AnyDocument_JSON(t *testing.T) {
 func TestExtractSpecInfo_AnyDocumentFromConfig(t *testing.T) {
 	random := `something: yeah
 nothing:
- - one
- - two
+  - one
+  - two
 why:
- yes: no`
+  yes: no`
 
 	r, e := ExtractSpecInfoWithConfig([]byte(random), &DocumentConfiguration{
 		BypassDocumentCheck: true,
@@ -281,7 +281,7 @@ func TestExtractSpecInfo_AsyncAPI_OddVersion(t *testing.T) {
 
 func TestExtractSpecInfo_BadVersion_OpenAPI3(t *testing.T) {
 	yml := `openapi:
-should: fail`
+ should: fail`
 
 	_, err := ExtractSpecInfo([]byte(yml))
 	assert.Error(t, err)
@@ -289,7 +289,7 @@ should: fail`
 
 func TestExtractSpecInfo_BadVersion_Swagger(t *testing.T) {
 	yml := `swagger:
-should: fail`
+ should: fail`
 
 	_, err := ExtractSpecInfo([]byte(yml))
 	assert.Error(t, err)
@@ -297,7 +297,7 @@ should: fail`
 
 func TestExtractSpecInfo_BadVersion_AsyncAPI(t *testing.T) {
 	yml := `asyncapi:
-should: fail`
+ should: fail`
 
 	_, err := ExtractSpecInfo([]byte(yml))
 	assert.Error(t, err)

--- a/datamodel/spec_info_test.go
+++ b/datamodel/spec_info_test.go
@@ -24,9 +24,10 @@ const (
 )
 
 var (
-	goodJSON = `{"name":"kitty", "noises":["meow","purrrr","gggrrraaaaaooooww"]}`
-	badJSON  = `{"name":"kitty, "noises":[{"meow","purrrr","gggrrraaaaaooooww"]}}`
-	goodYAML = `name: kitty
+	goodJSON            = `{"name":"kitty", "noises":["meow","purrrr","gggrrraaaaaooooww"]}`
+	badJSON             = `{"name":"kitty, "noises":[{"meow","purrrr","gggrrraaaaaooooww"]}}`
+	badJSONMissingQuote = `{"openapi": "3.0.1", "name":"kitty", "name":["kitty2",kitty3"]}`
+	goodYAML            = `name: kitty
 noises:
 - meow
 - purrr
@@ -76,7 +77,7 @@ servers:
 
 // This is a bad yaml file, where the second openapi path is indented incorrectly,
 // causing its 'get' operation to be on the same indent level as the first path's 'get' operation, so it's a duplicate key and would fail decoding.
-var BadYAML2 = `openapi: 3.0.1
+var BadYAMLRepeatedPathKey = `openapi: 3.0.1
 info:
   title: Test API
 paths:
@@ -135,6 +136,11 @@ func TestExtractSpecInfo_InvalidJSON(t *testing.T) {
 	assert.Error(t, e)
 }
 
+func TestExtractSpecInfo_InvalidJSON_MissingQuote(t *testing.T) {
+	_, e := ExtractSpecInfo([]byte(badJSONMissingQuote))
+	assert.Error(t, e)
+}
+
 func TestExtractSpecInfo_Nothing(t *testing.T) {
 	_, e := ExtractSpecInfo([]byte(""))
 	assert.Error(t, e)
@@ -151,8 +157,8 @@ func TestExtractSpecInfo_InvalidYAML(t *testing.T) {
 	assert.Error(t, e)
 }
 
-func TestExtractSpecInfo_InvalidYAML2(t *testing.T) {
-	_, e := ExtractSpecInfo([]byte(BadYAML2))
+func TestExtractSpecInfo_InvalidYAML_RepeatedPathKey(t *testing.T) {
+	_, e := ExtractSpecInfo([]byte(BadYAMLRepeatedPathKey))
 	assert.Error(t, e)
 }
 


### PR DESCRIPTION
Resolves: https://github.com/pb33f/libopenapi/issues/355

# Context

When testing a YAML setup similar to the one added in the test, I noticed no errors were reported and any invalid spec was ignored. While it's not a breaking behavior, it could lead to missing configuration without noticing.

# Fix

To fix this we simply should _not_ ignore any errors when parsing.

# Open Questions (from me)

- Does `bypass` make sense to use as the gate for ignoring (or not) the errors?
  - Should we _never_ ignore these errors?
  - Or should we add a new field specifically for this to lessen possibility of breaking users existing environments?
      - Adding this as a possible path forward as the unit tests fail when not ignoring errors, so it may make sense to have another parameter/option.

# Concerns (from me)

- This could technically be breaking. Users with invalid configurations - those caught by the Decode & Marshal methods - would now receive errors.
  - This breakage may be avoidable if instead of returning the error when caught, we store/save it until the final `return specInfo, nil`, where we'd return any error.
