### PR TITLE
Fix discriminator mapping bundling

### DIFF
--- a/bundler/bundler.go
+++ b/bundler/bundler.go
@@ -17,10 +17,108 @@ import (
 	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
 	"github.com/pb33f/libopenapi/index"
 	"github.com/pb33f/libopenapi/orderedmap"
+	"gopkg.in/yaml.v3"
 )
+
+// discriminatorMapping tracks a discriminator mapping that references a schema
+type discriminatorMapping struct {
+	mappingNode *yaml.Node
+	originalRef string
+}
 
 // ErrInvalidModel is returned when the model is not usable.
 var ErrInvalidModel = errors.New("invalid model")
+
+// discoverDiscriminatorMappings finds all discriminator mappings in schemas that reference other schemas
+func discoverDiscriminatorMappings(idx *index.SpecIndex) map[string][]*discriminatorMapping {
+	discriminatorMappings := make(map[string][]*discriminatorMapping)
+
+	for _, schema := range idx.GetAllSchemas() {
+		if schema.Node != nil {
+			findDiscriminatorMappingsInNode(schema.Node, discriminatorMappings)
+		}
+	}
+
+	return discriminatorMappings
+}
+
+// findDiscriminatorMappingsInNode recursively searches for discriminator mappings in a YAML node
+func findDiscriminatorMappingsInNode(node *yaml.Node, mappings map[string][]*discriminatorMapping) {
+	if node == nil {
+		return
+	}
+
+	switch node.Kind {
+	case yaml.MappingNode:
+		processMappingNode(node, mappings)
+	case yaml.SequenceNode:
+		for _, child := range node.Content {
+			findDiscriminatorMappingsInNode(child, mappings)
+		}
+	}
+}
+
+// processMappingNode handles discriminator discovery in mapping nodes
+func processMappingNode(node *yaml.Node, mappings map[string][]*discriminatorMapping) {
+	for i := 0; i < len(node.Content); i += 2 {
+		if i+1 >= len(node.Content) {
+			continue
+		}
+
+		keyNode := node.Content[i]
+		valueNode := node.Content[i+1]
+
+		if keyNode.Value == "discriminator" && valueNode.Kind == yaml.MappingNode {
+			processDiscriminatorNode(valueNode, mappings)
+		}
+
+		// Recursively search in child nodes
+		findDiscriminatorMappingsInNode(valueNode, mappings)
+	}
+}
+
+// processDiscriminatorNode processes a discriminator node to extract mappings
+func processDiscriminatorNode(discriminatorNode *yaml.Node, mappings map[string][]*discriminatorMapping) {
+	for i := 0; i < len(discriminatorNode.Content); i += 2 {
+		if i+1 >= len(discriminatorNode.Content) {
+			continue
+		}
+
+		keyNode := discriminatorNode.Content[i]
+		valueNode := discriminatorNode.Content[i+1]
+
+		if keyNode.Value == "mapping" && valueNode.Kind == yaml.MappingNode {
+			extractMappingReferences(valueNode, mappings)
+		}
+	}
+}
+
+// extractMappingReferences extracts all mapping references from a mapping node
+func extractMappingReferences(mappingNode *yaml.Node, mappings map[string][]*discriminatorMapping) {
+	for i := 0; i < len(mappingNode.Content); i += 2 {
+		if i+1 >= len(mappingNode.Content) {
+			continue
+		}
+
+		mappingValueNode := mappingNode.Content[i+1]
+		if mappingValueNode.Value != "" {
+			mapping := &discriminatorMapping{
+				mappingNode: mappingValueNode,
+				originalRef: mappingValueNode.Value,
+			}
+			mappings[mappingValueNode.Value] = append(mappings[mappingValueNode.Value], mapping)
+		}
+	}
+}
+
+// updateDiscriminatorMappings updates discriminator mappings when their referenced schemas are moved/inlined
+func updateDiscriminatorMappings(mappings []*discriminatorMapping, newRef string) {
+	for _, mapping := range mappings {
+		if mapping.mappingNode != nil {
+			mapping.mappingNode.Value = newRef
+		}
+	}
+}
 
 // BundleBytes will take a byte slice of an OpenAPI specification and return a bundled version of it.
 // This is useful for when you want to take a specification with external references, and you want to bundle it
@@ -117,14 +215,33 @@ func compose(model *v3.Document, compositionConfig *BundleCompositionConfig) ([]
 
 	rolodex := model.Rolodex
 	indexes := rolodex.GetIndexes()
+	rootIndex := rolodex.GetRootIndex()
+
+	// discover discriminator mappings across all indexes
+	allDiscriminatorMappings := make(map[string][]*discriminatorMapping)
+
+	// First check the root index
+	rootMappings := discoverDiscriminatorMappings(rootIndex)
+	for ref, mappingList := range rootMappings {
+		allDiscriminatorMappings[ref] = append(allDiscriminatorMappings[ref], mappingList...)
+	}
+
+	// Then check all other indexes
+	for _, idx := range indexes {
+		mappings := discoverDiscriminatorMappings(idx)
+		for ref, mappingList := range mappings {
+			allDiscriminatorMappings[ref] = append(allDiscriminatorMappings[ref], mappingList...)
+		}
+	}
 
 	cf := &handleIndexConfig{
-		idx:               rolodex.GetRootIndex(),
-		model:             model,
-		indexes:           indexes,
-		seen:              sync.Map{},
-		refMap:            orderedmap.New[string, *processRef](),
-		compositionConfig: compositionConfig,
+		idx:                   rootIndex,
+		model:                 model,
+		indexes:               indexes,
+		seen:                  sync.Map{},
+		refMap:                orderedmap.New[string, *processRef](),
+		compositionConfig:     compositionConfig,
+		discriminatorMappings: allDiscriminatorMappings,
 	}
 	// recursive function to handle the indexes, we need a different approach to composition vs. inlining.
 	handleIndex(cf)
@@ -144,11 +261,89 @@ func compose(model *v3.Document, compositionConfig *BundleCompositionConfig) ([]
 		return 0
 	})
 
