### PR TITLE
fix: check rendered first to fix a regression

### DIFF
--- a/datamodel/high/base/schema_proxy.go
+++ b/datamodel/high/base/schema_proxy.go
@@ -93,15 +93,15 @@ func (sp *SchemaProxy) Schema() *Schema {
 		return nil
 	}
 
-	if sp.schema == nil || sp.schema.Value == nil {
-		return nil
-	}
-
 	sp.lock.Lock()
 	defer sp.lock.Unlock()
 
 	if sp.rendered != nil {
 		return sp.rendered
+	}
+
+	if sp.schema == nil || sp.schema.Value == nil {
+		return nil
 	}
 
 	//check the high-level cache first.


### PR DESCRIPTION
Fix a regression with my recent change #391 

If I were to create a SchemaProxy from `CreateSchemaProxy`, `Schema()` will return `nil`. I do this in unit tests. 

In reality though, `schema` should be present.

We should keep original logic where we check `rendered` first before checking if schema is nil. So we move the check for `schema` after `rendered` check like before. They are both in critical section to prevent datarace issue from before.