### PR TITLE
Fixed issue with `$refs` being picked up in extensions.

### DIFF
--- a/index/extract_refs.go
+++ b/index/extract_refs.go
@@ -212,6 +212,19 @@ func (index *SpecIndex) ExtractRefs(node, parent *yaml.Node, seenPath []string, 
 
 			if i%2 == 0 && n.Value == "$ref" {
 
+				// check if this reference is under an extension or not, if so, drop it from the index.
+				ext := false
+				for _, spi := range seenPath {
+					if strings.HasPrefix(spi, "x-") {
+						ext = true
+						break
+					}
+				}
+
+				if ext {
+					continue
+				}
+
 				// only look at scalar values, not maps (looking at you k8s)
 				if len(node.Content) > i+1 {
 					if !utils.IsNodeStringValue(node.Content[i+1]) {

--- a/index/extract_refs.go
+++ b/index/extract_refs.go
@@ -213,16 +213,17 @@ func (index *SpecIndex) ExtractRefs(node, parent *yaml.Node, seenPath []string, 
 			if i%2 == 0 && n.Value == "$ref" {
 
 				// check if this reference is under an extension or not, if so, drop it from the index.
-				ext := false
-				for _, spi := range seenPath {
-					if strings.HasPrefix(spi, "x-") {
-						ext = true
-						break
+				if index.config.ExcludeExtensionRefs {
+					ext := false
+					for _, spi := range seenPath {
+						if strings.HasPrefix(spi, "x-") {
+							ext = true
+							break
+						}
 					}
-				}
-
-				if ext {
-					continue
+					if ext {
+						continue
+					}
 				}
 
 				// only look at scalar values, not maps (looking at you k8s)

--- a/index/extract_refs_test.go
+++ b/index/extract_refs_test.go
@@ -207,6 +207,7 @@ components:
 	var rootNode yaml.Node
 	_ = yaml.Unmarshal([]byte(yml), &rootNode)
 	c := CreateOpenAPIIndexConfig()
+	c.ExcludeExtensionRefs = true
 	idx := NewSpecIndexWithConfig(&rootNode, c)
 	assert.Len(t, idx.allMappedRefs, 0)
 	assert.Len(t, idx.allRefs, 0)

--- a/index/extract_refs_test.go
+++ b/index/extract_refs_test.go
@@ -194,3 +194,21 @@ components:
 	idx := NewSpecIndexWithConfig(&rootNode, c)
 	assert.Len(t, idx.allEnums, 3)
 }
+
+func TestSpecIndex_ExtractRefs_CheckRefsUnderExtensionsAreNotIncluded(t *testing.T) {
+	yml := `openapi: 3.1.0
+components:
+  schemas:
+    Pasta:
+      x-hello:
+       thing:
+         $ref: '404'
+   `
+	var rootNode yaml.Node
+	_ = yaml.Unmarshal([]byte(yml), &rootNode)
+	c := CreateOpenAPIIndexConfig()
+	idx := NewSpecIndexWithConfig(&rootNode, c)
+	assert.Len(t, idx.allMappedRefs, 0)
+	assert.Len(t, idx.allRefs, 0)
+	assert.Len(t, idx.refErrors, 0)
+}

--- a/index/index_model.go
+++ b/index/index_model.go
@@ -173,6 +173,10 @@ type SpecIndexConfig struct {
 	// to be bundled.
 	ExtractRefsSequentially bool
 
+	// ExcludeExtensionReferences will prevent the indexing of any $ref pointers buried under extensions.
+	// defaults to false (which means extensions will be included)
+	ExcludeExtensionRefs bool
+
 	// private fields
 	uri []string
 }

--- a/index/spec_index_test.go
+++ b/index/spec_index_test.go
@@ -78,7 +78,7 @@ func TestSpecIndex_ExtractRefsStripe(t *testing.T) {
 	combined := index.GetAllCombinedReferences()
 	assert.Equal(t, 871, len(combined))
 
-	assert.Equal(t, len(index.rawSequencedRefs), 2712)
+	assert.Equal(t, 2712, len(index.rawSequencedRefs))
 	assert.Equal(t, 336, index.pathCount)
 	assert.Equal(t, 494, index.operationCount)
 	assert.Equal(t, 871, index.schemaCount)
@@ -110,7 +110,7 @@ func TestSpecIndex_ExtractRefsStripe(t *testing.T) {
 	assert.Len(t, index.GetCircularReferences(), 1)
 
 	assert.Equal(t, 871, len(index.GetRefsByLine()))
-	assert.Equal(t, 2712, len(index.GetLinesWithReferences()), 1972)
+	assert.Equal(t, 2712, len(index.GetLinesWithReferences()))
 	assert.Equal(t, 0, len(index.GetAllExternalDocuments()))
 }
 


### PR DESCRIPTION
extensions that contain references will not be parsed, they should not be parsed, unless you want them to, and then, well, so you can! 

Now comes with a configurable switch in the config.