### PR TITLE
Potential fix for code scanning alert no. 27: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,5 +1,8 @@
 name: Build
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/pb33f/libopenapi/security/code-scanning/27](https://github.com/pb33f/libopenapi/security/code-scanning/27)

In general, the problem is solved by explicitly defining a `permissions` block either at the workflow root (to apply to all jobs) or per job, and setting the minimal needed scopes (typically `contents: read` for simple build/test workflows). This prevents the jobs from inheriting potentially broad default permissions such as `contents: write`.

For this workflow, the simplest and safest fix that preserves existing behavior is to add a workflow‑level `permissions` section right after the `name: Build` line. The jobs only need to check out the repository and run Go commands; they do not push commits, modify issues, or manage PRs. The Codecov action uses its own `CODECOV_TOKEN` secret and does not require GitHub write permissions. Therefore, setting `permissions: contents: read` at the top level is sufficient and minimal. No other code or steps need to be changed.

Concretely, edit `.github/workflows/build.yaml` and insert:

```yaml
permissions:
  contents: read
```

between the existing `name: Build` line and the `on:` block. This applies the restricted permissions to both `buildWindows` and `build` jobs and directly addresses the CodeQL alert.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
