### PR TITLE
Potential fix for code scanning alert no. 28: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   buildWindows:
     name: Build Windows


### PR DESCRIPTION
Potential fix for [https://github.com/pb33f/libopenapi/security/code-scanning/28](https://github.com/pb33f/libopenapi/security/code-scanning/28)

Generally, the fix is to explicitly declare a `permissions` block that grants only the scopes needed by the workflow. Since this workflow only checks out code and runs Go tests plus an external Codecov action (which uses its own secret token), it only needs read access to repository contents. The simplest, least-privilege fix is to set `permissions: contents: read` at the root of the workflow so it applies to both `buildWindows` and `build` jobs, without changing any job behavior.

Concretely, edit `.github/workflows/build.yaml` to insert a `permissions:` section near the top-level (e.g., after the `on:` block and before `jobs:`). Set `contents: read` as the only permission. No other changes, imports, or definitions are required, and no job-specific `permissions` blocks are necessary unless future steps need broader scopes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