-	rootIndex := rolodex.GetRootIndex()
 	remapIndex(rootIndex, processedNodes)
 
 	for _, idx := range indexes {
 		remapIndex(idx, processedNodes)
+	}
+
+	// update discriminator mappings after all references have been processed
+	for originalRef, mappings := range allDiscriminatorMappings {
+		if processedRef := processedNodes.GetOrZero(originalRef); processedRef != nil {
+			var newRef string
+			if len(processedRef.location) > 0 {
+				newRef = "#/" + strings.Join(processedRef.location, "/")
+			} else {
+				newRef = "#/components/schemas/" + processedRef.name
+			}
+			updateDiscriminatorMappings(mappings, newRef)
+		} else {
+			// Check for external file references that may match processed nodes
+			var bestMatch *processRef
+			for _, processedRef := range processedNodes.FromOldest() {
+				refExp := strings.Split(processedRef.ref.FullDefinition, "#/")
+				if len(refExp) == 2 {
+					externalFile := refExp[0]
+					if externalFile != "" {
+						matched := false
+
+						if originalRef == externalFile || strings.HasPrefix(originalRef, externalFile+"#/") {
+							matched = true
+						}
+
+						if !matched && strings.HasPrefix(originalRef, "./") {
+							rootIndexPath := rolodex.GetRootIndex().GetSpecAbsolutePath()
+							baseDir := filepath.Dir(rootIndexPath)
+
+							mappingRefParts := strings.Split(originalRef, "#/")
+							if len(mappingRefParts) == 2 {
+								relativeFile := mappingRefParts[0]
+								absFile := filepath.Join(baseDir, relativeFile)
+
+								if absFile == externalFile || strings.HasPrefix(processedRef.ref.FullDefinition, absFile+"#/") {
+									matched = true
+								}
+							}
+						}
+
+						if matched {
+							if bestMatch == nil ||
+								(len(processedRef.location) > len(bestMatch.location)) ||
+								(len(processedRef.location) == len(bestMatch.location) &&
+									len(processedRef.name) > len(bestMatch.name)) {
+								bestMatch = processedRef
+							}
+						}
+					}
+				}
+			}
+
+			if bestMatch != nil {
+				var newRef string
+				if len(bestMatch.location) > 0 && len(bestMatch.location) >= 3 &&
+					bestMatch.location[0] == "components" && bestMatch.location[1] == "schemas" {
+					newRef = "#/" + strings.Join(bestMatch.location, "/")
+				} else {
+					componentsSchemaName := ""
+					if model.Components != nil && model.Components.Schemas != nil {
+						for schemaName := range model.Components.Schemas.FromOldest() {
+							if strings.HasSuffix(schemaName, bestMatch.name) ||
+								strings.Contains(schemaName, bestMatch.name) {
+								componentsSchemaName = schemaName
+								break
+							}
+						}
+					}
+
+					if componentsSchemaName != "" {
+						newRef = "#/components/schemas/" + componentsSchemaName
+					} else {
+						newRef = "#/components/schemas/" + bestMatch.name
+					}
+				}
+				updateDiscriminatorMappings(mappings, newRef)
+			}
+		}
 	}
 
 	// anything that could not be recomposed and needs inlining
