### PR TITLE
add StrictValidation to BundleCompositionConfig to support more user friendly errors on invalid specs

### DIFF
--- a/bundler/bundler.go
+++ b/bundler/bundler.go
@@ -114,7 +114,8 @@ func BundleDocumentWithConfig(model *v3.Document, bundleConfig *BundleInlineConf
 
 // BundleCompositionConfig is used to configure the composition of OpenAPI documents when using BundleDocumentComposed.
 type BundleCompositionConfig struct {
-	Delimiter string // Delimiter is used to separate clashing names. Defaults to `__`.
+	Delimiter           string // Delimiter is used to separate clashing names. Defaults to `__`.
+	StrictValidation    bool   // StrictValidation will cause bundling to fail on invalid OpenAPI specs (e.g. $ref with siblings)
 }
 
 // BundleInlineConfig provides configuration options for inline bundling.
@@ -174,7 +175,9 @@ func compose(model *v3.Document, compositionConfig *BundleCompositionConfig) ([]
 		compositionConfig:     compositionConfig,
 		discriminatorMappings: discriminatorMappings,
 	}
-	handleIndex(cf)
+	if err := handleIndex(cf); err != nil {
+		return nil, err
+	}
 
 	processedNodes := orderedmap.New[string, *processRef]()
 	var errs []error

--- a/bundler/bundler_strict_validation_test.go
+++ b/bundler/bundler_strict_validation_test.go
@@ -1,0 +1,236 @@
+package bundler
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pb33f/libopenapi/datamodel"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStrictValidation_RefWithSiblings_ShouldError(t *testing.T) {
+	spec := `openapi: 3.0.0
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /test:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TestSchema'
+                description: This is invalid - $ref cannot have siblings
+components:
+  schemas:
+    TestSchema:
+      type: object
+      properties:
+        name:
+          type: string`
+
+	config := &BundleCompositionConfig{
+		StrictValidation: true,
+	}
+
+	docConfig := &datamodel.DocumentConfiguration{
+		AllowFileReferences: false,
+	}
+
+	_, err := BundleBytesComposed([]byte(spec), docConfig, config)
+
+	require.Error(t, err, "Strict validation must fail on invalid $ref siblings for 3.0 specs")
+	assert.Contains(
+		t,
+		err.Error(),
+		"invalid OpenAPI 3.0 specification: $ref cannot have sibling properties",
+	)
+	assert.Contains(t, err.Error(), "siblings [description]")
+	assert.Contains(t, err.Error(), "line 14")
+	assert.Contains(t, err.Error(), "column 17")
+}
+
+func TestStrictValidation_RefWithoutSiblings_ShouldSucceed(t *testing.T) {
+	spec := `openapi: 3.0.0
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /test:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TestSchema'
+components:
+  schemas:
+    TestSchema:
+      type: object
+      properties:
+        name:
+          type: string`
+
+	config := &BundleCompositionConfig{
+		StrictValidation: true,
+	}
+
+	docConfig := &datamodel.DocumentConfiguration{
+		AllowFileReferences: false,
+	}
+
+	result, err := BundleBytesComposed([]byte(spec), docConfig, config)
+
+	require.NoError(t, err, "Valid $ref without siblings should succeed")
+	assert.NotNil(t, result)
+	assert.True(t, len(result) > 0)
+}
+
+func TestStrictValidation_Disabled_ShouldNotError(t *testing.T) {
+	spec := `openapi: 3.0.0
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /test:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TestSchema'
+                description: This would be invalid with strict validation
+components:
+  schemas:
+    TestSchema:
+      type: object
+      properties:
+        name:
+          type: string`
+
+	config := &BundleCompositionConfig{
+		StrictValidation: false, // Disabled - should not error
+	}
+
+	docConfig := &datamodel.DocumentConfiguration{
+		AllowFileReferences: false,
+	}
+
+	result, err := BundleBytesComposed([]byte(spec), docConfig, config)
+
+	require.NoError(t, err, "Disabled strict validation should allow invalid siblings")
+	assert.NotNil(t, result)
+}
+
+func TestStrictValidation_openapi_3_1_ShouldNotError(t *testing.T) {
+	spec := `openapi: 3.1.0
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /test:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TestSchema'
+                description: This is valid with strict validation in 3.1 spec
+components:
+  schemas:
+    TestSchema:
+      type: object
+      properties:
+        name:
+          type: string`
+
+	config := &BundleCompositionConfig{
+		StrictValidation: true,
+	}
+
+	docConfig := &datamodel.DocumentConfiguration{
+		AllowFileReferences: false,
+	}
+
+	result, err := BundleBytesComposed([]byte(spec), docConfig, config)
+
+	require.NoError(t, err, "Strict validation in OpenAPI 3.1 spec should allow invalid siblings")
+	assert.NotNil(t, result)
+}
+
+func TestStrictValidation_RecursiveIndexError(t *testing.T) {
+	spec := `openapi: 3.0.0
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /test:
+    get:
+      responses:
+        '200':
+          $ref: 'external.yaml#/components/responses/TestResponse'
+components:
+  schemas:
+    TestSchema:
+      type: object`
+
+	external := `openapi: 3.0.0
+components:
+  responses:
+    TestResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ExternalSchema'
+            description: Invalid sibling property
+  schemas:
+    ExternalSchema:
+      type: object
+      properties:
+        name:
+          type: string`
+
+	tmp := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(tmp, "main.yaml"), []byte(spec), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(tmp, "external.yaml"), []byte(external), 0o644))
+
+	mainBytes, err := os.ReadFile(filepath.Join(tmp, "main.yaml"))
+	require.NoError(t, err)
+
+	config := &BundleCompositionConfig{
+		StrictValidation: true,
+	}
+
+	docConfig := &datamodel.DocumentConfiguration{
+		BasePath:            tmp,
+		AllowFileReferences: true,
+	}
+
+	_, err = BundleBytesComposed(mainBytes, docConfig, config)
+	require.Error(t, err)
+
+	assert.Contains(
+		t,
+		err.Error(),
+		"invalid OpenAPI 3.0 specification: $ref cannot have sibling properties",
+	)
+}
+
+func TestBundleCompositionConfig_DefaultValues(t *testing.T) {
+	config := &BundleCompositionConfig{}
+	assert.False(t, config.StrictValidation)
+	assert.Empty(t, config.Delimiter)
+}


