### PR TITLE
Check required field on added parameters

### DIFF
--- a/what-changed/model/operation.go
+++ b/what-changed/model/operation.go
@@ -247,7 +247,7 @@ func CompareOperations(l, r any) *OperationChanges {
 			for n := range rv {
 				if _, ok := lv[n]; !ok {
 					CreateChange(&changes, ObjectAdded, v3.ParametersLabel,
-						nil, rv[n].Name.ValueNode, true, nil,
+						nil, rv[n].Name.ValueNode, rv[n].Required.Value, nil,
 						rv[n].Name.Value)
 				}
 			}
@@ -350,7 +350,7 @@ func CompareOperations(l, r any) *OperationChanges {
 			for n := range rv {
 				if _, ok := lv[n]; !ok {
 					CreateChange(&changes, ObjectAdded, v3.ParametersLabel,
-						nil, rv[n].Name.ValueNode, true, nil,
+						nil, rv[n].Name.ValueNode, rv[n].Required.Value, nil,
 						rv[n].Name.Value)
 				}
 			}

--- a/what-changed/model/operation_test.go
+++ b/what-changed/model/operation_test.go
@@ -925,6 +925,7 @@ func TestCompareOperations_V3_AddRequiredParam(t *testing.T) {
   - name: honey
   - name: bunny
     in: fridge
+    required: false
   - name: pb33fRequired
     in: the_ranch
     required: true`

--- a/what-changed/model/operation_test.go
+++ b/what-changed/model/operation_test.go
@@ -262,8 +262,64 @@ parameters:
 	extChanges := CompareOperations(&lDoc, &rDoc)
 	assert.Equal(t, 1, extChanges.TotalChanges())
 	assert.Len(t, extChanges.GetAllChanges(), 1)
-	assert.Equal(t, 1, extChanges.TotalBreakingChanges())
+	assert.Equal(t, 0, extChanges.TotalBreakingChanges()) // Adding param without required field (defaults to false) is not breaking
 	assert.Equal(t, ObjectAdded, extChanges.Changes[0].ChangeType)
+}
+
+func TestCompareOperations_V2_AddRequiredParam(t *testing.T) {
+	left := `tags:
+  - one
+  - two
+summary: hello
+description: hello there my pal
+operationId: mintyFresh
+consumes:
+  - pizza
+  - cake
+produces:
+  - toast
+  - jam
+parameters:
+  - name: jimmy
+  - name: jammy
+    in: freezer`
+
+	right := `tags:
+  - one
+  - two
+summary: hello
+description: hello there my pal
+operationId: mintyFresh
+consumes:
+  - pizza
+  - cake
+produces:
+  - toast
+  - jam
+parameters:
+  - name: jimmy
+  - name: jammy
+    in: freezer
+  - name: jummyRequired
+    in: oven
+    required: true`
+
+	var lNode, rNode yaml.Node
+	_ = yaml.Unmarshal([]byte(left), &lNode)
+	_ = yaml.Unmarshal([]byte(right), &rNode)
+
+	// create low level objects
+	var lDoc v2.Operation
+	var rDoc v2.Operation
+	_ = low.BuildModel(lNode.Content[0], &lDoc)
+	_ = low.BuildModel(rNode.Content[0], &rDoc)
+	_ = lDoc.Build(context.Background(), nil, lNode.Content[0], nil)
+	_ = rDoc.Build(context.Background(), nil, rNode.Content[0], nil)
+
+	// compare.
+	extChanges := CompareOperations(&lDoc, &rDoc)
+	assert.Equal(t, 1, extChanges.TotalChanges())
+	assert.Equal(t, 1, extChanges.TotalBreakingChanges()) // The required param should be breaking
 }
 
 func TestCompareOperations_V2_RemoveParam(t *testing.T) {
@@ -855,8 +911,40 @@ func TestCompareOperations_V3_AddParam(t *testing.T) {
 	extChanges := CompareOperations(&lDoc, &rDoc)
 	assert.Equal(t, 1, extChanges.TotalChanges())
 	assert.Len(t, extChanges.GetAllChanges(), 1)
-	assert.Equal(t, 1, extChanges.TotalBreakingChanges())
+	assert.Equal(t, 0, extChanges.TotalBreakingChanges()) // Adding param without required field (defaults to false) is not breaking
 	assert.Equal(t, ObjectAdded, extChanges.Changes[0].ChangeType)
+}
+
+func TestCompareOperations_V3_AddRequiredParam(t *testing.T) {
+	left := `parameters:
+  - name: honey
+  - name: bunny
+    in: fridge`
+
+	right := `parameters:
+  - name: honey
+  - name: bunny
+    in: fridge
+  - name: pb33fRequired
+    in: the_ranch
+    required: true`
+
+	var lNode, rNode yaml.Node
+	_ = yaml.Unmarshal([]byte(left), &lNode)
+	_ = yaml.Unmarshal([]byte(right), &rNode)
+
+	// create low level objects
+	var lDoc v3.Operation
+	var rDoc v3.Operation
+	_ = low.BuildModel(lNode.Content[0], &lDoc)
+	_ = low.BuildModel(rNode.Content[0], &rDoc)
+	_ = lDoc.Build(context.Background(), nil, lNode.Content[0], nil)
+	_ = rDoc.Build(context.Background(), nil, rNode.Content[0], nil)
+
+	// compare.
+	extChanges := CompareOperations(&lDoc, &rDoc)
+	assert.Equal(t, 1, extChanges.TotalChanges())
+	assert.Equal(t, 1, extChanges.TotalBreakingChanges()) // The required param should be breaking
 }
 
 func TestCompareOperations_V3_RemoveParam(t *testing.T) {


### PR DESCRIPTION
I ran into this bug: https://github.com/pb33f/openapi-changes/issues/209 And tried to fix it. It seems like the breaking argument was hard coded to true rather than checking the required field on the parameter.