### PR TITLE
Improve rendering of schemas with circular references

### DIFF
--- a/renderer/schema_renderer.go
+++ b/renderer/schema_renderer.go
@@ -384,7 +384,9 @@ func (wr *SchemaRenderer) DiveIntoSchema(schema *base.Schema, key string, struct
 
 		// handle oneOf
 		oneOf := schema.OneOf
+		oneOfSuccess := true
 		for _, oneOfSchema := range oneOf {
+			oneOfSuccess = false
 			oneOfMap := make(map[string]any)
 			oneOfCompiled := oneOfSchema.Schema()
 			success := wr.DiveIntoSchema(oneOfCompiled, oneOfType, oneOfMap, copyMap(visited), depth+1)
@@ -399,14 +401,19 @@ func (wr *SchemaRenderer) DiveIntoSchema(schema *base.Schema, key string, struct
 			if m, ok := oneOfMap[oneOfType].(string); ok {
 				propertyMap[oneOfType] = m
 			}
-			// to do: throw error if none of the oneOf schemas was successfully rendered
+			oneOfSuccess = true
 
 			break
 		}
+		if !oneOfSuccess {
+			return false
+		}
 
 		// handle anyOf
+		anyOfSuccess := true
 		anyOf := schema.AnyOf
 		for _, anyOfSchema := range anyOf {
+			anyOfSuccess = false
 			anyOfMap := make(map[string]any)
 			anyOfCompiled := anyOfSchema.Schema()
 			success := wr.DiveIntoSchema(anyOfCompiled, anyOfType, anyOfMap, copyMap(visited), depth+1)
@@ -421,9 +428,13 @@ func (wr *SchemaRenderer) DiveIntoSchema(schema *base.Schema, key string, struct
 			if m, ok := anyOfMap[anyOfType].(string); ok {
 				propertyMap[anyOfType] = m
 			}
-			// to do: throw error if none of the oneOf schemas was successfully rendered
+			anyOfSuccess = true
 
 			break
+		}
+
+		if !anyOfSuccess {
+			return false
 		}
 
 		structure[key] = propertyMap

--- a/renderer/schema_renderer.go
+++ b/renderer/schema_renderer.go
@@ -329,7 +329,7 @@ func (wr *SchemaRenderer) DiveIntoSchema(schema *base.Schema, key string, struct
 						if required {
 							return false
 						}
-						propertyMap[propName] = nil
+						delete(propertyMap, propName)
 						continue
 					}
 				} else {

--- a/renderer/schema_renderer.go
+++ b/renderer/schema_renderer.go
@@ -294,13 +294,13 @@ func (wr *SchemaRenderer) DiveIntoSchema(schema *base.Schema, key string, struct
 	if slices.Contains(schema.Type, objectType) || (schema.Properties != nil && schema.Properties.Len() > 0) ||
 		schema.AllOf != nil || (schema.DependentSchemas != nil && schema.DependentSchemas.Len() > 0) || schema.OneOf != nil || schema.AnyOf != nil {
 
-		if schema.ParentProxy.IsReference() && visited[schema.ParentProxy.GetReference()] {
-			return false
-		}
-
 		if schema.ParentProxy.IsReference() {
+			if visited[schema.ParentProxy.GetReference()] {
+				return false
+			}
 			visited[schema.ParentProxy.GetReference()] = true
 		}
+
 
 		properties := schema.Properties
 		propertyMap := make(map[string]any)

--- a/renderer/schema_renderer_test.go
+++ b/renderer/schema_renderer_test.go
@@ -1769,6 +1769,48 @@ schemas:
 	assert.Equal(t, `{"name":"Maria the frog"}`, string(rendered))
 }
 
+func TestRenderSchema_Ref_SkipCircularProp(t *testing.T) {
+	yml := `
+schemas:
+  pet:
+    type: object
+    properties:
+      name:
+        type: string
+        example: Maria the frog
+      color:
+        type: string
+        example: green
+      bestFriend:
+        $ref: "#/schemas/pet"
+`
+
+	var idxNode yaml.Node
+	mErr := yaml.Unmarshal([]byte(yml), &idxNode)
+	assert.NoError(t, mErr)
+	idx := index.NewSpecIndex(&idxNode)
+
+	var components v3.Components
+	err := low.BuildModel(idxNode.Content[0], &components)
+	assert.NoError(t, err)
+
+	err = components.Build(context.Background(), idxNode.Content[0], idx)
+	assert.NoError(t, err)
+
+  lowRestaurant := components.FindSchema("pet")
+	lowNode := low.NodeReference[*lowbase.SchemaProxy]{
+		ValueNode: lowRestaurant.ValueNode,
+		Reference: lowRestaurant.Reference,
+		Value: lowRestaurant.Value,
+	}
+	schemaProxy := highbase.NewSchemaProxy(&lowNode)
+	schema := make(map[string]any)
+	visited := createVisitedMap()
+	wr := createSchemaRenderer()
+  wr.DiveIntoSchema(schemaProxy.Schema(), "pb33f", schema, visited, 0)
+	rendered, _ := json.Marshal(schema["pb33f"])
+	assert.Equal(t, `{"bestFriend":{"color":"green","name":"Maria the frog"},"color":"green","name":"Maria the frog"}`, string(rendered))
+}
 
 func TestRenderSchema_Ref_FailRenderOfCircularRef(t *testing.T) {
 	yml := `
@@ -1814,6 +1856,7 @@ schemas:
   success := wr.DiveIntoSchema(schemaProxy.Schema(), "pb33f", schema, visited, 0)
   assert.False(t, success)
 }
+
 
 func TestCreateRendererUsingDefaultDictionary(t *testing.T) {
 	assert.NotNil(t, CreateRendererUsingDefaultDictionary())

--- a/renderer/schema_renderer_test.go
+++ b/renderer/schema_renderer_test.go
@@ -1724,6 +1724,50 @@ schemas:
 	assert.Equal(t, `{"name":"John Doe","pet":{"bestFriend":{"age":1,"model":"ball"},"name":"Hilbert the fish"}}`, string(rendered))
 }
 
+func TestRenderSchema_Ref_SkipOptional(t *testing.T) {
+	yml := `
+schemas:
+  pet:
+    type: object
+    properties:
+      name:
+        type: string
+        example: Maria the frog
+      color:
+        type: string
+        example: green
+      bestFriend:
+        $ref: "#/schemas/pet"
+    required:
+      - name
+`
+
+	var idxNode yaml.Node
+	mErr := yaml.Unmarshal([]byte(yml), &idxNode)
+	assert.NoError(t, mErr)
+	idx := index.NewSpecIndex(&idxNode)
+
+	var components v3.Components
+	err := low.BuildModel(idxNode.Content[0], &components)
+	assert.NoError(t, err)
+
+	err = components.Build(context.Background(), idxNode.Content[0], idx)
+	assert.NoError(t, err)
+
+  lowRestaurant := components.FindSchema("pet")
+	lowNode := low.NodeReference[*lowbase.SchemaProxy]{
+		ValueNode: lowRestaurant.ValueNode,
+		Reference: lowRestaurant.Reference,
+		Value: lowRestaurant.Value,
+	}
+	schemaProxy := highbase.NewSchemaProxy(&lowNode)
+	schema := make(map[string]any)
+	visited := createVisitedMap()
+	wr := createSchemaRenderer()
+	wr.DiveIntoSchema(schemaProxy.Schema(), "pb33f", schema, visited, 0)
+	rendered, _ := json.Marshal(schema["pb33f"])
+	assert.Equal(t, `{"name":"Maria the frog"}`, string(rendered))
+}
 
 func TestCreateRendererUsingDefaultDictionary(t *testing.T) {
 	assert.NotNil(t, CreateRendererUsingDefaultDictionary())

--- a/renderer/schema_renderer_test.go
+++ b/renderer/schema_renderer_test.go
@@ -68,6 +68,10 @@ func getSchema(schema []byte) *highbase.Schema {
 	return schemaProxy.Schema()
 }
 
+func createVisitedMap() map[string]bool {
+  return make(map[string]bool)
+}
+
 func TestRenderExample_StringWithExample(t *testing.T) {
 	testObject := `type: string
 example: dog`
@@ -75,8 +79,8 @@ example: dog`
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
-	visited := make(map[string]bool)
-	wr := createSchemaRenderer()
+	visited := createVisitedMap()
+  wr := createSchemaRenderer()
 	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
 	assert.Equal(t, journeyMap["pb33f"], "dog")
@@ -88,7 +92,7 @@ func TestRenderExample_StringWithNoExample(t *testing.T) {
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
@@ -104,7 +108,7 @@ format: date-time`
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
@@ -120,7 +124,7 @@ pattern: "^[a-z]{5,10}@[a-z]{5,10}\\.(com|net|org)$"` // an email address
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
@@ -139,7 +143,7 @@ pattern: "^\\([0-9]{3}\\)-[0-9]{3}-[0-9]{4}$"` // a phone number
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
@@ -157,7 +161,7 @@ format: date`
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
@@ -174,7 +178,7 @@ format: time`
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
@@ -191,7 +195,7 @@ format: email`
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
@@ -206,7 +210,7 @@ format: hostname`
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
@@ -220,7 +224,7 @@ format: ipv4`
 
 	compiled := getSchema([]byte(testObject))
 
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	journeyMap := make(map[string]any)
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
@@ -237,7 +241,7 @@ format: ipv6`
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
@@ -253,7 +257,7 @@ format: uri`
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
@@ -271,7 +275,7 @@ format: uuid`
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
@@ -287,7 +291,7 @@ format: byte`
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
@@ -302,7 +306,7 @@ format: password`
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
@@ -317,7 +321,7 @@ format: uri-reference`
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
@@ -333,7 +337,7 @@ format: binary`
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
@@ -351,7 +355,7 @@ example: 3.14`
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
@@ -366,7 +370,7 @@ minLength: 10`
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
@@ -381,7 +385,7 @@ maxLength: 10`
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
@@ -397,7 +401,7 @@ minLength: 3`
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
@@ -412,7 +416,7 @@ func TestRenderExample_NumberNoExample_Default(t *testing.T) {
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
@@ -428,7 +432,7 @@ minimum: 60`
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
@@ -444,7 +448,7 @@ maximum: 4`
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
@@ -460,7 +464,7 @@ format: float`
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
@@ -475,7 +479,7 @@ format: double`
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
@@ -490,7 +494,7 @@ format: int32`
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
@@ -505,7 +509,7 @@ format: int64`
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
@@ -520,7 +524,7 @@ example: true`
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
@@ -534,7 +538,7 @@ func TestRenderExample_Boolean_WithoutExample(t *testing.T) {
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
@@ -550,7 +554,7 @@ items:
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
@@ -567,7 +571,7 @@ items:
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
@@ -585,7 +589,7 @@ items:
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
@@ -606,7 +610,7 @@ properties:
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
@@ -633,7 +637,7 @@ properties:
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
@@ -659,7 +663,7 @@ allOf:
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
@@ -688,7 +692,7 @@ dependentSchemas:
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
@@ -706,7 +710,7 @@ allOf:
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
@@ -731,7 +735,7 @@ oneOf:
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
@@ -748,7 +752,7 @@ oneOf:
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
@@ -773,7 +777,7 @@ anyOf:
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
@@ -790,7 +794,7 @@ anyOf:
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
@@ -842,7 +846,7 @@ properties:
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
@@ -907,7 +911,7 @@ example:
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
@@ -960,7 +964,7 @@ properties:
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
@@ -1006,7 +1010,7 @@ properties:
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
@@ -1034,7 +1038,7 @@ properties:
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
@@ -1059,7 +1063,7 @@ properties:
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
@@ -1090,7 +1094,7 @@ properties:
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DisableRequiredCheck()
 	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
@@ -1115,7 +1119,7 @@ properties:
 
 	compiled := getSchema([]byte(testObject))
 	schema := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(compiled, "pb33f", schema, visited, 0)
 	rendered, _ := json.Marshal(schema["pb33f"])
@@ -1131,7 +1135,7 @@ properties:
 
 	compiled := getSchema([]byte(testObject))
 	schema := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(compiled, "pb33f", schema, visited, 0)
 	rendered, _ := json.Marshal(schema["pb33f"])
@@ -1147,7 +1151,7 @@ properties:
 
 	compiled := getSchema([]byte(testObject))
 	schema := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(compiled, "pb33f", schema, visited, 0)
 	rendered, _ := json.Marshal(schema["pb33f"])
@@ -1163,7 +1167,7 @@ properties:
 
 	compiled := getSchema([]byte(testObject))
 	schema := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(compiled, "pb33f", schema, visited, 0)
 	rendered, _ := json.Marshal(schema["pb33f"])
@@ -1187,7 +1191,7 @@ properties:
 
 	compiled := getSchema([]byte(testObject))
 	schema := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(compiled, "pb33f", schema, visited, 0)
 	rendered, _ := json.Marshal(schema["pb33f"])
@@ -1213,7 +1217,7 @@ properties:
 
 	compiled := getSchema([]byte(testObject))
 	schema := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(compiled, "pb33f", schema, visited, 0)
 	rendered, _ := json.Marshal(schema["pb33f"])
@@ -1243,7 +1247,7 @@ properties:
 
 	compiled := getSchema([]byte(testObject))
 	schema := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(compiled, "pb33f", schema, visited, 0)
 	rendered, _ := json.Marshal(schema["pb33f"])
@@ -1276,7 +1280,7 @@ properties:
 
 	compiled := getSchema([]byte(testObject))
 	schema := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(compiled, "pb33f", schema, visited, 0)
 	rendered, _ := json.Marshal(schema["pb33f"])
@@ -1302,7 +1306,7 @@ properties:
 
 	compiled := getSchema([]byte(testObject))
 	schema := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(compiled, "pb33f", schema, visited, 0)
 	assert.NotEmpty(t, schema["pb33f"].(map[string]interface{})["bigint"])
@@ -1350,7 +1354,7 @@ schemas:
 	}
 	schemaProxy := highbase.NewSchemaProxy(&lowNode)
 	schema := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(schemaProxy.Schema(), "pb33f", schema, visited, 0)
 	rendered, _ := json.Marshal(schema["pb33f"])
@@ -1394,7 +1398,7 @@ schemas:
 	}
 	schemaProxy := highbase.NewSchemaProxy(&lowNode)
 	schema := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(schemaProxy.Schema(), "pb33f", schema, visited, 0)
 	assert.NotEmpty(t, schema["pb33f"].(map[string]interface{})["address"])
@@ -1451,12 +1455,275 @@ schemas:
 	}
 	schemaProxy := highbase.NewSchemaProxy(&lowNode)
 	schema := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(schemaProxy.Schema(), "pb33f", schema, visited, 0)
 	rendered, _ := json.Marshal(schema["pb33f"])
 	assert.Equal(t, `{"name":"John Doe","pets":[{"name":"Bob the cat","offspring":[]}]}`, string(rendered))
 }
+
+func TestRenderSchema_Ref_AllOfCircularArray(t *testing.T) {
+	yml := `
+schemas:
+  human:
+    type: object
+    properties:
+      name:
+        type: string
+        example: John Doe
+      pets:  
+        type: array
+        items: 
+          allOf:
+            - $ref: "#/schemas/animal"
+  animal:
+    type: object
+    properties:
+      name:
+        type: string
+        example: Bob the cat
+      offspring:
+        type: array
+        items:
+          $ref: "#/schemas/animal"
+    required:
+      - name
+      - offspring
+`
+
+	var idxNode yaml.Node
+	mErr := yaml.Unmarshal([]byte(yml), &idxNode)
+	assert.NoError(t, mErr)
+	idx := index.NewSpecIndex(&idxNode)
+
+	var components v3.Components
+	err := low.BuildModel(idxNode.Content[0], &components)
+	assert.NoError(t, err)
+
+	err = components.Build(context.Background(), idxNode.Content[0], idx)
+	assert.NoError(t, err)
+
+  lowRestaurant := components.FindSchema("human")
+	lowNode := low.NodeReference[*lowbase.SchemaProxy]{
+		ValueNode: lowRestaurant.ValueNode,
+		Reference: lowRestaurant.Reference,
+		Value: lowRestaurant.Value,
+	}
+	schemaProxy := highbase.NewSchemaProxy(&lowNode)
+	schema := make(map[string]any)
+	visited := createVisitedMap()
+	wr := createSchemaRenderer()
+	wr.DiveIntoSchema(schemaProxy.Schema(), "pb33f", schema, visited, 0)
+	rendered, _ := json.Marshal(schema["pb33f"])
+	assert.Equal(t, `{"name":"John Doe","pets":[{"name":"Bob the cat","offspring":[]}]}`, string(rendered))
+}
+
+func TestRenderSchema_Ref_AllOfCircularArray2(t *testing.T) {
+	yml := `
+schemas:
+  human:
+    type: object
+    properties:
+      name:
+        type: string
+        example: John Doe
+      friends:  
+        type: array
+        items: 
+          allOf:
+            - $ref: "#/schemas/human"
+`
+
+	var idxNode yaml.Node
+	mErr := yaml.Unmarshal([]byte(yml), &idxNode)
+	assert.NoError(t, mErr)
+	idx := index.NewSpecIndex(&idxNode)
+
+	var components v3.Components
+	err := low.BuildModel(idxNode.Content[0], &components)
+	assert.NoError(t, err)
+
+	err = components.Build(context.Background(), idxNode.Content[0], idx)
+	assert.NoError(t, err)
+
+  lowRestaurant := components.FindSchema("human")
+	lowNode := low.NodeReference[*lowbase.SchemaProxy]{
+		ValueNode: lowRestaurant.ValueNode,
+		Reference: lowRestaurant.Reference,
+		Value: lowRestaurant.Value,
+	}
+	schemaProxy := highbase.NewSchemaProxy(&lowNode)
+	schema := make(map[string]any)
+	visited := createVisitedMap()
+	wr := createSchemaRenderer()
+	wr.DiveIntoSchema(schemaProxy.Schema(), "pb33f", schema, visited, 0)
+	rendered, _ := json.Marshal(schema["pb33f"])
+	assert.Equal(t, `{"friends":[{"friends":[],"name":"John Doe"}],"name":"John Doe"}`, string(rendered))
+}
+
+func TestRenderSchema_Ref_AnyOfCircularArray(t *testing.T) {
+	yml := `
+schemas:
+  human:
+    type: object
+    properties:
+      name:
+        type: string
+        example: John Doe
+      pets:  
+        type: array
+        items: 
+          anyOf:
+            - $ref: "#/schemas/animal"
+  animal:
+    type: object
+    properties:
+      name:
+        type: string
+        example: Bob the cat
+      offspring:
+        type: array
+        items:
+          $ref: "#/schemas/animal"
+    required:
+      - name
+      - offspring
+`
+
+	var idxNode yaml.Node
+	mErr := yaml.Unmarshal([]byte(yml), &idxNode)
+	assert.NoError(t, mErr)
+	idx := index.NewSpecIndex(&idxNode)
+
+	var components v3.Components
+	err := low.BuildModel(idxNode.Content[0], &components)
+	assert.NoError(t, err)
+
+	err = components.Build(context.Background(), idxNode.Content[0], idx)
+	assert.NoError(t, err)
+
+  lowRestaurant := components.FindSchema("human")
+	lowNode := low.NodeReference[*lowbase.SchemaProxy]{
+		ValueNode: lowRestaurant.ValueNode,
+		Reference: lowRestaurant.Reference,
+		Value: lowRestaurant.Value,
+	}
+	schemaProxy := highbase.NewSchemaProxy(&lowNode)
+	schema := make(map[string]any)
+	visited := createVisitedMap()
+	wr := createSchemaRenderer()
+	wr.DiveIntoSchema(schemaProxy.Schema(), "pb33f", schema, visited, 0)
+	rendered, _ := json.Marshal(schema["pb33f"])
+	assert.Equal(t, `{"name":"John Doe","pets":[{"name":"Bob the cat","offspring":[]}]}`, string(rendered))
+}
+
+func TestRenderSchema_Ref_AnyOfCircularArray2(t *testing.T) {
+	yml := `
+schemas:
+  human:
+    type: object
+    properties:
+      name:
+        type: string
+        example: John Doe
+      friends:  
+        type: array
+        items: 
+          anyOf:
+            - $ref: "#/schemas/human"
+`
+
+	var idxNode yaml.Node
+	mErr := yaml.Unmarshal([]byte(yml), &idxNode)
+	assert.NoError(t, mErr)
+	idx := index.NewSpecIndex(&idxNode)
+
+	var components v3.Components
+	err := low.BuildModel(idxNode.Content[0], &components)
+	assert.NoError(t, err)
+
+	err = components.Build(context.Background(), idxNode.Content[0], idx)
+	assert.NoError(t, err)
+
+  lowRestaurant := components.FindSchema("human")
+	lowNode := low.NodeReference[*lowbase.SchemaProxy]{
+		ValueNode: lowRestaurant.ValueNode,
+		Reference: lowRestaurant.Reference,
+		Value: lowRestaurant.Value,
+	}
+	schemaProxy := highbase.NewSchemaProxy(&lowNode)
+	schema := make(map[string]any)
+	visited := createVisitedMap()
+	wr := createSchemaRenderer()
+	wr.DiveIntoSchema(schemaProxy.Schema(), "pb33f", schema, visited, 0)
+	rendered, _ := json.Marshal(schema["pb33f"])
+	assert.Equal(t, `{"friends":[{"friends":[],"name":"John Doe"}],"name":"John Doe"}`, string(rendered))
+}
+
+func TestRenderSchema_Ref_AnyOfCircularArraySkip(t *testing.T) {
+	yml := `
+schemas:
+  country:
+    type: object
+    properties:
+      president:
+        $ref: "#/schemas/human"
+  human:
+    type: object
+    properties:
+      name:
+        type: string
+        example: John Doe
+      pet:
+        $ref: "#/schemas/pet"
+  pet:
+    type: object
+    properties:
+      name:
+        type: string
+        example: Hilbert the fish
+      bestFriend:
+        anyOf:
+          - $ref: "#/schemas/pet"
+          - $ref: "#/schemas/toy"
+  toy:
+    type: object
+    properties:
+      model:
+        type: string
+        example: ball
+      age: 
+        type: number
+        example: 1
+`
+
+	var idxNode yaml.Node
+	mErr := yaml.Unmarshal([]byte(yml), &idxNode)
+	assert.NoError(t, mErr)
+	idx := index.NewSpecIndex(&idxNode)
+
+	var components v3.Components
+	err := low.BuildModel(idxNode.Content[0], &components)
+	assert.NoError(t, err)
+
+	err = components.Build(context.Background(), idxNode.Content[0], idx)
+	assert.NoError(t, err)
+
+  lowRestaurant := components.FindSchema("human")
+	lowNode := low.NodeReference[*lowbase.SchemaProxy]{
+		ValueNode: lowRestaurant.ValueNode,
+		Reference: lowRestaurant.Reference,
+		Value: lowRestaurant.Value,
+	}
+	schemaProxy := highbase.NewSchemaProxy(&lowNode)
+	schema := make(map[string]any)
+	visited := createVisitedMap()
+	wr := createSchemaRenderer()
+	wr.DiveIntoSchema(schemaProxy.Schema(), "pb33f", schema, visited, 0)
+	rendered, _ := json.Marshal(schema["pb33f"])
+	assert.Equal(t, `{"name":"John Doe","pet":{"bestFriend":{"age":1,"model":"ball"},"name":"Hilbert the fish"}}`, string(rendered))
+}
+
 
 func TestCreateRendererUsingDefaultDictionary(t *testing.T) {
 	assert.NotNil(t, CreateRendererUsingDefaultDictionary())
@@ -1525,7 +1792,7 @@ func TestWordRenderer_RandomWordMinMaxZero(t *testing.T) {
 func TestRenderSchema_NestedDeep(t *testing.T) {
 	deepNest := createNestedStructure()
 	journeyMap := make(map[string]any)
-	visited := make(map[string]bool)
+	visited := createVisitedMap()
 	wr := createSchemaRenderer()
 	wr.DiveIntoSchema(deepNest.Schema(), "pb33f", journeyMap, visited, 0)
 

--- a/renderer/schema_renderer_test.go
+++ b/renderer/schema_renderer_test.go
@@ -73,8 +73,9 @@ example: dog`
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
+	visited := make(map[string]bool)
 	wr := createSchemaRenderer()
-	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, 0)
+	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
 	assert.Equal(t, journeyMap["pb33f"], "dog")
 }
@@ -85,8 +86,9 @@ func TestRenderExample_StringWithNoExample(t *testing.T) {
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
+	visited := make(map[string]bool)
 	wr := createSchemaRenderer()
-	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, 0)
+	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
 	assert.NotNil(t, journeyMap["pb33f"])
 	assert.GreaterOrEqual(t, len(journeyMap["pb33f"].(string)), 3)
@@ -100,8 +102,9 @@ format: date-time`
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
+	visited := make(map[string]bool)
 	wr := createSchemaRenderer()
-	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, 0)
+	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
 	now := time.Now()
 	assert.NotNil(t, journeyMap["pb33f"])
@@ -115,8 +118,9 @@ pattern: "^[a-z]{5,10}@[a-z]{5,10}\\.(com|net|org)$"` // an email address
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
+	visited := make(map[string]bool)
 	wr := createSchemaRenderer()
-	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, 0)
+	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
 	assert.NotNil(t, journeyMap["pb33f"])
 
@@ -133,8 +137,9 @@ pattern: "^\\([0-9]{3}\\)-[0-9]{3}-[0-9]{4}$"` // a phone number
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
+	visited := make(map[string]bool)
 	wr := createSchemaRenderer()
-	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, 0)
+	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
 	assert.NotNil(t, journeyMap["pb33f"])
 
@@ -150,8 +155,9 @@ format: date`
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
+	visited := make(map[string]bool)
 	wr := createSchemaRenderer()
-	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, 0)
+	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
 	now := time.Now().Format("2006-01-02")
 
@@ -166,8 +172,9 @@ format: time`
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
+	visited := make(map[string]bool)
 	wr := createSchemaRenderer()
-	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, 0)
+	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
 	now := time.Now().Format("15:04:05")
 
@@ -182,8 +189,9 @@ format: email`
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
+	visited := make(map[string]bool)
 	wr := createSchemaRenderer()
-	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, 0)
+	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
 	assert.NotNil(t, journeyMap["pb33f"])
 	assert.True(t, strings.Contains(journeyMap["pb33f"].(string), "@"))
@@ -196,8 +204,9 @@ format: hostname`
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
+	visited := make(map[string]bool)
 	wr := createSchemaRenderer()
-	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, 0)
+	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
 	assert.NotNil(t, journeyMap["pb33f"])
 	assert.True(t, strings.Contains(journeyMap["pb33f"].(string), ".com"))
@@ -209,9 +218,10 @@ format: ipv4`
 
 	compiled := getSchema([]byte(testObject))
 
+	visited := make(map[string]bool)
 	journeyMap := make(map[string]any)
 	wr := createSchemaRenderer()
-	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, 0)
+	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
 	assert.NotNil(t, journeyMap["pb33f"])
 	segs := strings.Split(journeyMap["pb33f"].(string), ".")
@@ -225,8 +235,9 @@ format: ipv6`
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
+	visited := make(map[string]bool)
 	wr := createSchemaRenderer()
-	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, 0)
+	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
 	assert.NotNil(t, journeyMap["pb33f"])
 	segs := strings.Split(journeyMap["pb33f"].(string), ":")
@@ -240,8 +251,9 @@ format: uri`
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
+	visited := make(map[string]bool)
 	wr := createSchemaRenderer()
-	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, 0)
+	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
 	assert.NotNil(t, journeyMap["pb33f"])
 	uri, e := url.Parse(journeyMap["pb33f"].(string))
@@ -257,8 +269,9 @@ format: uuid`
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
+	visited := make(map[string]bool)
 	wr := createSchemaRenderer()
-	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, 0)
+	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
 	assert.NotNil(t, journeyMap["pb33f"])
 	segs := strings.Split(journeyMap["pb33f"].(string), "-")