### PR DESCRIPTION
Add a `StrictValidation` field to `BundleCompositionConfig` to handle reporting errors when trying to compose the bundle.

### Scenario

I've run into an issue using the bundler, where an invalid spec was causing a confusing error which states a file did not exist, if a component was trying to refer to another component whilst including an invalid sibling ref node, i.e.:

spec:
```yaml
openapi: 3.0.0
info:
  title: Historical Shipping Option Repro
  version: 1.0.0
paths:
  /shipments:
    post:
      requestBody:
        required: true
        content:
          application/json:
            schema:
              $ref: ./components/HistoricalShippingOption.json
      responses:
        '200':
          description: ok
```

./components/CountryCode.json
```json
{
  "type": "string",
  "description": "Country code in ISO 3166 ALPHA-2 format",
  "enum": [
    "US",
    "CA",
    "GB",
    "DE",
    "FR"
  ]
}
```

./components/HistoricalShippingOption.json
```json
{
  "title": "HistoricalShippingOption",
  "type": "object",
  "properties": {
    "country_code": {
      "$ref": "CountryCode.json",
      "description": "this should not be here"
    }
  },
  "required": [
    "country_code"
  ]
}
```

> [!WARNING] 
> This is invalid, the `country_code` property should **not** have a `description` with the `$ref`.
> 
> Deleting this description key fixes everything, but teams using this have been confused by how this error is reported.

The bundle gets created incorrectly, and linting then says `rolodex count not find file` for the external ref `CountryCode.json`, which is confusing as it's not that the file can't be found, it's the input is invalid.

Example code for bundling:
```go
	docConfig := &datamodel.DocumentConfiguration{
		AllowFileReferences:       true,
		AllowRemoteReferences:     true,
		BasePath:                  c.basePath,
		BundleInlineRefs:          false,
		ExtractRefsSequentially:   true,
		Logger:                    slogLogger,
		MergeReferencedProperties: false,
		RecomposeRefs:             true,
		SpecFilePath:              c.inputFile,
	}

	compositionConfig := &bundler.BundleCompositionConfig{
		Delimiter: "__",
	}

	bundled, err := bundler.BundleBytesComposed(
		specBytes,
		docConfig,
		compositionConfig,
	)
```

When I build with these changes and enable the `StrictValidation` my specific error gets flagged, which avoids the confusion of the file not found errors that are currently flagged.