### PR TITLE
fix: use NewDocumentConfiguration() as default config in BuildV3Model

### DIFF
--- a/document.go
+++ b/document.go
@@ -309,12 +309,7 @@ func (d *document) BuildV3Model() (*DocumentModel[v3high.Document], error) {
 
 	var lowDoc *v3low.Document
 	if d.config == nil {
-		d.config = &datamodel.DocumentConfiguration{
-			AllowFileReferences:   false,
-			BasePath:              "",
-			AllowRemoteReferences: false,
-			BaseURL:               nil,
-		}
+		d.config = datamodel.NewDocumentConfiguration()
 	}
 
 	var docErr error


### PR DESCRIPTION
When calling NewDocument() (without explicit configuration), BuildV3Model() was creating a bare DocumentConfiguration struct literal as the fallback. This meant all bool fields defaulted to false (Go zero values), causing TransformSiblingRefs and MergeReferencedProperties to be silently disabled.

BuildV2Model() already correctly uses datamodel.NewDocumentConfiguration() as its fallback. This aligns BuildV3Model() to do the same, ensuring features like sibling $ref -> allOf transformation are enabled by default regardless of which NewDocument constructor is used.

Fixes: https://github.com/pb33f/libopenapi/issues/90