### PR TITLE
Add SetSeed method to MockGenerator and SchemaRenderer for Deterministic Output

### DIFF
--- a/renderer/mock_generator.go
+++ b/renderer/mock_generator.go
@@ -69,6 +69,12 @@ func (mg *MockGenerator) DisableRequiredCheck() {
 	mg.renderer.DisableRequiredCheck()
 }
 
+// SetSeed sets a specific seed for the random number generator used by this mock generator.
+// This is useful for generating deterministic mocks for testing purposes.
+func (mg *MockGenerator) SetSeed(seed int64) {
+	mg.renderer.SetSeed(seed)
+}
+
 // GenerateMock generates a mock for a given high-level mockable struct. The mockable struct must contain the following fields:
 // Example: any type, this is the default example to use if no examples are present.
 // Examples: *orderedmap.Map[string, *base.Example], this is a map of examples keyed by name.

--- a/renderer/mock_generator_test.go
+++ b/renderer/mock_generator_test.go
@@ -485,3 +485,41 @@ properties:
 		})
 	}
 }
+
+func TestMockGenerator_SetSeed_Deterministic(t *testing.T) {
+	objectSchema := `type: object
+properties:
+  name:
+    type: string
+    minLength: 5
+    maxLength: 10
+  age:
+    type: integer
+    minimum: 18
+    maximum: 99`
+
+	fake := createFakeMock(objectSchema, nil, nil)
+
+	// Generate two mocks with the same seed
+	mg1 := NewMockGenerator(JSON)
+	mg1.SetSeed(42)
+	mock1, err := mg1.GenerateMock(fake, "")
+	assert.NoError(t, err)
+
+	mg2 := NewMockGenerator(JSON)
+	mg2.SetSeed(42)
+	mock2, err := mg2.GenerateMock(fake, "")
+	assert.NoError(t, err)
+
+	// They should be identical
+	assert.Equal(t, string(mock1), string(mock2))
+
+	// Generate a third mock with a different seed
+	mg3 := NewMockGenerator(JSON)
+	mg3.SetSeed(123)
+	mock3, err := mg3.GenerateMock(fake, "")
+	assert.NoError(t, err)
+
+	// It should be different from the first two
+	assert.NotEqual(t, string(mock1), string(mock3))
+}

--- a/renderer/schema_renderer_test.go
+++ b/renderer/schema_renderer_test.go
@@ -2304,3 +2304,41 @@ properties:
 	loopMe(root, 0)
 	return root
 }
+
+func TestSchemaRenderer_SetSeed_Deterministic(t *testing.T) {
+	testObject := `type: object
+properties:
+  name:
+    type: string
+    minLength: 5
+    maxLength: 10
+  age:
+    type: integer
+    minimum: 18
+    maximum: 99`
+
+	compiled := getSchema([]byte(testObject))
+
+	// Generate two schemas with the same seed
+	wr1 := CreateRendererUsingDefaultDictionary()
+	wr1.SetSeed(42)
+	schema1 := wr1.RenderSchema(compiled)
+	rendered1, _ := json.Marshal(schema1)
+
+	wr2 := CreateRendererUsingDefaultDictionary()
+	wr2.SetSeed(42)
+	schema2 := wr2.RenderSchema(compiled)
+	rendered2, _ := json.Marshal(schema2)
+
+	// They should be identical
+	assert.Equal(t, string(rendered1), string(rendered2))
+
+	// Generate a third schema with a different seed
+	wr3 := CreateRendererUsingDefaultDictionary()
+	wr3.SetSeed(123)
+	schema3 := wr3.RenderSchema(compiled)
+	rendered3, _ := json.Marshal(schema3)
+
+	// It should be different from the first two
+	assert.NotEqual(t, string(rendered1), string(rendered3))
+}


### PR DESCRIPTION
- Add SetSeed() method to SchemaRenderer to allow setting custom random seed
- Add SetSeed() method to MockGenerator that delegates to underlying renderer
- Replace global rand usage with instance-based *rand.Rand in SchemaRenderer
- Update all rand.* calls to use instance-specific random source

This enables deterministic mock generation for testing purposes while keeping existing random behavior by default.

Some background, the random behavior was convenient but made certain generation scenarios a bit hard to test. If this isn't something you think is needed lmk it's not a big deal either way