@@ -272,8 +285,9 @@ format: byte`
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
+	visited := make(map[string]bool)
 	wr := createSchemaRenderer()
-	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, 0)
+	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
 	assert.NotNil(t, journeyMap["pb33f"])
 	assert.NotEmpty(t, journeyMap["pb33f"].(string))
@@ -286,8 +300,9 @@ format: password`
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
+	visited := make(map[string]bool)
 	wr := createSchemaRenderer()
-	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, 0)
+	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
 	assert.NotNil(t, journeyMap["pb33f"])
 	assert.NotEmpty(t, journeyMap["pb33f"].(string))
@@ -300,8 +315,9 @@ format: uri-reference`
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
+	visited := make(map[string]bool)
 	wr := createSchemaRenderer()
-	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, 0)
+	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
 	assert.NotNil(t, journeyMap["pb33f"])
 	segs := strings.Split(journeyMap["pb33f"].(string), "/")
@@ -315,8 +331,9 @@ format: binary`
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
+	visited := make(map[string]bool)
 	wr := createSchemaRenderer()
-	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, 0)
+	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
 	encoded := journeyMap["pb33f"].(string)
 	decodedString, err := base64.StdEncoding.DecodeString(encoded)
@@ -332,8 +349,9 @@ example: 3.14`
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
+	visited := make(map[string]bool)
 	wr := createSchemaRenderer()
-	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, 0)
+	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
 	assert.NotNil(t, journeyMap["pb33f"])
 	assert.Equal(t, 3.14, journeyMap["pb33f"])
@@ -346,8 +364,9 @@ minLength: 10`
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
+	visited := make(map[string]bool)
 	wr := createSchemaRenderer()
