### PR TITLE
Fix Bundler Compose Mode Breaking with Non Filename Dots

### DIFF
--- a/bundler/composer_functions.go
+++ b/bundler/composer_functions.go
@@ -160,7 +160,7 @@ func renameRef(idx *index.SpecIndex, def string, processedNodes *orderedmap.Map[
 		if len(defSplit) != 2 {
 			return def
 		}
-		ptr := defSplit[1] // e.g. components/schemas/Foo
+		ptr := defSplit[1]
 		segs := strings.Split(ptr, "/")
 		if len(segs) < 2 {
 			return def

--- a/bundler/composer_functions_test.go
+++ b/bundler/composer_functions_test.go
@@ -172,3 +172,10 @@ func TestRenameRef_RootFileImport(t *testing.T) {
 
 	assert.Equal(t, "#/components/schemas/Pet", got)
 }
+
+// A JSON-pointer that has only one segment (e.g. "#/Foo") must be returned
+// unchanged
+func TestRenameRef_ShortPointerIsReturnedUnchanged(t *testing.T) {
+	got := renameRef(nil, "#/Foo", orderedmap.New[string, *processRef]())
+	assert.Equal(t, "#/Foo", got)
+}

--- a/bundler/composer_functions_test.go
+++ b/bundler/composer_functions_test.go
@@ -98,8 +98,6 @@ func TestProcessRef_UnknownLocation_ThreeStep(t *testing.T) {
 	assert.Len(t, config.inlineRequired, 1)
 }
 
-// ---- RenameRef Tests ----
-
 // A component key that contains a dot (“asdf.zxcv”) must *not* be shortened to
 // “asdf” when we re-wire references.
 func TestRenameRef_KeepsDotInComponentName(t *testing.T) {


### PR DESCRIPTION
Fixes #421 

Refs with dots were failing. Fixes that behavior, while preserving the ability to actually strip the filename