### PR TITLE
v0.21.12

### DIFF
--- a/datamodel/low/extraction_functions.go
+++ b/datamodel/low/extraction_functions.go
@@ -95,9 +95,15 @@ func LocateRefNodeWithContext(ctx context.Context, root *yaml.Node, idx *index.S
 					if !IsCircular(found[rv].Node, idx) {
 						return LocateRefNodeWithContext(ctx, found[rv].Node, idx)
 					} else {
+
+						crr := GetCircularReferenceResult(found[rv].Node, idx)
+						jp := ""
+						if crr != nil {
+							jp = crr.GenerateJourneyPath()
+						}
 						return found[rv].Node, idx, fmt.Errorf("circular reference '%s' found during lookup at line "+
 							"%d, column %d, It cannot be resolved",
-							GetCircularReferenceResult(found[rv].Node, idx).GenerateJourneyPath(),
+							jp,
 							found[rv].Node.Line,
 							found[rv].Node.Column), ctx
 					}

--- a/what-changed/model/schema.go
+++ b/what-changed/model/schema.go
@@ -398,7 +398,7 @@ func CompareSchemas(l, r *base.SchemaProxy) *SchemaChanges {
 			rHash := r.Schema().Hash()
 			if lHash != rHash {
 				CreateChange(&changes, Modified, v3.RefLabel,
-					l.GetValueNode(), r.GetValueNode().Content[1], true, l, r.GetReference())
+					l.GetValueNode(), r.GetValueNode().Content[1], false, l, r.GetReference())
 				sc.PropertyChanges = NewPropertyChanges(changes)
 				return sc // we're done here
 			}
@@ -412,7 +412,7 @@ func CompareSchemas(l, r *base.SchemaProxy) *SchemaChanges {
 			rHash := r.Schema().Hash()
 			if lHash != rHash {
 				CreateChange(&changes, Modified, v3.RefLabel,
-					l.GetValueNode().Content[1], r.GetValueNode(), true, l.GetReference(), r)
+					l.GetValueNode().Content[1], r.GetValueNode(), false, l.GetReference(), r)
 				sc.PropertyChanges = NewPropertyChanges(changes)
 				return sc // done, nothing else to do.
 			}
@@ -631,22 +631,22 @@ func buildProperty(lProps, rProps []string, lEntities, rEntities map[string]*bas
 
 	// stuff added
 	if len(rProps) > len(lProps) {
-		for w := range rProps {
-			if lEntities[rProps[w]] != nil {
+		for _, propName := range rProps {
+			if lEntities[propName] != nil {
 				wg.Add(1)
-				go checkProperty(rProps[w], lEntities[rProps[w]], rEntities[rProps[w]])
+				go checkProperty(propName, lEntities[propName], rEntities[propName])
 			} else {
 				CreateChange(changes, ObjectAdded, v3.PropertiesLabel,
-					nil, rKeyNodes[rProps[w]], false, nil, rEntities[rProps[w]])
+					nil, rKeyNodes[propName], false, nil, rEntities[propName])
 			}
 		}
-		for w := range lProps {
-			if rEntities[lProps[w]] != nil {
+		for _, propName := range lProps {
+			if rEntities[propName] != nil {
 				wg.Add(1)
-				go checkProperty(lProps[w], lEntities[lProps[w]], rEntities[rProps[w]])
+				go checkProperty(propName, lEntities[propName], rEntities[propName])
 			} else {
 				CreateChange(changes, ObjectRemoved, v3.PropertiesLabel,
-					nil, lKeyNodes[lProps[w]], true, lEntities[lProps[w]], nil)
+					nil, lKeyNodes[propName], true, lEntities[propName], nil)
 			}
 		}
 	}


### PR DESCRIPTION
Updated the what-changed module to stop a breaking change when a reference and an inline schema are swapped out. Reported by @LasneF 

Also fixes https://github.com/pb33f/openapi-changes/issues/203 and confirms https://github.com/pb33f/openapi-changes/issues/197 is fixed.