### PR TITLE
Add Gleece to the list of projects depending on libopenapi.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ like our _very kind_ sponsors:
 - [github.com/speakeasy-api/speakeasy](https://github.com/speakeasy-api/speakeasy) - "Speakeasy CLI makes validating OpenAPI docs and generating idiomatic SDKs easy!"
 - [github.com/apicat/apicat](https://github.com/apicat/apicat) - "AI-powered API development tool"
 - [github.com/mattermost/mattermost](https://github.com/mattermost/mattermost) - "Software development lifecycle platform"
+- [github.com/gopher-fleece/gleece](https://github.com/gopher-fleece/gleece) - "Building and documenting REST APIs through code-first development"
 - Your project here?
 ---
 


### PR DESCRIPTION
Hi, 

I have utilized the `libopenapi` package to generate OpenAPI specifications in the [Gleece](https://github.com/gopher-fleece/gleece) project.

If you think this project meets your standards, I will be happy to be added to the dependent projects list. In any case, thank you for creating this awesome project!

