### PR TITLE
Embed name of the changed parameter

### DIFF
--- a/what-changed/model/parameter.go
+++ b/what-changed/model/parameter.go
@@ -17,6 +17,7 @@ import (
 // ParameterChanges represents changes found between Swagger or OpenAPI Parameter objects.
 type ParameterChanges struct {
 	*PropertyChanges
+	Name             string            `json:"name,omitempty" yaml:"name,omitempty"`
 	SchemaChanges    *SchemaChanges    `json:"schemas,omitempty" yaml:"schemas,omitempty"`
 	ExtensionChanges *ExtensionChanges `json:"extensions,omitempty" yaml:"extensions,omitempty"`
 
@@ -236,6 +237,7 @@ func CompareParameters(l, r any) *ParameterChanges {
 	if reflect.TypeOf(&v2.Parameter{}) == reflect.TypeOf(l) && reflect.TypeOf(&v2.Parameter{}) == reflect.TypeOf(r) {
 		lParam := l.(*v2.Parameter)
 		rParam := r.(*v2.Parameter)
+		pc.Name = lParam.Name.Value
 
 		// perform hash check to avoid further processing
 		if low.AreEqual(lParam, rParam) {
@@ -283,6 +285,7 @@ func CompareParameters(l, r any) *ParameterChanges {
 
 		lParam := l.(*v3.Parameter)
 		rParam := r.(*v3.Parameter)
+		pc.Name = lParam.Name.Value
 
 		// perform hash check to avoid further processing
 		if low.AreEqual(lParam, rParam) {

--- a/what-changed/model/parameter_test.go
+++ b/what-changed/model/parameter_test.go
@@ -54,7 +54,7 @@ func TestCompareParameters_V3(t *testing.T) {
 	// compare.
 	extChanges := CompareParametersV3(&lDoc, &rDoc)
 	assert.Equal(t, 1, extChanges.TotalChanges())
-	assert.Equal(t, "a param", extChanges)
+	assert.Equal(t, "a param", extChanges.Name)
 }
 
 func TestCompareParameters_V3_Schema(t *testing.T) {

--- a/what-changed/model/parameter_test.go
+++ b/what-changed/model/parameter_test.go
@@ -54,6 +54,7 @@ func TestCompareParameters_V3(t *testing.T) {
 	// compare.
 	extChanges := CompareParametersV3(&lDoc, &rDoc)
 	assert.Equal(t, 1, extChanges.TotalChanges())
+	assert.Equal(t, "a param", extChanges)
 }
 
 func TestCompareParameters_V3_Schema(t *testing.T) {


### PR DESCRIPTION
Just from looking at the changed parameter result array  coming from https://github.com/pb33f/libopenapi/blob/8fd18648b47e4a823edab8680e14e89feb897290/what-changed/model/operation.go#L337-L342 it's hard to understand what parameters have actually changed.

_I'm not sure if this is the way you want the model to change going forward, but having the parameter name value somewhere helps when inspecting the changes._