-	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, 0)
+	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
 	assert.NotNil(t, journeyMap["pb33f"])
 	assert.GreaterOrEqual(t, len(journeyMap["pb33f"].(string)), 10)
@@ -360,8 +379,9 @@ maxLength: 10`
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
+	visited := make(map[string]bool)
 	wr := createSchemaRenderer()
-	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, 0)
+	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
 	assert.NotNil(t, journeyMap["pb33f"])
 	assert.LessOrEqual(t, len(journeyMap["pb33f"].(string)), 10)
@@ -375,8 +395,9 @@ minLength: 3`
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
+	visited := make(map[string]bool)
 	wr := createSchemaRenderer()
-	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, 0)
+	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
 	assert.NotNil(t, journeyMap["pb33f"])
 	assert.LessOrEqual(t, len(journeyMap["pb33f"].(string)), 8)
@@ -389,8 +410,9 @@ func TestRenderExample_NumberNoExample_Default(t *testing.T) {
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
+	visited := make(map[string]bool)
 	wr := createSchemaRenderer()
-	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, 0)
+	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
 	assert.NotNil(t, journeyMap["pb33f"])
 	assert.Greater(t, journeyMap["pb33f"], int64(0))
@@ -404,8 +426,9 @@ minimum: 60`
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
+	visited := make(map[string]bool)
 	wr := createSchemaRenderer()
-	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, 0)
+	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
 	assert.NotNil(t, journeyMap["pb33f"])
 	assert.GreaterOrEqual(t, journeyMap["pb33f"], int64(60))
@@ -419,8 +442,9 @@ maximum: 4`
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
+	visited := make(map[string]bool)
 	wr := createSchemaRenderer()
