### PR TITLE
support escaping openapi key words with quotes

### DIFF
--- a/bundler/detect_type.go
+++ b/bundler/detect_type.go
@@ -149,6 +149,7 @@ func hasPathItemProperties(node *yaml.Node) bool {
 }
 
 // Helper function to get all keys from a mapping node
+// Excludes quoted keys since they should be treated as literal strings, not OpenAPI keywords
 func getNodeKeys(node *yaml.Node) []string {
 	if node.Kind != yaml.MappingNode {
 		return nil
@@ -157,7 +158,12 @@ func getNodeKeys(node *yaml.Node) []string {
 	var keys []string
 	for i := 0; i < len(node.Content); i += 2 {
 		if i < len(node.Content) {
-			keys = append(keys, node.Content[i].Value)
+			keyNode := node.Content[i]
+			// Skip quoted keys - they should not be treated as OpenAPI keywords
+			if keyNode.Style == yaml.SingleQuotedStyle || keyNode.Style == yaml.DoubleQuotedStyle {
+				continue
+			}
+			keys = append(keys, keyNode.Value)
 		}
 	}
 	return keys


### PR DESCRIPTION
Me again with an edge-casey one.

Example schemas that use openapi keywords don't get in-lined during bundling, so give this spec:
```yaml
openapi: 3.0.0
info:
  title: Test API
  version: 1.0.0
paths:
  /test:
    get:
      responses:
        '200':
          description: Success
          content:
            application/json:
              example:
                $ref: './example.yaml'
```
and the external example ref:
```yaml
"items":
  - id: 1
    name: "test"
  - id: 2
    name: "example"
```

This gets bundled as:
```yaml
components:
  schemas:
    example:
      items: {}
```
Items is an empty object, so the example is lost.

The usual way of handling reserved words in yaml is quoting them, however this isn't currently handled by the bundling so quoting the `items` key makes no difference. 

So, I've added logic to `getNodeKeys` to check if the node is quoted, which means after this change the above example gets properly inlined, like:
```yaml
paths:
  /test:
    get:
      responses:
        '200':
          description: Success
          content:
            application/json:
              example:
                'items':
                  - id: 1
                    name: "test"
                  - id: 2
                    name: "example"
```

So now if someone has an example which contains a field using an openapi keyword, they can quote it, and it will get properly bundled.