### PR TITLE
Fix: Address issue: #383

### DIFF
--- a/index/cache.go
+++ b/index/cache.go
@@ -37,10 +37,12 @@ func (index *SpecIndex) GetHighCacheMisses() uint64 {
 
 // GetHighCache returns the high model cache for this index.
 func (index *SpecIndex) GetHighCache() Cache {
-	if index.highModelCache == nil {
-		index.highModelCache = CreateNewCache()
-	}
 	return index.highModelCache
+}
+
+// InitHighCache allocates a new high model cache onto the index.
+func (index *SpecIndex) InitHighCache() {
+	index.highModelCache = CreateNewCache()
 }
 
 // SetHighCache sets the high model cache for this index.

--- a/index/cache_test.go
+++ b/index/cache_test.go
@@ -9,6 +9,13 @@ import (
 	"testing"
 )
 
+// NewTestSpecIndex Test helper function to create a SpecIndex with initialised high cache.
+func NewTestSpecIndex() *SpecIndex {
+	index := &SpecIndex{}
+	index.InitHighCache()
+	return index
+}
+
 // SimpleCache struct and methods are assumed to be imported from the respective package
 
 // TestCreateNewCache tests that a new cache is correctly created.

--- a/index/find_component_test.go
+++ b/index/find_component_test.go
@@ -202,7 +202,7 @@ components:
 
 func TestSpecIndex_FailFindComponentInRoot(t *testing.T) {
 
-	index := &SpecIndex{}
+	index := NewTestSpecIndex()
 	assert.Nil(t, index.FindComponentInRoot("does it even matter? of course not. no"))
 
 }

--- a/index/index_model_test.go
+++ b/index/index_model_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestSpecIndex_GetConfig(t *testing.T) {
-	idx1 := new(SpecIndex)
+	idx1 := NewTestSpecIndex()
 	c := SpecIndexConfig{}
 	idx1.config = &c
 	assert.Equal(t, &c, idx1.GetConfig())

--- a/index/rolodex_file_loader_test.go
+++ b/index/rolodex_file_loader_test.go
@@ -145,7 +145,7 @@ func TestRolodexLocalFile_BadParse(t *testing.T) {
 
 func TestRolodexLocalFile_NoIndexRoot(t *testing.T) {
 
-	lf := &LocalFile{data: []byte("burders"), index: &SpecIndex{}}
+	lf := &LocalFile{data: []byte("burders"), index: NewTestSpecIndex()}
 	n, e := lf.GetContentAsYAMLNode()
 	assert.NotNil(t, n)
 	assert.NoError(t, e)

--- a/index/rolodex_remote_loader_test.go
+++ b/index/rolodex_remote_loader_test.go
@@ -210,14 +210,14 @@ func TestRemoteFile_NoContent(t *testing.T) {
 }
 
 func TestRemoteFile_BadContent(t *testing.T) {
-	rf := &RemoteFile{data: []byte("bad: data: on: a single: line: makes: for: unhappy: yaml"), index: &SpecIndex{}}
+	rf := &RemoteFile{data: []byte("bad: data: on: a single: line: makes: for: unhappy: yaml"), index: NewTestSpecIndex()}
 	x, y := rf.GetContentAsYAMLNode()
 	assert.Nil(t, x)
 	assert.Error(t, y)
 }
 
 func TestRemoteFile_GoodContent(t *testing.T) {
-	rf := &RemoteFile{data: []byte("good: data"), index: &SpecIndex{}}
+	rf := &RemoteFile{data: []byte("good: data"), index: NewTestSpecIndex()}
 	x, y := rf.GetContentAsYAMLNode()
 	assert.NotNil(t, x)
 	assert.NoError(t, y)
@@ -231,7 +231,7 @@ func TestRemoteFile_GoodContent(t *testing.T) {
 }
 
 func TestRemoteFile_Index_AlreadySet(t *testing.T) {
-	rf := &RemoteFile{data: []byte("good: data"), index: &SpecIndex{}}
+	rf := &RemoteFile{data: []byte("good: data"), index: NewTestSpecIndex()}
 	x, y := rf.Index(&SpecIndexConfig{})
 	assert.NotNil(t, x)
 	assert.NoError(t, y)

--- a/index/rolodex_test.go
+++ b/index/rolodex_test.go
@@ -89,7 +89,7 @@ func TestRolodex_LocalNativeFS(t *testing.T) {
 	f, rerr := rolo.Open("spec.yaml")
 	assert.NoError(t, rerr)
 	assert.Equal(t, "hip", f.GetContent())
-	rolo.rootIndex = &SpecIndex{}
+	rolo.rootIndex = NewTestSpecIndex()
 	rolo.indexes = append(rolo.indexes, rolo.rootIndex)
 	rolo.ClearIndexCaches()
 

--- a/index/spec_index.go
+++ b/index/spec_index.go
@@ -39,6 +39,7 @@ const (
 func NewSpecIndexWithConfig(rootNode *yaml.Node, config *SpecIndexConfig) *SpecIndex {
 	index := new(SpecIndex)
 	boostrapIndexCollections(index)
+	index.InitHighCache()
 	index.config = config
 	index.rolodex = config.Rolodex
 	index.uri = config.uri
@@ -65,6 +66,7 @@ func NewSpecIndexWithConfig(rootNode *yaml.Node, config *SpecIndexConfig) *SpecI
 // the rolodex will automatically read those files or open those h
 func NewSpecIndex(rootNode *yaml.Node) *SpecIndex {
 	index := new(SpecIndex)
+	index.InitHighCache()
 	index.config = CreateOpenAPIIndexConfig()
 	index.root = rootNode
 	boostrapIndexCollections(index)

--- a/index/spec_index_test.go
+++ b/index/spec_index_test.go
@@ -936,7 +936,7 @@ func TestTagsNoDescription(t *testing.T) {
 }
 
 func TestGlobalCallbacksNoIndexTest(t *testing.T) {
-	idx := new(SpecIndex)
+	idx := NewTestSpecIndex()
 	assert.Equal(t, -1, idx.GetGlobalCallbacksCount())
 }
 
@@ -1864,13 +1864,6 @@ components:
 	assert.Equal(t, 0, len(schemas))
 }
 
-func Test_GetAllComponentSchemas(t *testing.T) {
-
-	// check for a nil
-	index := SpecIndex{}
-	assert.Nil(t, index.GetAllComponentSchemas())
-}
-
 func TestSpecIndex_GetAllComponentSchemas_ConcurrentAccess(t *testing.T) {
 	yml := `
 openapi: 3.0.0
@@ -1929,7 +1922,7 @@ func TestSpecIndex_GetAllComponentSchemas_NilIndex(t *testing.T) {
 
 func TestSpecIndex_Cache(t *testing.T) {
 
-	idx := new(SpecIndex)
+	idx := NewTestSpecIndex()
 	assert.NotNil(t, idx.GetHighCache())
 	assert.NotNil(t, uint(1), idx.HighCacheHit())
 	assert.NotNil(t, uint(1), idx.HighCacheMiss())


### PR DESCRIPTION
# Context

This should address issue: #383

# Fix

Remove initialisation side effect from `GetHighCache()`

- Pull initialisation of `index.highModelCache` out of `GetHighCache()` and create a new function `InitHighCache()`
- **For active code**, call that new function everywhere a `SpecIndex` is created. This ensures that the cache *is always* initialised and no longer requires the side effect in `GetHighCache()`
- **For unit tests** that also rely on that _side-effect_.
  - Create a new unit-test helper `NewTestSpecIndex()` that initialises the high cache.
  - Use that everywhere a new `SpecIndex` is created.