-	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, 0)
+	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
 	assert.NotNil(t, journeyMap["pb33f"])
 	assert.GreaterOrEqual(t, journeyMap["pb33f"], int64(1))
@@ -434,8 +458,9 @@ format: float`
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
+	visited := make(map[string]bool)
 	wr := createSchemaRenderer()
-	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, 0)
+	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
 	assert.NotNil(t, journeyMap["pb33f"])
 	assert.Greater(t, journeyMap["pb33f"], float32(0))
@@ -448,8 +473,9 @@ format: double`
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
+	visited := make(map[string]bool)
 	wr := createSchemaRenderer()
-	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, 0)
+	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
 	assert.NotNil(t, journeyMap["pb33f"])
 	assert.Greater(t, journeyMap["pb33f"], float64(0))
@@ -462,8 +488,9 @@ format: int32`
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
+	visited := make(map[string]bool)
 	wr := createSchemaRenderer()
-	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, 0)
+	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
 	assert.NotNil(t, journeyMap["pb33f"])
 	assert.Greater(t, journeyMap["pb33f"], 0)
@@ -476,8 +503,9 @@ format: int64`
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
+	visited := make(map[string]bool)
 	wr := createSchemaRenderer()
-	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, 0)
+	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
 	assert.NotNil(t, journeyMap["pb33f"])
 	assert.Greater(t, journeyMap["pb33f"], int64(0))
