### PR TITLE
fix(v3): don't inject empty `webhooks: {}` for OpenAPI 3.0 docs with a same-named scalar value

### DIFF
--- a/datamodel/low/v3/create_document.go
+++ b/datamodel/low/v3/create_document.go
@@ -483,6 +483,11 @@ func extractPaths(ctx context.Context, root *yaml.Node, nodes documentTopLevelNo
 }
 
 func extractWebhooks(ctx context.Context, root *yaml.Node, nodes documentTopLevelNodes, doc *Document, idx *index.SpecIndex) error {
+	// without a genuine top-level key, ExtractMap can match a same-named scalar
+	// (e.g. "webhooks" in an extension value) and create an empty webhooks map.
+	if nodes.webhooks.value == nil {
+		return nil
+	}
 	hooks, hooksL, hooksN, err := low.ExtractMap[*PathItem](ctx, WebhooksLabel, root, idx)
 	if err != nil {
 		return err

--- a/datamodel/low/v3/create_document_test.go
+++ b/datamodel/low/v3/create_document_test.go
@@ -496,6 +496,28 @@ webhooks:
 	assert.Len(t, utils.UnwrapErrors(err), 1)
 }
 
+// a "webhooks" scalar value (here in an extension) must not create a webhooks map.
+func TestCreateDocument_WebHooks_NoFalsePositive(t *testing.T) {
+	yml := `openapi: 3.0.3
+info:
+  title: t
+  version: "1.0.0"
+x-foo:
+  service: webhooks
+paths:
+  /a:
+    get:
+      responses:
+        '200':
+          description: OK`
+
+	info, _ := datamodel.ExtractSpecInfo([]byte(yml))
+	d, err := CreateDocumentFromConfig(info, &datamodel.DocumentConfiguration{})
+	require.NoError(t, err)
+	assert.Nil(t, d.Webhooks.Value)
+	assert.Nil(t, d.Webhooks.KeyNode)
+}
+
 func TestCreateDocument_Servers(t *testing.T) {
 	initTest()
 	assert.Len(t, doc.Servers.Value, 2)


### PR DESCRIPTION
## What

`extractWebhooks` (in `datamodel/low/v3/create_document.go`) called `low.ExtractMap[*PathItem](ctx, WebhooksLabel, root, idx)` unconditionally and then guarded on the returned key/value nodes (`if hooksN != nil && hooksL != nil`).

When a document has **no** top-level `webhooks` key, `ExtractMap` resolves the label through the index and can match a **same-named scalar value** elsewhere in the document — e.g. the `webhooks` in `x-foo: { service: webhooks }`, or a server URL ending in `/webhooks`. That returns a non-nil empty map plus non-nil key/value nodes, so `doc.Webhooks` gets populated with an empty map, which the high-level model renders as `webhooks: {}`.

`webhooks` is an OpenAPI 3.1+ field, so emitting it into a rendered **3.0.x** document produces output that fails strict 3.0 schema validation (e.g. Spectral `oas3-schema`).

## Fix

Gate extraction on the genuine top-level `webhooks` node (`nodes.webhooks`, already collected by `collectDocumentTopLevelNodes`), mirroring `extractServers` / `extractTags` / `extractPaths`, which all resolve the real top-level key and guard on `vn != nil`. `extractWebhooks` was the only top-level extractor bypassing that.

## Regression range

Bisected to `cda65e2` ("more model refactoring and cleanup"), first released in **v0.35.1**. `v0.34.4` and earlier are unaffected; `v0.35.1`–`v0.37.3` are affected.

## Test

Added `TestCreateDocument_WebHooks_NoFalsePositive` covering a 3.0 doc whose only occurrence of `webhooks` is a vendor-extension scalar value; asserts `doc.Webhooks` is not populated. Existing webhooks tests (`TestCreateDocument_WebHooks`, `TestCreateDocument_WebHooks_Error`, the `collectDocumentTopLevelNodes` tests) still pass, and the full `go test ./...` suite is green.

Fixes #586