@@ -181,6 +376,25 @@ func compose(model *v3.Document, compositionConfig *BundleCompositionConfig) ([]
 func bundle(model *v3.Document) ([]byte, error) {
 	rolodex := model.Rolodex
 	indexes := rolodex.GetIndexes()
+	rootIndex := rolodex.GetRootIndex()
+
+	// discover discriminator mappings across all indexes
+	allDiscriminatorMappings := make(map[string][]*discriminatorMapping)
+
+	// First check the root index
+	rootMappings := discoverDiscriminatorMappings(rootIndex)
+	for ref, mappingList := range rootMappings {
+		allDiscriminatorMappings[ref] = append(allDiscriminatorMappings[ref], mappingList...)
+	}
+
+	// Then check all other indexes
+	for _, idx := range indexes {
+		mappings := discoverDiscriminatorMappings(idx)
+		for ref, mappingList := range mappings {
+			allDiscriminatorMappings[ref] = append(allDiscriminatorMappings[ref], mappingList...)
+		}
+	}
+
 	// compact function.
 	compact := func(idx *index.SpecIndex, root bool) {
 		mappedReferences := idx.GetMappedReferences()
@@ -188,19 +402,14 @@ func bundle(model *v3.Document) ([]byte, error) {
 		for _, sequenced := range sequencedReferences {
 			mappedReference := mappedReferences[sequenced.FullDefinition]
 
-			// if we're in the root document, don't bundle anything.
 			refExp := strings.Split(sequenced.FullDefinition, "#/")
 			if len(refExp) == 2 {
-
-				// make sure to use the correct index.
-				// https://github.com/pb33f/libopenapi/issues/397
 				if root {
 					for _, i := range indexes {
 						if i.GetSpecAbsolutePath() == refExp[0] {
 							if mappedReference != nil && !mappedReference.Circular {
 								mr := i.FindComponent(context.Background(), sequenced.Definition)
 								if mr != nil {
-									// found the component; this is the one we want to use.
 									mappedReference = mr
 									break
 								}
@@ -219,6 +428,56 @@ func bundle(model *v3.Document) ([]byte, error) {
 			}
 
 			if mappedReference != nil && !mappedReference.Circular {
+				hasDiscriminatorMapping := false
+
+				if _, exists := allDiscriminatorMappings[sequenced.FullDefinition]; exists {
+					hasDiscriminatorMapping = true
+				}
+
+				if !hasDiscriminatorMapping {
+					refExp := strings.Split(sequenced.FullDefinition, "#/")
+					if len(refExp) == 2 {
+						externalFile := refExp[0]
+						if externalFile != "" {
+							for mappingRef, _ := range allDiscriminatorMappings {
+								matched := false
+
+								if mappingRef == externalFile || strings.HasPrefix(mappingRef, externalFile+"#/") {
+									matched = true
+								}
+
+								if !matched && strings.HasPrefix(mappingRef, "./") {
+									rootIndexPath := rolodex.GetRootIndex().GetSpecAbsolutePath()
+									baseDir := filepath.Dir(rootIndexPath)
+
+									mappingRefParts := strings.Split(mappingRef, "#/")
+									if len(mappingRefParts) == 2 {
+										relativeFile := mappingRefParts[0]
+										absFile := filepath.Join(baseDir, relativeFile)
+
+										if absFile == externalFile || strings.HasPrefix(sequenced.FullDefinition, absFile+"#/") {
+											matched = true
+										}
+									}
+								}
+
+								if matched {
+									hasDiscriminatorMapping = true
+									break
+								}
+							}
+						}
+					}
+				}
+
+				if hasDiscriminatorMapping {
+					if idx.GetLogger() != nil {
+						idx.GetLogger().Debug("[bundler] preserving schema referenced by discriminator mapping",
+							"ref", sequenced.Definition)
+					}
+					continue
+				}
+
 				sequenced.Node.Content = mappedReference.Node.Content
 				continue
 			}
@@ -236,5 +495,27 @@ func bundle(model *v3.Document) ([]byte, error) {
 		compact(idx, false)
 	}
 	compact(rolodex.GetRootIndex(), true)
+
+	// Update discriminator mappings to point to components after bundling
+	for originalRef, mappings := range allDiscriminatorMappings {
+		if strings.HasPrefix(originalRef, "./") || strings.Contains(originalRef, "/") {
+			mappingRefParts := strings.Split(originalRef, "#/")
+			if len(mappingRefParts) == 2 {
+				fragmentName := mappingRefParts[1]
+
+				if model.Components != nil && model.Components.Schemas != nil {
+					for schemaName := range model.Components.Schemas.FromOldest() {
+						if strings.Contains(schemaName, fragmentName) ||
+							strings.HasSuffix(schemaName, fragmentName) {
+							newRef := "#/components/schemas/" + schemaName
+							updateDiscriminatorMappings(mappings, newRef)
+							break
+						}
+					}
+				}
+			}
+		}
+	}
+
 	return model.Render()
 }

--- a/bundler/bundler.go
+++ b/bundler/bundler.go
@@ -376,6 +376,7 @@ func bundle(model *v3.Document) ([]byte, error) {
 			// if we're in the root document, don't bundle anything.
 			refExp := strings.Split(sequenced.FullDefinition, "#/")
 			if len(refExp) == 2 {
+
 				// make sure to use the correct index.
 				// https://github.com/pb33f/libopenapi/issues/397
 				if root {

--- a/bundler/bundler.go
+++ b/bundler/bundler.go
@@ -312,8 +312,9 @@ func updateDiscriminatorMappingsForComposition(allDiscriminatorMappings map[stri
 	for originalRef, mappings := range allDiscriminatorMappings {
 		bestMatch := findBestMatchForDiscriminatorMapping(originalRef, processedNodes, rolodex)
 		if bestMatch != nil {
-			newRef := buildComponentReference(bestMatch, model)
-			updateDiscriminatorMappings(mappings, newRef)
+			if newRef, found := buildComponentReference(bestMatch, model); found {
+				updateDiscriminatorMappings(mappings, newRef)
+			}
 		}
 	}
 }
@@ -337,16 +338,17 @@ func findBestMatchForDiscriminatorMapping(originalRef string, processedNodes *or
 }
 
 // buildComponentReference builds a component reference from a processed reference
-func buildComponentReference(processedRef *processRef, model *v3.Document) string {
+// Returns the reference and true if found, empty string and false if not found
+func buildComponentReference(processedRef *processRef, model *v3.Document) (string, bool) {
 	if model.Components != nil && model.Components.Schemas != nil {
 		for schemaName := range model.Components.Schemas.FromOldest() {
 			if strings.HasSuffix(schemaName, processedRef.name) || strings.Contains(schemaName, processedRef.name) {
-				return "#/components/schemas/" + schemaName
+				return "#/components/schemas/" + schemaName, true
 			}
 		}
 	}
 
-	return "#/components/schemas/" + processedRef.name
+	return "", false
 }
 
 // hasDiscriminatorReference checks if a reference is used by any discriminator mapping

--- a/bundler/bundler.go
+++ b/bundler/bundler.go
@@ -373,14 +373,18 @@ func bundle(model *v3.Document) ([]byte, error) {
 		for _, sequenced := range sequencedReferences {
 			mappedReference := mappedReferences[sequenced.FullDefinition]
 
+			// if we're in the root document, don't bundle anything.
 			refExp := strings.Split(sequenced.FullDefinition, "#/")
 			if len(refExp) == 2 {
+				// make sure to use the correct index.
+				// https://github.com/pb33f/libopenapi/issues/397
 				if root {
 					for _, i := range indexes {
 						if i.GetSpecAbsolutePath() == refExp[0] {
 							if mappedReference != nil && !mappedReference.Circular {
 								mr := i.FindComponent(context.Background(), sequenced.Definition)
 								if mr != nil {
+									// found the component; this is the one we want to use.
 									mappedReference = mr
 									break
 								}

--- a/bundler/bundler_composer.go
+++ b/bundler/bundler_composer.go
@@ -24,13 +24,14 @@ type processRef struct {
 }
 
 type handleIndexConfig struct {
-	idx               *index.SpecIndex
-	model             *v3.Document
-	indexes           []*index.SpecIndex
-	refMap            *orderedmap.Map[string, *processRef]
-	seen              sync.Map
-	inlineRequired    []*processRef
-	compositionConfig *BundleCompositionConfig
+	idx                   *index.SpecIndex
+	model                 *v3.Document
+	indexes               []*index.SpecIndex
+	refMap                *orderedmap.Map[string, *processRef]
+	seen                  sync.Map
+	inlineRequired        []*processRef
+	compositionConfig     *BundleCompositionConfig
+	discriminatorMappings map[string][]*discriminatorMapping
 }
 
 // handleIndex will recursively explore the indexes and their references, building a map of references

--- a/bundler/bundler_composer_test.go
+++ b/bundler/bundler_composer_test.go
@@ -5,8 +5,10 @@ package bundler
 
 import (
 	"errors"
+	"github.com/stretchr/testify/require"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"testing"
@@ -145,4 +147,113 @@ func TestBundlerComposed_StrangeRefs(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		assert.Len(t, bytes, 3397)
 	}
+}
+
+// TestDiscriminatorMappingComposed tests discriminator mapping with composed bundling.
+func TestDiscriminatorMappingComposed(t *testing.T) {
+	// Create a spec with external reference in discriminator mapping
+	spec := `openapi: 3.0.0
+info:
+  title: Test API
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Animal:
+      type: object
+      discriminator:
+        propertyName: type
+        mapping:
+          dog: '#/components/schemas/Dog'
+          cat: './external-cat.yaml#/Cat'
+    Dog:
+      type: object
+      properties:
+        type:
+          type: string
+        bark:
+          type: boolean
+    # Add a proper $ref to the external file so it gets processed by composed bundling
+    ExternalCat:
+      $ref: './external-cat.yaml#/Cat'
+`
+
+	// Create external file
+	externalSpec := `Cat:
+  type: object
+  properties:
+    type:
+      type: string
+    meow:
+      type: boolean`
+
+	// Create temporary files
+	tempDir := t.TempDir()
+	mainFile := filepath.Join(tempDir, "main.yaml")
+	externalFile := filepath.Join(tempDir, "external-cat.yaml")
+
+	err := os.WriteFile(mainFile, []byte(spec), 0644)
+	require.NoError(t, err)
+
+	err = os.WriteFile(externalFile, []byte(externalSpec), 0644)
+	require.NoError(t, err)
+
+	// Load the document
+	mainBytes, err := os.ReadFile(mainFile)
+	require.NoError(t, err)
+
+	config := &datamodel.DocumentConfiguration{
+		BasePath: tempDir,
+	}
+
+	// Bundle the document using composed bundling
+	bundled, err := BundleBytesComposed(mainBytes, config, &BundleCompositionConfig{
+		Delimiter: "__",
+	})
+	require.NoError(t, err)
+
+	// Parse the bundled result
+	var bundledSpec map[string]interface{}
+	err = yaml.Unmarshal(bundled, &bundledSpec)
+	require.NoError(t, err)
+
+	// Check the discriminator mapping in the bundled result
+	components, ok := bundledSpec["components"].(map[string]interface{})
+	require.True(t, ok, "components should exist")
+
+	schemas, ok := components["schemas"].(map[string]interface{})
+	require.True(t, ok, "schemas should exist")
+
+	animal, ok := schemas["Animal"].(map[string]interface{})
+	require.True(t, ok, "Animal schema should exist")
+
+	discriminator, ok := animal["discriminator"].(map[string]interface{})
+	require.True(t, ok, "discriminator should exist")
+
+	mapping, ok := discriminator["mapping"].(map[string]interface{})
+	require.True(t, ok, "mapping should exist")
+
+	// after composed bundling, the external reference should point to the components
+	catMapping, ok := mapping["cat"].(string)
+	require.True(t, ok, "cat mapping should exist")
+
+	// The external schema is placed as ExternalCat so the discriminator mapping should point to the correct location
+	assert.Equal(t, "#/components/schemas/ExternalCat", catMapping, "cat mapping should point to the correct component location")
+
+	t.Logf("Discriminator cat mapping: '%s'", catMapping)
+	t.Logf("Expected: '#/components/schemas/ExternalCat'")
+	t.Logf("Current behavior: '%s'", catMapping)
+
+	// Also verify that the ExternalCat schema was actually bundled
+	_, externalCatExists := schemas["ExternalCat"]
+	assert.True(t, externalCatExists, "ExternalCat schema should be bundled into the main document")
+
+	// Log the actual structure to understand what's happening
+	t.Logf("Components schemas keys: %v", func() []string {
+		keys := make([]string, 0)
+		for k := range schemas {
+			keys = append(keys, k)
+		}
+		return keys
+	}())
 }

--- a/bundler/bundler_composer_test.go
+++ b/bundler/bundler_composer_test.go
@@ -5,13 +5,14 @@ package bundler
 
 import (
 	"errors"
-	"github.com/stretchr/testify/require"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"regexp"
 	"runtime"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/pb33f/libopenapi"
 	"github.com/pb33f/libopenapi/datamodel"
@@ -247,13 +248,112 @@ components:
 	// Also verify that the ExternalCat schema was actually bundled
 	_, externalCatExists := schemas["ExternalCat"]
 	assert.True(t, externalCatExists, "ExternalCat schema should be bundled into the main document")
+}
 
-	// Log the actual structure to understand what's happening
-	t.Logf("Components schemas keys: %v", func() []string {
-		keys := make([]string, 0)
-		for k := range schemas {
-			keys = append(keys, k)
-		}
-		return keys
-	}())
+// TestDiscriminatorMappingNonExistentComposed tests that discriminator mappings pointing to non-existent files are left unchanged during composed bundling
+func TestDiscriminatorMappingNonExistentComposed(t *testing.T) {
+	spec := `openapi: 3.0.0
+info:
+  title: Test API
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Animal:
+      type: object
+      discriminator:
+        propertyName: type
+        mapping:
+          dog: '#/components/schemas/Dog'
+          cat: './external-cat.yaml#/Cat'
+          nonexistent: './does-not-exist.yaml#/Missing'
+          invalid: './also-missing.yaml#/Schema'
+    Dog:
+      type: object
+      properties:
+        type:
+          type: string
+        bark:
+          type: boolean
+    # Add a proper $ref to the external file so it gets processed by composed bundling
+    ExternalCat:
+      $ref: './external-cat.yaml#/Cat'
+`
+
+	// Create external file (but not the non-existent ones)
+	externalSpec := `Cat:
+  type: object
+  properties:
+    type:
+      type: string
+    meow:
+      type: boolean`
+
+	// Create temporary files
+	tempDir := t.TempDir()
+	mainFile := filepath.Join(tempDir, "main.yaml")
+	externalFile := filepath.Join(tempDir, "external-cat.yaml")
+
+	err := os.WriteFile(mainFile, []byte(spec), 0644)
+	require.NoError(t, err)
+
+	err = os.WriteFile(externalFile, []byte(externalSpec), 0644)
+	require.NoError(t, err)
+
+	// Load the document
+	mainBytes, err := os.ReadFile(mainFile)
+	require.NoError(t, err)
+
+	config := &datamodel.DocumentConfiguration{
+		BasePath: tempDir,
+	}
+
+	// Bundle the document using composed bundling
+	bundled, err := BundleBytesComposed(mainBytes, config, &BundleCompositionConfig{
+		Delimiter: "__",
+	})
+	require.NoError(t, err)
+
+	// Parse the bundled result
+	var bundledSpec map[string]interface{}
+	err = yaml.Unmarshal(bundled, &bundledSpec)
+	require.NoError(t, err)
+
+	// Check the discriminator mapping in the bundled result
+	components, ok := bundledSpec["components"].(map[string]interface{})
+	require.True(t, ok, "components should exist")
+
+	schemas, ok := components["schemas"].(map[string]interface{})
+	require.True(t, ok, "schemas should exist")
+
+	animal, ok := schemas["Animal"].(map[string]interface{})
+	require.True(t, ok, "Animal schema should exist")
+
+	discriminator, ok := animal["discriminator"].(map[string]interface{})
+	require.True(t, ok, "discriminator should exist")
+
+	mapping, ok := discriminator["mapping"].(map[string]interface{})
+	require.True(t, ok, "mapping should exist")
+
+	// Valid mappings should be updated
+	dogMapping, ok := mapping["dog"].(string)
+	require.True(t, ok, "dog mapping should exist")
+	assert.Equal(t, "#/components/schemas/Dog", dogMapping, "dog mapping should point to component")
+
+	catMapping, ok := mapping["cat"].(string)
+	require.True(t, ok, "cat mapping should exist")
+	assert.Equal(t, "#/components/schemas/ExternalCat", catMapping, "cat mapping should point to component")
+
+	// Non-existent mappings should be left unchanged
+	nonExistentMapping, ok := mapping["nonexistent"].(string)
+	require.True(t, ok, "nonexistent mapping should still exist")
+	assert.Equal(t, "./does-not-exist.yaml#/Missing", nonExistentMapping, "nonexistent mapping should be unchanged")
+
+	invalidMapping, ok := mapping["invalid"].(string)
+	require.True(t, ok, "invalid mapping should still exist")
+	assert.Equal(t, "./also-missing.yaml#/Schema", invalidMapping, "invalid mapping should be unchanged")
+
+	// Verify that the valid external schema was bundled
+	_, externalCatExists := schemas["ExternalCat"]
+	assert.True(t, externalCatExists, "ExternalCat schema should be bundled into the main document")
 }

--- a/bundler/bundler_composer_test.go
+++ b/bundler/bundler_composer_test.go
@@ -242,10 +242,6 @@ components:
 	// The external schema is placed as ExternalCat so the discriminator mapping should point to the correct location
 	assert.Equal(t, "#/components/schemas/ExternalCat", catMapping, "cat mapping should point to the correct component location")
 
-	t.Logf("Discriminator cat mapping: '%s'", catMapping)
-	t.Logf("Expected: '#/components/schemas/ExternalCat'")
-	t.Logf("Current behavior: '%s'", catMapping)
-
 	// Also verify that the ExternalCat schema was actually bundled
 	_, externalCatExists := schemas["ExternalCat"]
 	assert.True(t, externalCatExists, "ExternalCat schema should be bundled into the main document")

--- a/bundler/bundler_composer_test.go
+++ b/bundler/bundler_composer_test.go
@@ -248,6 +248,9 @@ components:
 	// Also verify that the ExternalCat schema was actually bundled
 	_, externalCatExists := schemas["ExternalCat"]
 	assert.True(t, externalCatExists, "ExternalCat schema should be bundled into the main document")
+
+	// Force garbage collection to close any open file handles (Windows fix)
+	runtime.GC()
 }
 
 // TestDiscriminatorMappingNonExistentComposed tests that discriminator mappings pointing to non-existent files are left unchanged during composed bundling
@@ -356,4 +359,7 @@ components:
 	// Verify that the valid external schema was bundled
 	_, externalCatExists := schemas["ExternalCat"]
 	assert.True(t, externalCatExists, "ExternalCat schema should be bundled into the main document")
+
+	// Force garbage collection to close any open file handles (Windows fix)
+	runtime.GC()
 }

--- a/bundler/bundler_composer_test.go
+++ b/bundler/bundler_composer_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/pb33f/libopenapi"
 	"github.com/pb33f/libopenapi/datamodel"
+	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
 	"github.com/pb33f/libopenapi/index"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"
@@ -362,4 +363,21 @@ components:
 
 	// Force garbage collection to close any open file handles (Windows fix)
 	runtime.GC()
+}
+
+// TestBuildComponentReferenceFallback tests the fallback case in buildComponentReference
+func TestBuildComponentReferenceFallback(t *testing.T) {
+	// Create a processRef with a name
+	processedRef := &processRef{
+		name: "TestSchema",
+	}
+
+	// Create a model with no components section
+	model := &v3.Document{}
+
+	// This should return "", false since there are no components
+	result, found := buildComponentReference(processedRef, model)
+
+	assert.Equal(t, "", result, "should return empty string when no components")
+	assert.False(t, found, "should return false when no components")
 }

--- a/bundler/bundler_test.go
+++ b/bundler/bundler_test.go
@@ -493,6 +493,9 @@ components:
 	// verify that the ExternalCat schema was actually bundled
 	_, externalCatExists := schemas["ExternalCat"]
 	assert.True(t, externalCatExists, "ExternalCat schema should be bundled via $ref")
+
+	// Force garbage collection to close any open file handles (Windows fix)
+	runtime.GC()
 }
 
 // TestDiscriminatorMappingNonExistent tests that discriminator mappings pointing to non-existent files are left unchanged
@@ -602,4 +605,7 @@ components:
 	// Verify that the valid external schema was bundled
 	_, externalCatExists := schemas["ExternalCat"]
 	assert.True(t, externalCatExists, "ExternalCat schema should be bundled")
+
+	// Force garbage collection to close any open file handles (Windows fix)
+	runtime.GC()
 }

--- a/bundler/bundler_test.go
+++ b/bundler/bundler_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pb33f/libopenapi/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 func TestBundleDocument_DigitalOcean(t *testing.T) {
@@ -394,4 +395,704 @@ paths:
 	_, e := BundleBytesComposed(specBytes, nil, nil)
 
 	assert.Error(t, e)
+}
+
+func TestDiscriminatorMappings_PropertyNameOnly(t *testing.T) {
+	// Test discriminator with propertyName only (no mapping)
+	specBytes := []byte(`openapi: "3.1.0"
+info:
+  title: PropertyName Only Test
+  version: "1.0.0"
+paths:
+  /vehicles:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Vehicle"
+      responses:
+        '200':
+          description: Success
+components:
+  schemas:
+    Vehicle:
+      oneOf:
+        - $ref: "#/components/schemas/Car"
+        - $ref: "#/components/schemas/Truck"
+      discriminator:
+        propertyName: vehicleType
+    Car:
+      type: object
+      properties:
+        vehicleType:
+          type: string
+          enum: [Car]
+    Truck:
+      type: object
+      properties:
+        vehicleType:
+          type: string
+          enum: [Truck]
+        capacity:
+          type: integer`)
+
+	config := &datamodel.DocumentConfiguration{
+		BasePath:                "test/specs",
+		ExtractRefsSequentially: true,
+	}
+
+	// Test both bundling modes
+	bundledBytes, err := BundleBytes(specBytes, config)
+	assert.NoError(t, err)
+	assert.Contains(t, string(bundledBytes), "discriminator:")
+	assert.Contains(t, string(bundledBytes), "propertyName:")
+
+	composedBytes, err := BundleBytesComposed(specBytes, config, &BundleCompositionConfig{Delimiter: "__"})
+	assert.NoError(t, err)
+	assert.Contains(t, string(composedBytes), "discriminator:")
+	assert.Contains(t, string(composedBytes), "propertyName:")
+}
+
+func TestDiscriminatorMappings_ExternalFileReferences(t *testing.T) {
+	// Test discriminator with mapping to external files
+	specBytes := []byte(`openapi: "3.1.0"
+info:
+  title: External File References Test
+  version: "1.0.0"
+paths:
+  /vehicles:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Vehicle"
+      responses:
+        '200':
+          description: Success
+components:
+  schemas:
+    Vehicle:
+      oneOf:
+        - $ref: "vehicle.yaml"
+      discriminator:
+        propertyName: vehicleType
+        mapping:
+          vehicle: "vehicle.yaml"`)
+
+	config := &datamodel.DocumentConfiguration{
+		BasePath:                "test/specs",
+		ExtractRefsSequentially: true,
+	}
+
+	// Test inline bundling
+	bundledBytes, err := BundleBytes(specBytes, config)
+	assert.NoError(t, err)
+	bundledSpec := string(bundledBytes)
+	assert.Contains(t, bundledSpec, "discriminator:")
+	assert.Contains(t, bundledSpec, "wheels:") // from vehicle.yaml
+
+	// Test composition bundling
+	composedBytes, err := BundleBytesComposed(specBytes, config, &BundleCompositionConfig{Delimiter: "__"})
+	assert.NoError(t, err)
+	composedSpec := string(composedBytes)
+	assert.Contains(t, composedSpec, "discriminator:")
+	assert.Contains(t, composedSpec, "components:")
+	assert.Contains(t, composedSpec, "schemas:")
+}
+
+func TestDiscriminatorMappings_MixedLocalExternal(t *testing.T) {
+	// Test discriminator with mixed local and external mappings
+	specBytes := []byte(`openapi: "3.1.0"
+info:
+  title: Mixed References Test
+  version: "1.0.0"
+paths:
+  /vehicles:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Vehicle"
+      responses:
+        '200':
+          description: Success
+components:
+  schemas:
+    Vehicle:
+      oneOf:
+        - $ref: "#/components/schemas/Car"
+        - $ref: "vehicle.yaml"
+      discriminator:
+        propertyName: vehicleType
+        mapping:
+          car: "#/components/schemas/Car"
+          vehicle: "vehicle.yaml"
+    Car:
+      type: object
+      properties:
+        vehicleType:
+          type: string
+          enum: [car]
+        doors:
+          type: integer`)
+
+	config := &datamodel.DocumentConfiguration{
+		BasePath:                "test/specs",
+		ExtractRefsSequentially: true,
+	}
+
+	// Test inline bundling
+	bundledBytes, err := BundleBytes(specBytes, config)
+	assert.NoError(t, err)
+	bundledSpec := string(bundledBytes)
+	assert.Contains(t, bundledSpec, "discriminator:")
+	assert.Contains(t, bundledSpec, "doors:")  // from local Car schema
+	assert.Contains(t, bundledSpec, "wheels:") // from external vehicle.yaml
+
+	// Test composition bundling
+	composedBytes, err := BundleBytesComposed(specBytes, config, &BundleCompositionConfig{Delimiter: "__"})
+	assert.NoError(t, err)
+	composedSpec := string(composedBytes)
+	assert.Contains(t, composedSpec, "discriminator:")
+	assert.Contains(t, composedSpec, "components:")
+	assert.Contains(t, composedSpec, "schemas:")
+}
+
+func TestDiscriminatorMappings_ExternalWithFragment(t *testing.T) {
+	// Test discriminator with external file references that include fragments
+	// First create a vehicle file with proper structure
+	vehicleWithFragment := []byte(`
+Vehicle:
+  type: object
+  properties:
+    vehicleType:
+      type: string
+    wheels:
+      type: integer
+  required:
+    - vehicleType`)
+
+	// Write to temp file
+	tempFile, err := os.CreateTemp("test/specs", "vehicle-fragment-*.yaml")
+	assert.NoError(t, err)
+	defer os.Remove(tempFile.Name())
+
+	_, err = tempFile.Write(vehicleWithFragment)
+	assert.NoError(t, err)
+	tempFile.Close()
+
+	fileName := filepath.Base(tempFile.Name())
+
+	specBytes := []byte(`openapi: "3.1.0"
+info:
+  title: External Fragment Test
+  version: "1.0.0"
+paths:
+  /vehicles:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Vehicle"
+      responses:
+        '200':
+          description: Success
+components:
+  schemas:
+    Vehicle:
+      oneOf:
+        - $ref: "` + fileName + `#/Vehicle"
+      discriminator:
+        propertyName: vehicleType
+        mapping:
+          vehicle: "` + fileName + `#/Vehicle"`)
+
+	config := &datamodel.DocumentConfiguration{
+		BasePath:                "test/specs",
+		ExtractRefsSequentially: true,
+	}
+
+	// Test inline bundling
+	bundledBytes, err := BundleBytes(specBytes, config)
+	assert.NoError(t, err)
+	bundledSpec := string(bundledBytes)
+	assert.Contains(t, bundledSpec, "discriminator:")
+
+	// Test composition bundling
+	composedBytes, err := BundleBytesComposed(specBytes, config, &BundleCompositionConfig{Delimiter: "__"})
+	assert.NoError(t, err)
+	composedSpec := string(composedBytes)
+	assert.Contains(t, composedSpec, "discriminator:")
+	assert.Contains(t, composedSpec, "components:")
+}
+
+func TestDiscriminatorMappings_EdgeCases(t *testing.T) {
+	// Test edge cases like empty mappings, non-existent references, etc.
+	specBytes := []byte(`openapi: "3.1.0"
+info:
+  title: Edge Cases Test
+  version: "1.0.0"
+paths:
+  /vehicles:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Vehicle"
+      responses:
+        '200':
+          description: Success
+components:
+  schemas:
+    Vehicle:
+      oneOf:
+        - $ref: "#/components/schemas/Car"
+      discriminator:
+        propertyName: vehicleType
+        mapping:
+          car: "#/components/schemas/Car"
+          nonexistent: "#/components/schemas/NonExistent"
+          empty: ""
+    Car:
+      type: object
+      properties:
+        vehicleType:
+          type: string
+          enum: [car]
+        doors:
+          type: integer`)
+
+	config := &datamodel.DocumentConfiguration{
+		BasePath:                "test/specs",
+		ExtractRefsSequentially: true,
+	}
+
+	// Should not error even with problematic mappings
+	bundledBytes, err := BundleBytes(specBytes, config)
+	assert.NoError(t, err)
+	bundledSpec := string(bundledBytes)
+	assert.Contains(t, bundledSpec, "discriminator:")
+	assert.Contains(t, bundledSpec, "doors:")
+
+	composedBytes, err := BundleBytesComposed(specBytes, config, &BundleCompositionConfig{Delimiter: "__"})
+	assert.NoError(t, err)
+	composedSpec := string(composedBytes)
+	assert.Contains(t, composedSpec, "discriminator:")
+}
+
+func TestDiscoverDiscriminatorMappings(t *testing.T) {
+	specBytes := []byte(`openapi: "3.1.0"
+info:
+  title: Discovery Test
+  version: "1.0.0"
+components:
+  schemas:
+    Vehicle:
+      oneOf:
+        - $ref: "#/components/schemas/Car"
+        - $ref: "#/components/schemas/Truck"
+      discriminator:
+        propertyName: vehicleType
+        mapping:
+          car: "#/components/schemas/Car"
+          truck: "#/components/schemas/Truck"
+          external: "vehicle.yaml"
+    Car:
+      type: object
+    Truck:
+      type: object`)
+
+	doc, err := libopenapi.NewDocumentWithConfiguration(specBytes, &datamodel.DocumentConfiguration{
+		BasePath: "test/specs",
+	})
+	assert.NoError(t, err)
+
+	_, errs := doc.BuildV3Model()
+	assert.NoError(t, errors.Join(errs...))
+}
+
+func TestDiscriminatorMappings_BugFix_Integration(t *testing.T) {
+	// This test verifies the original discriminator mapping bug is fixed
+	specBytes := []byte(`openapi: "3.1.0"
+info:
+  title: Bug Fix Test
+  version: "1.0.0"
+paths:
+  /vehicles:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Vehicle"
+      responses:
+        '200':
+          description: Success
+components:
+  schemas:
+    Vehicle:
+      oneOf:
+        - $ref: "vehicle.yaml"
+      discriminator:
+        propertyName: vehicleType
+        mapping:
+          vehicle: "vehicle.yaml"`)
+
+	config := &datamodel.DocumentConfiguration{
+		BasePath:                "test/specs",
+		ExtractRefsSequentially: true,
+	}
+
+	// Test composition bundling - mappings should be updated to point to components
+	bundledBytes, err := BundleBytesComposed(specBytes, config, &BundleCompositionConfig{Delimiter: "__"})
+	assert.NoError(t, err)
+
+	bundledSpec := string(bundledBytes)
+
+	// Verify external schemas were composed into components
+	assert.Contains(t, bundledSpec, "components:")
+	assert.Contains(t, bundledSpec, "schemas:")
+	assert.Contains(t, bundledSpec, "wheels:") // from vehicle.yaml
+
+	// Verify discriminator mappings were updated to point to components (bug fix)
+	assert.Contains(t, bundledSpec, "#/components/schemas/")
+
+	// The original bug would leave mappings pointing to "vehicle.yaml"
+	// which would be invalid after bundling. Our fix updates them to proper component refs.
+
+	// Test inline bundling - mappings should be cleared since schemas are inlined
+	inlineBundledBytes, err := BundleBytes(specBytes, config)
+	assert.NoError(t, err)
+
+	inlineBundledSpec := string(inlineBundledBytes)
+
+	// Verify schemas were inlined
+	assert.Contains(t, inlineBundledSpec, "wheels:") // from vehicle.yaml inlined
+
+	// Verify discriminator mapping structure is preserved
+	assert.Contains(t, inlineBundledSpec, "discriminator:")
+	assert.Contains(t, inlineBundledSpec, "mapping:")
+}
+
+// TestDiscriminatorMappingBugDemo demonstrates the actual bug where discriminator mappings
+// point to invalid locations after bundling without our fix
+func TestDiscriminatorMappingBugDemo(t *testing.T) {
+	// Create a spec with external reference in discriminator mapping
+	spec := `openapi: 3.0.0
+info:
+  title: Test API
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Animal:
+      type: object
+      discriminator:
+        propertyName: type
+        mapping:
+          dog: '#/components/schemas/Dog'
+          cat: './external-cat.yaml#/Cat'
+    Dog:
+      type: object
+      properties:
+        type:
+          type: string
+        bark:
+          type: boolean
+    # Let's also add a proper $ref to the external file to make sure it gets bundled
+    ExternalCat:
+      $ref: './external-cat.yaml#/Cat'
+`
+
+	// Create external file
+	externalSpec := `Cat:
+  type: object
+  properties:
+    type:
+      type: string
+    meow:
+      type: boolean`
+
+	// Create temporary files
+	tempDir := t.TempDir()
+	mainFile := filepath.Join(tempDir, "main.yaml")
+	externalFile := filepath.Join(tempDir, "external-cat.yaml")
+
+	err := os.WriteFile(mainFile, []byte(spec), 0644)
+	require.NoError(t, err)
+
+	err = os.WriteFile(externalFile, []byte(externalSpec), 0644)
+	require.NoError(t, err)
+
+	// Load the document
+	mainBytes, err := os.ReadFile(mainFile)
+	require.NoError(t, err)
+
+	config := &datamodel.DocumentConfiguration{
+		BasePath:                tempDir,
+		AllowFileReferences:     true,
+		AllowRemoteReferences:   false,
+		ExtractRefsSequentially: true,
+	}
+
+	// Bundle the document
+	bundled, err := BundleBytes(mainBytes, config)
+	require.NoError(t, err)
+
+	// Parse the bundled result
+	var bundledSpec map[string]interface{}
+	err = yaml.Unmarshal(bundled, &bundledSpec)
+	require.NoError(t, err)
+
+	// Check the discriminator mapping in the bundled result
+	components, ok := bundledSpec["components"].(map[string]interface{})
+	require.True(t, ok, "components should exist")
+
+	schemas, ok := components["schemas"].(map[string]interface{})
+	require.True(t, ok, "schemas should exist")
+
+	animal, ok := schemas["Animal"].(map[string]interface{})
+	require.True(t, ok, "Animal schema should exist")
+
+	discriminator, ok := animal["discriminator"].(map[string]interface{})
+	require.True(t, ok, "discriminator should exist")
+
+	mapping, ok := discriminator["mapping"].(map[string]interface{})
+	require.True(t, ok, "mapping should exist")
+
+	// This is the key test - after bundling, the external reference should be updated or removed
+	// Without our fix, this would still point to './external-cat.yaml#/Cat' which doesn't exist in the bundled spec
+	catMapping, ok := mapping["cat"].(string)
+	require.True(t, ok, "cat mapping should exist")
+
+	// With our fix for inline bundling, the mapping should point to the component location
+	// where the external schema was placed, not be empty or point to an invalid external file
+	assert.Equal(t, "#/components/schemas/ExternalCat", catMapping, "cat mapping should point to the component location after inline bundling")
+
+	// Also verify that the ExternalCat schema was actually bundled
+	_, externalCatExists := schemas["ExternalCat"]
+	assert.True(t, externalCatExists, "ExternalCat schema should be bundled via $ref")
+}
+
+// TestDiscriminatorMappingBugDemoComposed demonstrates the bug for composed bundling
+func TestDiscriminatorMappingBugDemoComposed(t *testing.T) {
+	// Create a spec with external reference in discriminator mapping
+	spec := `openapi: 3.0.0
+info:
+  title: Test API
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Animal:
+      type: object
+      discriminator:
+        propertyName: type
+        mapping:
+          dog: '#/components/schemas/Dog'
+          cat: './external-cat.yaml#/Cat'
+    Dog:
+      type: object
+      properties:
+        type:
+          type: string
+        bark:
+          type: boolean
+    # Add a proper $ref to the external file so it gets processed by composed bundling
+    ExternalCat:
+      $ref: './external-cat.yaml#/Cat'
+`
+
+	// Create external file
+	externalSpec := `Cat:
+  type: object
+  properties:
+    type:
+      type: string
+    meow:
+      type: boolean`
+
+	// Create temporary files
+	tempDir := t.TempDir()
+	mainFile := filepath.Join(tempDir, "main.yaml")
+	externalFile := filepath.Join(tempDir, "external-cat.yaml")
+
+	err := os.WriteFile(mainFile, []byte(spec), 0644)
+	require.NoError(t, err)
+
+	err = os.WriteFile(externalFile, []byte(externalSpec), 0644)
+	require.NoError(t, err)
+
+	// Load the document
+	mainBytes, err := os.ReadFile(mainFile)
+	require.NoError(t, err)
+
+	config := &datamodel.DocumentConfiguration{
+		BasePath: tempDir,
+	}
+
+	// Bundle the document using composed bundling
+	bundled, err := BundleBytesComposed(mainBytes, config, &BundleCompositionConfig{
+		Delimiter: "__",
+	})
+	require.NoError(t, err)
+
+	// Parse the bundled result
+	var bundledSpec map[string]interface{}
+	err = yaml.Unmarshal(bundled, &bundledSpec)
+	require.NoError(t, err)
+
+	// Check the discriminator mapping in the bundled result
+	components, ok := bundledSpec["components"].(map[string]interface{})
+	require.True(t, ok, "components should exist")
+
+	schemas, ok := components["schemas"].(map[string]interface{})
+	require.True(t, ok, "schemas should exist")
+
+	animal, ok := schemas["Animal"].(map[string]interface{})
+	require.True(t, ok, "Animal schema should exist")
+
+	discriminator, ok := animal["discriminator"].(map[string]interface{})
+	require.True(t, ok, "discriminator should exist")
+
+	mapping, ok := discriminator["mapping"].(map[string]interface{})
+	require.True(t, ok, "mapping should exist")
+
+	// This is the key test - after composed bundling, the external reference should point to the components
+	// Without our fix, this would still point to './external-cat.yaml#/Cat' which doesn't exist in the bundled spec
+	catMapping, ok := mapping["cat"].(string)
+	require.True(t, ok, "cat mapping should exist")
+
+	// With our fix for composed bundling, the mapping should point to the components section
+	// The external schema is placed as ExternalCat so the discriminator mapping should point to the correct location
+	assert.Equal(t, "#/components/schemas/ExternalCat", catMapping, "cat mapping should point to the correct component location")
+
+	t.Logf("Discriminator cat mapping: '%s'", catMapping)
+	t.Logf("Expected: '#/components/schemas/ExternalCat'")
+	t.Logf("Current behavior: '%s'", catMapping)
+
+	// Also verify that the ExternalCat schema was actually bundled
+	_, externalCatExists := schemas["ExternalCat"]
+	assert.True(t, externalCatExists, "ExternalCat schema should be bundled into the main document")
+
+	// Log the actual structure to understand what's happening
+	t.Logf("Components schemas keys: %v", func() []string {
+		keys := make([]string, 0)
+		for k := range schemas {
+			keys = append(keys, k)
+		}
+		return keys
+	}())
+}
+
+// TestDiscriminatorMappingInlineReality tests what actually happens to discriminators with pure inlining
+func TestDiscriminatorMappingInlineReality(t *testing.T) {
+	// Create a spec that actually uses the discriminator mapping in a reference
+	spec := `openapi: 3.0.0
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      responses:
+        '200':
+          description: A list of pets
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Animal'
+components:
+  schemas:
+    Animal:
+      type: object
+      discriminator:
+        propertyName: type
+        mapping:
+          dog: '#/components/schemas/Dog'
+          cat: './external-cat.yaml#/Cat'
+      oneOf:
+        - $ref: '#/components/schemas/Dog'
+        - $ref: './external-cat.yaml#/Cat'
+    Dog:
+      type: object
+      properties:
+        type:
+          type: string
+        bark:
+          type: boolean
+`
+
+	// Create external file
+	externalSpec := `Cat:
+  type: object
+  properties:
+    type:
+      type: string
+    meow:
+      type: boolean`
+
+	// Create temporary files
+	tempDir := t.TempDir()
+	mainFile := filepath.Join(tempDir, "main.yaml")
+	externalFile := filepath.Join(tempDir, "external-cat.yaml")
+
+	err := os.WriteFile(mainFile, []byte(spec), 0644)
+	require.NoError(t, err)
+
+	err = os.WriteFile(externalFile, []byte(externalSpec), 0644)
+	require.NoError(t, err)
+
+	// Load the document
+	mainBytes, err := os.ReadFile(mainFile)
+	require.NoError(t, err)
+
+	config := &datamodel.DocumentConfiguration{
+		BasePath:                tempDir,
+		AllowFileReferences:     true,
+		AllowRemoteReferences:   false,
+		ExtractRefsSequentially: true,
+	}
+
+	// Bundle the document (inline bundling)
+	bundled, err := BundleBytes(mainBytes, config)
+	require.NoError(t, err)
+
+	t.Logf("Bundled result:\n%s", string(bundled))
+
+	// Parse the bundled result
+	var bundledSpec map[string]interface{}
+	err = yaml.Unmarshal(bundled, &bundledSpec)
+	require.NoError(t, err)
+
+	// Check what happened to the discriminator
+	paths := bundledSpec["paths"].(map[string]interface{})
+	getPets := paths["/pets"].(map[string]interface{})
+	getMethod := getPets["get"].(map[string]interface{})
+	responses := getMethod["responses"].(map[string]interface{})
+	response200 := responses["200"].(map[string]interface{})
+	content := response200["content"].(map[string]interface{})
+	appJson := content["application/json"].(map[string]interface{})
+	schema := appJson["schema"].(map[string]interface{})
+	items := schema["items"].(map[string]interface{})
+
+	t.Logf("Items schema: %v", items)
+
+	// Check if discriminator still exists and is valid
+	if discriminator, exists := items["discriminator"]; exists {
+		t.Logf("Discriminator still exists: %v", discriminator)
+
+		if disc, ok := discriminator.(map[string]interface{}); ok {
+			if mapping, exists := disc["mapping"]; exists {
+				t.Logf("Mapping still exists: %v", mapping)
+			}
+		}
+	}
 }

--- a/bundler/test/specs/vehicle.yaml
+++ b/bundler/test/specs/vehicle.yaml
@@ -1,0 +1,8 @@
+type: object
+properties:
+  vehicleType:
+    type: string
+  wheels:
+    type: integer
+required:
+  - vehicleType 

--- a/bundler/test/specs/vehicle.yaml
+++ b/bundler/test/specs/vehicle.yaml
@@ -1,8 +1,0 @@
-type: object
-properties:
-  vehicleType:
-    type: string
-  wheels:
-    type: integer
-required:
-  - vehicleType 


### PR DESCRIPTION
Fixes bug with #433 

this would preserve discriminator schemas similarly to circular refs or put them under components/schemas and update the value (for compose) provided it's pointing to somewhere valid. Or it would just leave it alone if it's invalid

Allow me to add 500 lines of code to fix discriminators because they don't use standard ref behavior. Would love to know the historical reason for why they aren't standard refs in the open-api spec :<