@@ -490,8 +518,9 @@ example: true`
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
+	visited := make(map[string]bool)
 	wr := createSchemaRenderer()
-	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, 0)
+	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
 	assert.NotNil(t, journeyMap["pb33f"])
 	assert.True(t, journeyMap["pb33f"].(bool))
@@ -503,8 +532,9 @@ func TestRenderExample_Boolean_WithoutExample(t *testing.T) {
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
+	visited := make(map[string]bool)
 	wr := createSchemaRenderer()
-	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, 0)
+	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
 	assert.NotNil(t, journeyMap["pb33f"])
 	assert.True(t, journeyMap["pb33f"].(bool))
@@ -518,8 +548,9 @@ items:
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
+	visited := make(map[string]bool)
 	wr := createSchemaRenderer()
-	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, 0)
+	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
 	assert.NotNil(t, journeyMap["pb33f"])
 	assert.Len(t, journeyMap["pb33f"], 1)
@@ -534,8 +565,9 @@ items:
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
+	visited := make(map[string]bool)
 	wr := createSchemaRenderer()
-	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, 0)
+	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
 	assert.NotNil(t, journeyMap["pb33f"])
 	assert.Len(t, journeyMap["pb33f"], 1)
@@ -551,8 +583,9 @@ items:
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
+	visited := make(map[string]bool)
 	wr := createSchemaRenderer()
-	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, 0)
+	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
 	assert.NotNil(t, journeyMap["pb33f"])
 	assert.Len(t, journeyMap["pb33f"], 3)
@@ -571,8 +604,9 @@ properties:
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
+	visited := make(map[string]bool)
 	wr := createSchemaRenderer()
-	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, 0)
+	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
 	assert.NotNil(t, journeyMap["pb33f"])
 	assert.Len(t, journeyMap["pb33f"], 2)
@@ -597,8 +631,9 @@ properties:
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
+	visited := make(map[string]bool)
 	wr := createSchemaRenderer()
-	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, 0)
+	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
 	assert.NotNil(t, journeyMap["pb33f"])
 	assert.Len(t, journeyMap["pb33f"], 2)
@@ -622,8 +657,9 @@ allOf:
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
+	visited := make(map[string]bool)
 	wr := createSchemaRenderer()
-	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, 0)
+	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
 	assert.NotNil(t, journeyMap["pb33f"])
 	assert.Len(t, journeyMap["pb33f"], 2)
@@ -650,8 +686,9 @@ dependentSchemas:
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
+	visited := make(map[string]bool)
 	wr := createSchemaRenderer()
-	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, 0)
+	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
 	assert.NotNil(t, journeyMap["pb33f"])
 	assert.Len(t, journeyMap["pb33f"], 1)
@@ -667,8 +704,9 @@ allOf:
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
+	visited := make(map[string]bool)
 	wr := createSchemaRenderer()
-	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, 0)
+	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
 	assert.NotNil(t, journeyMap["pb33f"])
 	assert.Len(t, journeyMap["pb33f"], 1)
@@ -691,8 +729,9 @@ oneOf:
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
+	visited := make(map[string]bool)
 	wr := createSchemaRenderer()
-	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, 0)
+	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
 	assert.NotNil(t, journeyMap["pb33f"])
 	assert.Len(t, journeyMap["pb33f"], 1)
@@ -707,8 +746,9 @@ oneOf:
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
+	visited := make(map[string]bool)
 	wr := createSchemaRenderer()
-	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, 0)
+	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
 	assert.NotNil(t, journeyMap["pb33f"])
 	assert.Len(t, journeyMap["pb33f"], 1)
@@ -731,8 +771,9 @@ anyOf:
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
+	visited := make(map[string]bool)
 	wr := createSchemaRenderer()
-	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, 0)
+	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
 	assert.NotNil(t, journeyMap["pb33f"])
 	assert.Len(t, journeyMap["pb33f"], 1)
@@ -747,8 +788,9 @@ anyOf:
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
+	visited := make(map[string]bool)
 	wr := createSchemaRenderer()
-	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, 0)
+	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
 	assert.NotNil(t, journeyMap["pb33f"])
 	assert.Len(t, journeyMap["pb33f"], 1)
@@ -798,8 +840,9 @@ properties:
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
+	visited := make(map[string]bool)
 	wr := createSchemaRenderer()
-	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, 0)
+	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
 	assert.NotNil(t, journeyMap["pb33f"])
 	assert.Equal(t, journeyMap["pb33f"].(map[string]interface{})["id"].(string), "d1404c5c-69bd-4cd2-a4cf-b47c79a30112")
@@ -862,8 +905,9 @@ example:
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
+	visited := make(map[string]bool)
 	wr := createSchemaRenderer()
-	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, 0)
+	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
 	assert.NotNil(t, journeyMap["pb33f"])
 	assert.Equal(t, journeyMap["pb33f"].(map[string]interface{})["id"].(string), "not-a-uuid")
@@ -914,8 +958,9 @@ properties:
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
+	visited := make(map[string]bool)
 	wr := createSchemaRenderer()
-	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, 0)
+	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
 	assert.NotNil(t, journeyMap["pb33f"])
 	assert.NotEmpty(t, journeyMap["pb33f"].(map[string]interface{})["id"].(string))
@@ -959,8 +1004,9 @@ properties:
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
+	visited := make(map[string]bool)
 	wr := createSchemaRenderer()
-	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, 0)
+	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
 	assert.NotNil(t, journeyMap["pb33f"])
 	burger := journeyMap["pb33f"].(map[string]interface{})["burger"].(map[string]interface{})
@@ -986,8 +1032,9 @@ properties:
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
+	visited := make(map[string]bool)
 	wr := createSchemaRenderer()
-	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, 0)
+	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
 	assert.NotNil(t, journeyMap["pb33f"])
 	drink := journeyMap["pb33f"].(map[string]interface{})["drink"].(string)
@@ -1010,8 +1057,9 @@ properties:
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
+	visited := make(map[string]bool)
 	wr := createSchemaRenderer()
-	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, 0)
+	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
 	assert.NotNil(t, journeyMap["pb33f"])
 	drink := journeyMap["pb33f"].(map[string]interface{})["drink"].(string)
@@ -1040,9 +1088,10 @@ properties:
 	compiled := getSchema([]byte(testObject))
 
 	journeyMap := make(map[string]any)
+	visited := make(map[string]bool)
 	wr := createSchemaRenderer()
 	wr.DisableRequiredCheck()
-	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, 0)
+	wr.DiveIntoSchema(compiled, "pb33f", journeyMap, visited, 0)
 
 	assert.NotNil(t, journeyMap["pb33f"])
 	drink := journeyMap["pb33f"].(map[string]interface{})["drink"].(string)
@@ -1064,8 +1113,9 @@ properties:
 
 	compiled := getSchema([]byte(testObject))
 	schema := make(map[string]any)
+	visited := make(map[string]bool)
 	wr := createSchemaRenderer()
-	wr.DiveIntoSchema(compiled, "pb33f", schema, 0)
+	wr.DiveIntoSchema(compiled, "pb33f", schema, visited, 0)
 	rendered, _ := json.Marshal(schema["pb33f"])
 	assert.Equal(t, `{"name":"pb33f"}`, string(rendered))
 }
@@ -1079,8 +1129,9 @@ properties:
 
 	compiled := getSchema([]byte(testObject))
 	schema := make(map[string]any)
+	visited := make(map[string]bool)
 	wr := createSchemaRenderer()
-	wr.DiveIntoSchema(compiled, "pb33f", schema, 0)
+	wr.DiveIntoSchema(compiled, "pb33f", schema, visited, 0)
 	rendered, _ := json.Marshal(schema["pb33f"])
 	assert.Equal(t, `{"name":"pb33f"}`, string(rendered))
 }
@@ -1094,8 +1145,9 @@ properties:
 
 	compiled := getSchema([]byte(testObject))
 	schema := make(map[string]any)
+	visited := make(map[string]bool)
 	wr := createSchemaRenderer()
-	wr.DiveIntoSchema(compiled, "pb33f", schema, 0)
+	wr.DiveIntoSchema(compiled, "pb33f", schema, visited, 0)
 	rendered, _ := json.Marshal(schema["pb33f"])
 	assert.Equal(t, `{"count":9934.223}`, string(rendered))
 }
@@ -1109,8 +1161,9 @@ properties:
 
 	compiled := getSchema([]byte(testObject))
 	schema := make(map[string]any)
+	visited := make(map[string]bool)
 	wr := createSchemaRenderer()
-	wr.DiveIntoSchema(compiled, "pb33f", schema, 0)
+	wr.DiveIntoSchema(compiled, "pb33f", schema, visited, 0)
 	rendered, _ := json.Marshal(schema["pb33f"])
 	assert.Equal(t, `{"count":9934}`, string(rendered))
 }
@@ -1132,8 +1185,9 @@ properties:
 
 	compiled := getSchema([]byte(testObject))
 	schema := make(map[string]any)
+	visited := make(map[string]bool)
 	wr := createSchemaRenderer()
-	wr.DiveIntoSchema(compiled, "pb33f", schema, 0)
+	wr.DiveIntoSchema(compiled, "pb33f", schema, visited, 0)
 	rendered, _ := json.Marshal(schema["pb33f"])
 	assert.Equal(t, `{"args":{"arrParam":"test,test2","arrParamExploded":["1"]}}`, string(rendered))
 }
@@ -1157,8 +1211,9 @@ properties:
 
 	compiled := getSchema([]byte(testObject))
 	schema := make(map[string]any)
+	visited := make(map[string]bool)
 	wr := createSchemaRenderer()
-	wr.DiveIntoSchema(compiled, "pb33f", schema, 0)
+	wr.DiveIntoSchema(compiled, "pb33f", schema, visited, 0)
 	rendered, _ := json.Marshal(schema["pb33f"])
 	assert.Equal(t, `{"args":{"arrParam":"test,test2","arrParamExploded":["1","2"]}}`, string(rendered))
 }
@@ -1186,8 +1241,9 @@ properties:
 
 	compiled := getSchema([]byte(testObject))
 	schema := make(map[string]any)
+	visited := make(map[string]bool)
 	wr := createSchemaRenderer()
-	wr.DiveIntoSchema(compiled, "pb33f", schema, 0)
+	wr.DiveIntoSchema(compiled, "pb33f", schema, visited, 0)
 	rendered, _ := json.Marshal(schema["pb33f"])
 	assert.Equal(t, `{"bigint":8821239038968084,"bigintStr":"9223372036854775808","decimal":3.141592653589793,"decimalStr":"3.14159265358979344719667586"}`, string(rendered))
 }
@@ -1218,8 +1274,9 @@ properties:
 
 	compiled := getSchema([]byte(testObject))
 	schema := make(map[string]any)
+	visited := make(map[string]bool)
 	wr := createSchemaRenderer()
-	wr.DiveIntoSchema(compiled, "pb33f", schema, 0)
+	wr.DiveIntoSchema(compiled, "pb33f", schema, visited, 0)
 	rendered, _ := json.Marshal(schema["pb33f"])
 	assert.Equal(t, `{"bigint":8821239038968084,"bigintStr":"9223372036854775808","decimal":3.141592653589793,"decimalStr":"3.14159265358979344719667586"}`, string(rendered))
 }
@@ -1243,8 +1300,9 @@ properties:
 
 	compiled := getSchema([]byte(testObject))
 	schema := make(map[string]any)
+	visited := make(map[string]bool)
 	wr := createSchemaRenderer()
-	wr.DiveIntoSchema(compiled, "pb33f", schema, 0)
+	wr.DiveIntoSchema(compiled, "pb33f", schema, visited, 0)
 	assert.NotEmpty(t, schema["pb33f"].(map[string]interface{})["bigint"])
 	assert.NotEmpty(t, schema["pb33f"].(map[string]interface{})["bigintStr"])
 	assert.NotEmpty(t, schema["pb33f"].(map[string]interface{})["decimal"])
@@ -1318,8 +1376,9 @@ func TestWordRenderer_RandomWordMinMaxZero(t *testing.T) {
 func TestRenderSchema_NestedDeep(t *testing.T) {
 	deepNest := createNestedStructure()
 	journeyMap := make(map[string]any)
+	visited := make(map[string]bool)
 	wr := createSchemaRenderer()
-	wr.DiveIntoSchema(deepNest.Schema(), "pb33f", journeyMap, 0)
+	wr.DiveIntoSchema(deepNest.Schema(), "pb33f", journeyMap, visited, 0)
 
 	assert.NotNil(t, journeyMap["pb33f"])
 	journeyLevel := 0


### PR DESCRIPTION
This PR enhances the rendering of schemas containing circular references.
Previously, circular references caused excessively deep nesting, only terminating when the maximum depth limit was hit. This update introduces more intelligent handling to avoid that behavior.

## Example 1

Assume we are given this schema `S`
```
schemas:
  human:
    type: object
    properties:
      name:
        type: string
        example: John Doe
      pets:  
        type: array
        items: 
          $ref: "#/schemas/animal"
  animal:
    type: object
    properties:
      name:
        type: string
        example: Bob the cat
      offspring:
        type: array
        items:
          $ref: "#/schemas/animal"
    required:
      - name
      - offspring
