### PR TITLE
Added new top level ClearAllCaches()

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -1,0 +1,25 @@
+// Copyright 2022-2026 Princess B33f Heavy Industries / Dave Shanley
+// SPDX-License-Identifier: MIT
+
+package libopenapi
+
+import (
+	highbase "github.com/pb33f/libopenapi/datamodel/high/base"
+	"github.com/pb33f/libopenapi/datamodel/low"
+	lowbase "github.com/pb33f/libopenapi/datamodel/low/base"
+	"github.com/pb33f/libopenapi/index"
+	"github.com/pb33f/libopenapi/utils"
+)
+
+// ClearAllCaches resets every global in-process cache in libopenapi.
+// Call this between document lifecycles in long-running processes
+// (servers, CLI tools that process many specs) to release memory that
+// would otherwise accumulate and never be garbage-collected.
+func ClearAllCaches() {
+	low.ClearHashCache()              // hashCache + indexCollectionCache
+	lowbase.ClearSchemaQuickHashMap() // SchemaQuickHashMap
+	index.ClearHashCache()            // nodeHashCache
+	index.ClearContentDetectionCache()
+	highbase.ClearInlineRenderingTracker()
+	utils.ClearJSONPathCache()
+}

--- a/cache_test.go
+++ b/cache_test.go
@@ -1,0 +1,16 @@
+// Copyright 2022-2026 Princess B33f Heavy Industries / Dave Shanley
+// SPDX-License-Identifier: MIT
+
+package libopenapi
+
+import (
+	"testing"
+)
+
+func TestClearAllCaches(t *testing.T) {
+	// ClearAllCaches should not panic when called on empty caches.
+	ClearAllCaches()
+
+	// Call twice to ensure idempotency.
+	ClearAllCaches()
+}

