### PR TITLE
Demonstrate problem with external ref skipping

### DIFF
--- a/document_examples_test.go
+++ b/document_examples_test.go
@@ -19,13 +19,12 @@ import (
 	"github.com/pb33f/libopenapi/index"
 	"github.com/pb33f/libopenapi/orderedmap"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/pb33f/libopenapi/datamodel/high"
 	v3high "github.com/pb33f/libopenapi/datamodel/high/v3"
 	low "github.com/pb33f/libopenapi/datamodel/low/base"
 	v3 "github.com/pb33f/libopenapi/datamodel/low/v3"
 	"github.com/pb33f/libopenapi/utils"
+	"github.com/stretchr/testify/assert"
 )
 
 func ExampleNewDocument_fromOpenAPI3Document() {
@@ -701,11 +700,12 @@ components:
           $ref: './models/product.yaml'
         customer:
           $ref: 'https://example.com/schemas/customer.yaml'
-		warehouse:
-          $ref: 'https://example.com/schemas/supplier.yaml#/components/schemas/Warehouse'
+        warehouse:
+          $ref: 'https://example.com/schemas/warehouse.yaml#/components/schemas/Warehouse'
       required:
         - id
         - product
+        - warehouse
     Pet:
       $ref: './models/pet.yaml'
     ErrorResponse:


### PR DESCRIPTION
This is an example of where the fix for issue #519 fails. External references often have fragments after the external reference to pull in a specific schema.