### PR TITLE
refactor: simplify tests with t.TempDir; close file handler

### DIFF
--- a/bundler/bundler_test.go
+++ b/bundler/bundler_test.go
@@ -32,9 +32,8 @@ import (
 
 func TestBundleDocument_DigitalOcean(t *testing.T) {
 	// test the mother of all exploded specs.
-	tmp, _ := os.MkdirTemp("", "openapi")
+	tmp := t.TempDir()
 	cmd := exec.Command("git", "clone", "-b", "asb/dedup-key-model", "https://github.com/digitalocean/openapi.git", tmp)
-	defer os.RemoveAll(filepath.Join(tmp, "openapi"))
 
 	err := cmd.Run()
 	if err != nil {

--- a/datamodel/high/v3/document_test.go
+++ b/datamodel/high/v3/document_test.go
@@ -468,9 +468,8 @@ func TestAsanaAsDoc(t *testing.T) {
 
 func TestDigitalOceanAsDocViaCheckout(t *testing.T) {
 	// this is a full checkout of the digitalocean API repo.
-	tmp, _ := os.MkdirTemp("", "openapi")
+	tmp := t.TempDir()
 	cmd := exec.Command("git", "clone", "https://github.com/digitalocean/openapi", tmp)
-	defer os.RemoveAll(filepath.Join(tmp, "openapi"))
 
 	err := cmd.Run()
 	if err != nil {

--- a/index/rolodex_file_loader.go
+++ b/index/rolodex_file_loader.go
@@ -437,18 +437,18 @@ func (l *LocalFS) extractFile(p string) (*LocalFile, error) {
 	switch extension {
 	case YAML, JSON, JS, GO, TS, CS, C, CPP, PHP, PY, HTML, MD, JAVA, RS, ZIG, RB:
 		var file fs.File
-		var fileError error
 		if config != nil && config.DirFS != nil {
 			l.logger.Debug("[rolodex file loader]: collecting file from dirFS", "file", extension, "location", abs)
 			file, _ = config.DirFS.Open(p)
 		} else {
 			l.logger.Debug("[rolodex file loader]: reading local file from OS", "file", extension, "location", abs)
+			var fileError error
 			file, fileError = os.Open(abs)
-		}
-
-		// if reading without a directory FS, error out on any error, do not continue.
-		if fileError != nil {
-			return nil, fileError
+			// if reading without a directory FS, error out on any error, do not continue.
+			if fileError != nil {
+				return nil, fileError
+			}
+			defer file.Close()
 		}
 
 		modTime := time.Now()

--- a/index/spec_index_test.go
+++ b/index/spec_index_test.go
@@ -270,9 +270,8 @@ func TestSpecIndex_Redocly(t *testing.T) {
 
 func TestSpecIndex_DigitalOcean_FullCheckoutLocalResolve(t *testing.T) {
 	// this is a full checkout of the digitalocean API repo.
-	tmp, _ := os.MkdirTemp("", "openapi")
+	tmp := t.TempDir()
 	cmd := exec.Command("git", "clone", "https://github.com/digitalocean/openapi", tmp)
-	defer os.RemoveAll(filepath.Join(tmp, "openapi"))
 
 	err := cmd.Run()
 	if err != nil {
@@ -352,9 +351,8 @@ func TestSpecIndex_DigitalOcean_FullCheckoutLocalResolve(t *testing.T) {
 
 func TestSpecIndex_DigitalOcean_FullCheckoutLocalResolve_RecursiveLookup(t *testing.T) {
 	// this is a full checkout of the digitalocean API repo.
-	tmp, _ := os.MkdirTemp("", "openapi")
+	tmp := t.TempDir()
 	cmd := exec.Command("git", "clone", "https://github.com/digitalocean/openapi", tmp)
-	defer os.RemoveAll(filepath.Join(tmp, "openapi"))
 
 	err := cmd.Run()
 	if err != nil {

--- a/renderer/schema_renderer.go
+++ b/renderer/schema_renderer.go
@@ -482,7 +482,9 @@ func (wr *SchemaRenderer) DiveIntoSchema(schema *base.Schema, key string, struct
 	return true
 }
 
-func readFile(file io.Reader) []string {
+func readFile(file io.ReadCloser) []string {
+	defer file.Close()
+
 	bytes, err := io.ReadAll(file)
 	if err != nil {
 		return []string{}

--- a/renderer/schema_renderer_test.go
+++ b/renderer/schema_renderer_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/url"
 	"os"
 	"regexp"
@@ -2179,8 +2180,12 @@ func TestReadDictionary(t *testing.T) {
 
 func TestCreateFakeDictionary(t *testing.T) {
 	// create a temp file and create a simple temp dictionary
-	tmpFile, _ := os.CreateTemp("", "pb33f")
+	tmpFile, err := os.CreateTemp("", "pb33f")
+	if err != nil {
+		t.Fatal(err)
+	}
 	tmpFile.Write([]byte("one\nfive\nthree"))
+	defer tmpFile.Close()
 	words := ReadDictionary(tmpFile.Name())
 	renderer := CreateRendererUsingDictionary(tmpFile.Name())
 	assert.Len(t, words, 3)
@@ -2202,7 +2207,7 @@ func (errReader) Read(p []byte) (n int, err error) {
 }
 
 func TestReadDictionary_BadReader(t *testing.T) {
-	words := readFile(errReader(0))
+	words := readFile(io.NopCloser(errReader(0)))
 	assert.LessOrEqual(t, len(words), 0)
 }
 


### PR DESCRIPTION
The PR refactors tests with [`t.TempDir`](https://pkg.go.dev/testing#T.TempDir):

> TempDir returns a temporary directory for the test to use. The directory is automatically removed when the test and all its subtests complete. Each subsequent call to t.TempDir returns a unique directory; if the directory creation fails, TempDir terminates the test by calling Fatal.

Additionally, this PR fixes an issue where a file was not being closed.