--- a/datamodel/high/base/schema_proxy.go
+++ b/datamodel/high/base/schema_proxy.go
@@ -38,6 +38,15 @@ func buildCacheKey(path string, line, col int) string {
 // so sync.Map's internal sharding reduces contention compared to a single mutex.
 var inlineRenderingTracker sync.Map
 
+// ClearInlineRenderingTracker resets the inline rendering tracker.
+// Call this between document lifecycles in long-running processes to bound memory.
+func ClearInlineRenderingTracker() {
+	inlineRenderingTracker.Range(func(key, _ interface{}) bool {
+		inlineRenderingTracker.Delete(key)
+		return true
+	})
+}
+
 // bundlingModeCount tracks the number of active bundling operations.
 // Uses reference counting to support concurrent BundleDocument calls safely.
 //

--- a/datamodel/high/base/schema_proxy_test.go
+++ b/datamodel/high/base/schema_proxy_test.go
@@ -1389,3 +1389,20 @@ func TestInlineRenderContext_ModePreservedDuringOperations(t *testing.T) {
 	ctx.StopRendering("test-key")
 	assert.Equal(t, RenderingModeValidation, ctx.Mode)
 }
+
+func TestClearInlineRenderingTracker(t *testing.T) {
+	// Store a value.
+	inlineRenderingTracker.Store("test-key", true)
+
+	// Verify it's there.
+	_, ok := inlineRenderingTracker.Load("test-key")
+	assert.True(t, ok)
+
+	// Clear and verify it's gone.
+	ClearInlineRenderingTracker()
+	_, ok = inlineRenderingTracker.Load("test-key")
+	assert.False(t, ok)
+
+	// Idempotent: clearing an empty map should not panic.
+	ClearInlineRenderingTracker()
+}

--- a/datamodel/low/base/schema.go
+++ b/datamodel/low/base/schema.go
@@ -195,6 +195,15 @@ func (s *Schema) Hash() uint64 {
 // The hash map means each schema is hashed once, and then the hash is reused for quick equality checking.
 var SchemaQuickHashMap sync.Map
 
+// ClearSchemaQuickHashMap resets the schema quick-hash cache.
+// Call this between document lifecycles in long-running processes to bound memory.
+func ClearSchemaQuickHashMap() {
+	SchemaQuickHashMap.Range(func(key, _ interface{}) bool {
+		SchemaQuickHashMap.Delete(key)
+		return true
+	})
+}
+
 func (s *Schema) hash(quick bool) uint64 {
 	if s == nil {
 		return 0

--- a/datamodel/low/base/schema_test.go
+++ b/datamodel/low/base/schema_test.go
@@ -2,7 +2,6 @@ package base
 
 import (
 	"context"
-	"sync"
 	"testing"
 	timeStd "time"
 
@@ -1983,7 +1982,7 @@ func TestSchema_Hash_Empty(t *testing.T) {
 }
 
 func TestSetup(t *testing.T) {
-	SchemaQuickHashMap = sync.Map{}
+	ClearSchemaQuickHashMap()
 }
 
 func TestSchema_QuickHash(t *testing.T) {
@@ -3205,4 +3204,21 @@ func TestExtractSchema_SchemaKeyRef_SkipExternalRef(t *testing.T) {
 	assert.Equal(t, "./models/Pet.yaml#/Pet", result.Value.GetReference())
 	assert.Nil(t, result.Value.Schema())
 	assert.Nil(t, result.Value.GetBuildError())
+}
+
+func TestClearSchemaQuickHashMap(t *testing.T) {
+	// Store a value.
+	SchemaQuickHashMap.Store("test-key", "test-value")
+
+	// Verify it's there.
+	_, ok := SchemaQuickHashMap.Load("test-key")
+	assert.True(t, ok)
+
+	// Clear and verify it's gone.
+	ClearSchemaQuickHashMap()
+	_, ok = SchemaQuickHashMap.Load("test-key")
+	assert.False(t, ok)
+
+	// Idempotent: clearing an empty map should not panic.
+	ClearSchemaQuickHashMap()
 }

--- a/datamodel/low/extraction_functions.go
+++ b/datamodel/low/extraction_functions.go
@@ -46,8 +46,14 @@ var ErrExternalRefSkipped = errors.New("external reference resolution skipped")
 // ClearHashCache clears the global hash cache. This should be called before
 // starting a new document comparison to ensure clean state.
 func ClearHashCache() {
-	hashCache = sync.Map{}
-	indexCollectionCache = sync.Map{}
+	hashCache.Range(func(key, _ interface{}) bool {
+		hashCache.Delete(key)
+		return true
+	})
+	indexCollectionCache.Range(func(key, _ interface{}) bool {
+		indexCollectionCache.Delete(key)
+		return true
+	})
 }
 
 // GetStringBuilder retrieves a strings.Builder from the pool, resets it, and returns it.

--- a/index/enhanced_coverage_test.go
+++ b/index/enhanced_coverage_test.go
@@ -103,7 +103,7 @@ other: test`,
 	})
 
 	t.Run("DetectRemoteContentType with caching", func(t *testing.T) {
-		clearContentDetectionCache()
+		ClearContentDetectionCache()
 
 		// Test cache miss and population
 		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
@@ -129,7 +129,7 @@ other: test`,
 	})
 
 	t.Run("Content detection with unsupported result", func(t *testing.T) {
-		clearContentDetectionCache()
+		ClearContentDetectionCache()
 
 		config := CreateOpenAPIIndexConfig()
 		config.AllowUnknownExtensionContentDetection = true

--- a/index/issue438_test.go
+++ b/index/issue438_test.go
@@ -79,7 +79,7 @@ components:
 		require.NoError(t, err)
 
 		// Clear cache to ensure fresh detection
-		clearContentDetectionCache()
+		ClearContentDetectionCache()
 
 		file, err := rfs.Open(server.URL + "/yaml-no-ext")
 		assert.NoError(t, err)
@@ -99,7 +99,7 @@ components:
 		require.NoError(t, err)
 
 		// Clear cache to ensure fresh detection
-		clearContentDetectionCache()
+		ClearContentDetectionCache()
 
 		file, err := rfs.Open(server.URL + "/json-no-ext")
 		assert.NoError(t, err)
@@ -119,7 +119,7 @@ components:
 		require.NoError(t, err)
 
 		// Clear cache to ensure fresh detection
-		clearContentDetectionCache()
+		ClearContentDetectionCache()
 
 		file, err := rfs.Open(server.URL + "/yaml-no-ext")
 		assert.Error(t, err)
@@ -134,7 +134,7 @@ components:
 		require.NoError(t, err)
 
 		// Clear cache to ensure fresh detection
-		clearContentDetectionCache()
+		ClearContentDetectionCache()
 
 		file, err := rfs.Open(server.URL + "/invalid-content")
 		assert.Error(t, err)
@@ -149,7 +149,7 @@ components:
 		require.NoError(t, err)
 
 		// Clear cache to ensure fresh detection
-		clearContentDetectionCache()
+		ClearContentDetectionCache()
 
 		file, err := rfs.Open(server.URL + "/binary-content")
 		assert.Error(t, err)
@@ -366,7 +366,7 @@ func TestContentDetectionCache(t *testing.T) {
 	require.NoError(t, err)
 
 	// Clear cache
-	clearContentDetectionCache()
+	ClearContentDetectionCache()
 
 	url := server.URL + "/test"
 
@@ -379,7 +379,7 @@ func TestContentDetectionCache(t *testing.T) {
 	assert.Equal(t, YAML, result2)
 
 	// Clear cache and verify it's cleared
-	clearContentDetectionCache()
+	ClearContentDetectionCache()
 
 	// Verify cache is actually cleared by checking if we can detect again
 	result3 := detectRemoteContentType(url, rfs.RemoteHandlerFunc, nil)
@@ -425,7 +425,7 @@ func TestIssue438_PastebinExample(t *testing.T) {
 		require.NoError(t, err)
 
 		// Clear cache
-		clearContentDetectionCache()
+		ClearContentDetectionCache()
 
 		// This URL has no file extension, mimicking the Pastebin example
 		file, err := rfs.Open(server.URL + "/raw/LAvtwJn6")
@@ -447,7 +447,7 @@ func TestIssue438_PastebinExample(t *testing.T) {
 		require.NoError(t, err)
 
 		// Clear cache
-		clearContentDetectionCache()
+		ClearContentDetectionCache()
 
 		file, err := rfs.Open(server.URL + "/raw/LAvtwJn6")
 		assert.Error(t, err)

--- a/index/rolodex_remote_loader.go
+++ b/index/rolodex_remote_loader.go
@@ -230,8 +230,9 @@ func detectRemoteContentType(url string, handler utils.RemoteURLHandler, logger 
 	return detectedType
 }
 
-// clearContentDetectionCache clears the content detection cache
-func clearContentDetectionCache() {
+// ClearContentDetectionCache clears the content detection cache.
+// Call this between document lifecycles in long-running processes to bound memory.
+func ClearContentDetectionCache() {
 	contentDetectionMutex.Lock()
 	contentDetectionCache = make(map[string]FileExtension)
 	contentDetectionMutex.Unlock()

--- a/index/rolodex_remote_loader_deep_test.go
+++ b/index/rolodex_remote_loader_deep_test.go
@@ -161,7 +161,7 @@ func TestFetchWithRetryComprehensive(t *testing.T) {
 // TestDetectRemoteContentTypeComprehensive tests caching and error scenarios
 func TestDetectRemoteContentTypeComprehensive(t *testing.T) {
 	// Clear cache before test
-	clearContentDetectionCache()
+	ClearContentDetectionCache()
 
 	t.Run("Network error that gets cached", func(t *testing.T) {
 		handler := func(url string) (*http.Response, error) {
@@ -199,7 +199,7 @@ func TestDetectRemoteContentTypeComprehensive(t *testing.T) {
 	})
 
 	// Clear cache after test
-	clearContentDetectionCache()
+	ClearContentDetectionCache()
 }
 
 // TestRemoteFSOpenWithContextComprehensive tests all edge cases for the main OpenWithContext method

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -50,6 +50,15 @@ type cachedJSONPath struct {
 // jsonPathCache stores compiled JSONPath expressions keyed by normalized string.
 var jsonPathCache sync.Map
 
+// ClearJSONPathCache resets the compiled JSONPath cache.
+// Call this between document lifecycles in long-running processes to bound memory.
+func ClearJSONPathCache() {
+	jsonPathCache.Range(func(key, _ interface{}) bool {
+		jsonPathCache.Delete(key)
+		return true
+	})
+}
+
 var jsonPathQuery = func(path *jsonpath.JSONPath, node *yaml.Node) []*yaml.Node {
 	return path.Query(node)
 }

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -57,8 +57,31 @@ func TestFindNodes_BadPath(t *testing.T) {
 	assert.Nil(t, nodes)
 }
 
+func TestClearJSONPathCache(t *testing.T) {
+	// populate the cache
+	_, _ = getJSONPath("$.info.contact")
+	_, _ = getJSONPath("$.paths")
+
+	// verify entries exist
+	count := 0
+	jsonPathCache.Range(func(_, _ interface{}) bool { count++; return true })
+	assert.GreaterOrEqual(t, count, 2)
+
+	// clear and verify empty
+	ClearJSONPathCache()
+
+	count = 0
+	jsonPathCache.Range(func(_, _ interface{}) bool { count++; return true })
+	assert.Equal(t, 0, count)
+
+	// verify cache still works after clearing
+	p, err := getJSONPath("$.info.contact")
+	assert.NoError(t, err)
+	assert.NotNil(t, p)
+}
+
 func TestGetJSONPath_CacheHit(t *testing.T) {
-	jsonPathCache = sync.Map{}
+	ClearJSONPathCache()
 
 	path1, err := getJSONPath("$.info.contact")
 	assert.NoError(t, err)
@@ -70,7 +93,7 @@ func TestGetJSONPath_CacheHit(t *testing.T) {
 }
 
 func TestGetJSONPath_CacheHit_Invalid(t *testing.T) {
-	jsonPathCache = sync.Map{}
+	ClearJSONPathCache()
 
 	path1, err := getJSONPath("I am not valid")
 	assert.Error(t, err)


### PR DESCRIPTION
```go
// ClearAllCaches resets every global in-process cache in libopenapi.
// Call this between document lifecycles in long-running processes
// (servers, CLI tools that process many specs) to release memory that
// would otherwise accumulate and never be garbage-collected.
func ClearAllCaches() {
```