```

Currently, it renders an example based on `S` as follows
```
{
  "name":"John Doe",
  "pets":[{
     "name":"Bob the cat","
     offspring":[{
       "name":"Bob the cat",
       "offspring":[{
         "name":"Bob the cat",
          "offspring":[{"name":"Bob the cat","offspring":[{"name":"Bob the cat","offspring":[{"name":"Bob the cat","offspring":[{"name":"Bob the cat","offspring":[{"name":"Bob the cat","offspring":[{"name":"Bob the cat","offspring":[{"name":"Bob the cat","offspring":[{"name":"Bob the cat","offspring":[{"name":"Bob the cat","offspring":[{"name":"Bob the cat","offspring":[{"name":"Bob the cat","offspring":[{"name":"Bob the cat","offspring":[{"name":"Bob the cat","offspring":[{"name":"Bob the cat","offspring":[{"name":"Bob the cat","offspring":[{"name":"Bob the cat","offspring":[{"name":"Bob the cat","offspring":[{"name":"Bob the cat","offspring":[{"name":"Bob the cat","offspring":[{"name":"Bob the cat","offspring":[{"name":"Bob the cat","offspring":[{"name":"Bob the cat","offspring":[{"name":"Bob the cat","offspring":[{"name":"Bob the cat","offspring":[{"name":"Bob the cat","offspring":[{"name":"Bob the cat","offspring":[{"name":"Bob the cat","offspring":[{"name":"Bob the cat","offspring":[{"name":"Bob the cat","offspring":[{"name":"Bob the cat","offspring":[{"name":"Bob the cat","offspring":[{"name":"Bob the cat","offspring":[{"name":"Bob the cat","offspring":[{"name":"Bob the cat","offspring":[{"name":"Bob the cat","offspring":[{"name":"Bob the cat","offspring":[{"name":"Bob the cat","offspring":[{"name":"Bob the cat","offspring":[{"name":"Bob the cat","offspring":[{"name":"Bob the cat","offspring":[{"name":"Bob the cat","offspring":[{"name":"Bob the cat","offspring":[{"name":"Bob the cat","offspring":[{"name":"Bob the cat","offspring":[{"name":"Bob the cat","offspring":[{"name":"Bob the cat","offspring":[{"name":"Bob the cat","offspring":"to deep to continue rendering..."}]}]}]}]}]}]}]}]}]}]}]}]}]}]}]}]}]}]}]}]}]}]}]}]}]}]}]}]}]}]}]}]}]}]}]}]}]}]}]}]}]}]}]}]}]}]}]}]}]}]}
