### PR TITLE
Fix swapped LeftNode and RightNode in exclusiveMaximum PropertyCheck

### DIFF
--- a/what-changed/model/schema.go
+++ b/what-changed/model/schema.go
@@ -761,8 +761,8 @@ func checkSchemaPropertyChanges(
 	}
 	// ExclusiveMaximum
 	props = append(props, &PropertyCheck{
-		LeftNode:  rnv,
-		RightNode: lnv,
+		LeftNode:  lnv,
+		RightNode: rnv,
 		Label:     v3.ExclusiveMaximumLabel,
 		Changes:   changes,
 		Breaking:  true,


### PR DESCRIPTION
Fixes issue where LeftNode was assigned rnv and RightNode was assigned lnv, causing incorrect node references in change detection for exclusiveMaximum property comparisons.

Addresses #451