### PR TITLE
Bug: Render missing required property 

### DIFF
--- a/renderer/schema_renderer_test.go
+++ b/renderer/schema_renderer_test.go
@@ -996,6 +996,32 @@ properties:
 	assert.Nil(t, journeyMap["pb33f"].(map[string]interface{})["fries"])
 }
 
+func TestRenderExample_Test_RequiredWithMissingProp(t *testing.T) {
+	testObject := `type: [object]
+required:
+  - missing
+  - drink
+properties:
+  burger:
+    type: string`
+
+	compiled := getSchema([]byte(testObject))
+
+	journeyMap := make(map[string]any)
+	wr := createSchemaRenderer()
+	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, 0)
+
+	assert.NotNil(t, journeyMap["pb33f"])
+	drink := journeyMap["pb33f"].(map[string]interface{})["drink"].(string)
+	assert.NotNil(t, drink)
+
+	_, exists := journeyMap["pb33f"].(map[string]interface{})["missing"]
+	assert.True(t, exists)
+
+	assert.Nil(t, journeyMap["pb33f"].(map[string]interface{})["burger"])
+}
+
+
 func TestRenderExample_Test_RequiredCheckDisabled(t *testing.T) {
 	testObject := `type: [object]
 required:

--- a/renderer/schema_renderer_test.go
+++ b/renderer/schema_renderer_test.go
@@ -1003,6 +1003,8 @@ required:
   - drink
 properties:
   burger:
+    type: string
+  drink:
     type: string`
 
 	compiled := getSchema([]byte(testObject))
@@ -1026,6 +1028,7 @@ func TestRenderExample_Test_RequiredCheckDisabled(t *testing.T) {
 	testObject := `type: [object]
 required:
   - drink
+  - missing
 properties:
   burger:
     type: string
@@ -1044,6 +1047,10 @@ properties:
 	assert.NotNil(t, journeyMap["pb33f"])
 	drink := journeyMap["pb33f"].(map[string]interface{})["drink"].(string)
 	assert.NotNil(t, drink)
+
+	_, exists := journeyMap["pb33f"].(map[string]interface{})["missing"]
+	assert.True(t, exists)
+
 	assert.NotNil(t, journeyMap["pb33f"].(map[string]interface{})["burger"])
 	assert.NotNil(t, journeyMap["pb33f"].(map[string]interface{})["fries"])
 }


### PR DESCRIPTION
Given a specification
```
type: [object]
required:
  - drink
  - missing
properties:
  burger:
    type: string
  fries:
    type: string
  drink:
    type: string
```
I expect a mock
```
{
  "drink": "test",
  "missing": {} // or any other value
}
```

Currently, it crashes due to dereferencing a nil pointer.

## Solution

This PR proposes rendering the missing required property by setting it to an empty object; we could also set it to any other type (like string, integers, ...). I believe the OpenAPI specification allows any type if the property is missing in the `properties` field.

## Note

I am very new to Go. Let me know if I do something very weird.