```

This PR will render an example based on schema `S` as follows
```
{
  "name":"John Doe",
  "pets":[{
    "name":"Bob the cat",
    "offspring":[]
  }]
}
```

## Example 2

Assume we are given this schema `S`
```
schemas:
  country:
    type: object
    properties:
      president:
        $ref: "#/schemas/human"
  human:
    type: object
    properties:
      name:
        type: string
        example: John Doe
      pet:
        $ref: "#/schemas/pet"
  pet:
    type: object
    properties:
      name:
        type: string
        example: Hilbert the fish
      bestFriend:
        anyOf:
          - $ref: "#/schemas/pet"
          - $ref: "#/schemas/toy"
  toy:
    type: object
    properties:
      model:
        type: string
        example: ball
      age: 
        type: number
        example: 1
```
Currently, it renders an example based on `S` as a deeply nested object similar to Example 1 due to the circular dependency of `pet.bestFriend -> pet`.

This PR will render an example based on schema `S` as follows
```
{"name":"John Doe","pet":{"bestFriend":{"age":1,"model":"ball"},"name":"Hilbert the fish"}}
```
Note how the `bestFriend` property skips the `$ref: "#/schemas/pet"` reference since it detects a cycle and uses the `$ref: "#/schemas/toy"` reference instead.


## TO-DO

- [x] Add more tests