### PR TITLE
fix: don't mutate shared yaml.Node when rendering schemas concurrently

### DIFF
--- a/datamodel/high/base/schema_proxy_test.go
+++ b/datamodel/high/base/schema_proxy_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/pb33f/libopenapi/datamodel"
@@ -2214,4 +2215,108 @@ func TestCreateSchemaProxyRefWithSchema_IsRefWithSiblings(t *testing.T) {
 
 	refWithNilSchema := CreateSchemaProxyRefWithSchema("#/components/schemas/Pet", nil)
 	assert.False(t, refWithNilSchema.isRefWithSiblings())
+}
+
+// findScalarNode returns the first scalar node in the tree whose value matches.
+func findScalarNode(n *yaml.Node, value string) *yaml.Node {
+	if n == nil {
+		return nil
+	}
+	if n.Kind == yaml.ScalarNode && n.Value == value {
+		return n
+	}
+	for _, c := range n.Content {
+		if found := findScalarNode(c, value); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+// TestSchemaProxy_ConcurrentRender_DoesNotMutateSharedNodes is a regression test
+// for a data race in inline rendering. Rendering a schema runs the underlying
+// *yaml.Node through (*yaml.Node).Encode, whose desolve stage rewrites Tag/Style
+// in place. Because the representer aliases input nodes, rendering mutated the
+// model's shared scalar nodes: while one goroutine rendered a schema, another
+// reading the same node (e.g. a const type check) could observe the tag briefly
+// cleared to "" and report a bogus "const value type does not match" error.
+//
+// The renders below must never mutate the captured `const` scalar's tag.
+// Run under `-race` to also catch the underlying data race directly.
+func TestSchemaProxy_ConcurrentRender_DoesNotMutateSharedNodes(t *testing.T) {
+	const ymlComponents = `components:
+    schemas:
+     Status:
+       type: object
+       properties:
+         state:
+           type: string
+           const: ok`
+
+	idx := func() *index.SpecIndex {
+		var idxNode yaml.Node
+		require.NoError(t, yaml.Unmarshal([]byte(ymlComponents), &idxNode))
+		return index.NewSpecIndexWithConfig(&idxNode, index.CreateOpenAPIIndexConfig())
+	}()
+
+	const ymlSchema = `type: object
+properties:
+  state:
+    type: string
+    const: ok`
+	var node yaml.Node
+	require.NoError(t, yaml.Unmarshal([]byte(ymlSchema), &node))
+
+	// The `const: ok` scalar is a string; rendering must leave its tag intact.
+	constNode := findScalarNode(node.Content[0], "ok")
+	require.NotNil(t, constNode)
+	require.Equal(t, "!!str", constNode.Tag)
+
+	lowProxy := new(lowbase.SchemaProxy)
+	require.NoError(t, lowProxy.Build(context.Background(), nil, node.Content[0], idx))
+	highProxy := NewSchemaProxy(&low.NodeReference[*lowbase.SchemaProxy]{
+		Value:     lowProxy,
+		ValueNode: node.Content[0],
+	})
+
+	var corrupted atomic.Int64
+	stop := make(chan struct{})
+
+	var readers sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		readers.Add(1)
+		go func() {
+			defer readers.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					if constNode.Tag != "!!str" {
+						corrupted.Add(1)
+					}
+				}
+			}
+		}()
+	}
+
+	var writers sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		writers.Add(1)
+		go func() {
+			defer writers.Done()
+			for j := 0; j < 20; j++ {
+				_, err := highProxy.MarshalYAMLInlineWithContext(NewInlineRenderContext())
+				assert.NoError(t, err)
+			}
+		}()
+	}
+
+	writers.Wait()
+	close(stop)
+	readers.Wait()
+
+	assert.Equal(t, int64(0), corrupted.Load(),
+		"rendering mutated the shared const scalar's tag (was cleared by desolve)")
+	assert.Equal(t, "!!str", constNode.Tag, "shared const scalar tag must survive rendering")
 }

--- a/datamodel/high/node_builder.go
+++ b/datamodel/high/node_builder.go
@@ -348,6 +348,36 @@ func (n *NodeBuilder) Render() *yaml.Node {
 	return m
 }
 
+// encodeSafeValue returns a value safe to pass to (*yaml.Node).Encode. When the
+// value is a *yaml.Node it returns a deep copy: Encode desolves the represented
+// graph in place (Desolve rewrites Tag/Style), and the representer aliases input
+// nodes, so encoding a model-owned node would mutate it. With concurrent renders
+// (e.g. linters running rules in parallel) that mutation races with readers of
+// the same node. Encoding a copy keeps shared nodes immutable.
+func encodeSafeValue(value any) any {
+	if vn, ok := value.(*yaml.Node); ok {
+		return deepCopyYAMLNode(vn)
+	}
+	return value
+}
+
+func deepCopyYAMLNode(n *yaml.Node) *yaml.Node {
+	if n == nil {
+		return nil
+	}
+	c := *n
+	if n.Alias != nil {
+		c.Alias = deepCopyYAMLNode(n.Alias)
+	}
+	if n.Content != nil {
+		c.Content = make([]*yaml.Node, len(n.Content))
+		for i, child := range n.Content {
+			c.Content[i] = deepCopyYAMLNode(child)
+		}
+	}
+	return &c
+}
+
 // AddYAMLNode will add a new *yaml.Node to the parent node, using the tag, key and value provided.
 // If the value is nil, then the node will not be added. This method is recursive, so it will dig down
 // into any non-scalar types.
@@ -492,7 +522,7 @@ func (n *NodeBuilder) AddYAMLNode(parent *yaml.Node, entry *nodes.NodeEntry) *ya
 			break
 		}
 
-		err := rawNode.Encode(value)
+		err := rawNode.Encode(encodeSafeValue(value))
 		if err != nil {
 			return parent
 		} else {
@@ -645,7 +675,7 @@ func (n *NodeBuilder) AddYAMLNode(parent *yaml.Node, entry *nodes.NodeEntry) *ya
 						}
 					}
 
-					err := rawNode.Encode(value)
+					err := rawNode.Encode(encodeSafeValue(value))
 					if err != nil {
 						return parent
 					} else {

--- a/datamodel/high/node_builder_test.go
+++ b/datamodel/high/node_builder_test.go
@@ -1700,3 +1700,43 @@ func TestOriginalFloatLexeme(t *testing.T) {
 		})
 	}
 }
+
+func TestEncodeSafeValue_DeepCopiesYAMLNodes(t *testing.T) {
+	// non-*yaml.Node values pass through unchanged.
+	assert.Equal(t, 42, encodeSafeValue(42))
+	assert.Equal(t, "hello", encodeSafeValue("hello"))
+
+	// nil nodes return nil rather than panicking.
+	assert.Nil(t, deepCopyYAMLNode(nil))
+	assert.Nil(t, encodeSafeValue((*yaml.Node)(nil)))
+
+	// a *yaml.Node is deep-copied: every node is a distinct pointer, including
+	// content children and aliases, so mutating the copy can't affect the model.
+	anchor := &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "anchored"}
+	orig := &yaml.Node{
+		Kind: yaml.MappingNode,
+		Content: []*yaml.Node{
+			{Kind: yaml.ScalarNode, Tag: "!!str", Value: "key"},
+			{Kind: yaml.ScalarNode, Tag: "!!str", Value: "val", Style: yaml.DoubleQuotedStyle},
+			{Kind: yaml.AliasNode, Value: "ref", Alias: anchor},
+		},
+	}
+
+	copied, ok := encodeSafeValue(orig).(*yaml.Node)
+	assert.True(t, ok)
+	assert.NotSame(t, orig, copied)
+	assert.Equal(t, len(orig.Content), len(copied.Content))
+	for i := range orig.Content {
+		assert.NotSame(t, orig.Content[i], copied.Content[i])
+		assert.Equal(t, orig.Content[i].Value, copied.Content[i].Value)
+	}
+
+	// the alias child is deep-copied too.
+	assert.NotNil(t, copied.Content[2].Alias)
+	assert.NotSame(t, anchor, copied.Content[2].Alias)
+	assert.Equal(t, "anchored", copied.Content[2].Alias.Value)
+
+	// mutating the copy must not touch the original (this is the whole point).
+	copied.Content[1].Tag = ""
+	assert.Equal(t, "!!str", orig.Content[1].Tag)
+}


### PR DESCRIPTION
Fixes https://github.com/daveshanley/vacuum/issues/912

## Summary

`NodeBuilder.AddYAMLNode` calls `(*yaml.Node).Encode(value)` where `value` is frequently a `*yaml.Node` owned by the model. `Encode` runs the value through the desolve stage, which rewrites `Tag`/`Style` **in place**, and the representer returns input `*yaml.Node`s as-is (`nodev` returns the node unchanged). So rendering a schema mutates the shared node it was built from.

When schemas are rendered concurrently — e.g. a linter running rules in parallel — that mutation races with any goroutine reading the same node. A common symptom: a string scalar's tag is briefly elided to `""` mid-render, so a concurrent reader checking `node.Tag == "!!str"` sees the wrong type and reports a bogus `const value type does not match schema type` error.

This fixes it by encoding a deep copy whenever the value is a `*yaml.Node`, so the desolve mutation lands on a throwaway copy and the model's nodes stay immutable.

## When this regressed

The shared-node read path is not new — the trigger is a change in `go.yaml.in/yaml/v4`'s `(*Node).Encode`, pulled in when libopenapi went from v0.37.x to v0.38.0.

- `go.yaml.in/yaml/v4` **rc.4** (used up to libopenapi v0.37.2): `Encode` marshalled the value to YAML bytes and re-parsed them into fresh nodes. It never touched the caller's node. There is no `desolver.go` in rc.4.
- `go.yaml.in/yaml/v4` **rc.5** (pulled in by libopenapi v0.38.0): `Encode` was rewritten into a `Represent` → `Desolve` → `Serialize` pipeline. The new `Desolve` stage elides inferable tags (`n.Tag = ""`) and normalizes quote style **on the represented graph**, and `Represent`/`nodev` returns input `*Node` values as-is (aliased). So `Encode` now mutates caller-owned nodes.

Because libopenapi hands shared model nodes to `Encode` during inline schema rendering, that new in-place mutation began landing on shared nodes and racing with concurrent readers. This is why the downstream symptom (vacuum #912) appears exactly at vacuum v0.29.3 / libopenapi v0.38.0 and not before.

Downstream confirmation in vacuum (which renders schemas concurrently across rules): `GOMAXPROCS=1` makes the false error disappear, vacuum v0.29.2 (libopenapi v0.37.2 / yaml rc.4) never reproduces it, and v0.29.3+ does.

## Changes

- `datamodel/high/node_builder.go`: add `encodeSafeValue` (deep-copies `*yaml.Node` values) and `deepCopyYAMLNode`; route both `rawNode.Encode(value)` call sites through `encodeSafeValue`.
- `datamodel/high/base/schema_proxy_test.go`: add `TestSchemaProxy_ConcurrentRender_DoesNotMutateSharedNodes`, which renders a schema concurrently while reading a captured `const` scalar's tag and asserts the tag is never mutated.
- `datamodel/high/node_builder_test.go`: add `TestEncodeSafeValue_DeepCopiesYAMLNodes`, a unit test covering the passthrough, nil, alias and content branches of the new helpers.

## Reproduction

The race detector flags it on `main`:

```
WARNING: DATA RACE
Write by goroutine N:
  go.yaml.in/yaml/v4 ...Desolver.desolveScalar   desolver.go:98   (writes n.Tag/n.Style)
  go.yaml.in/yaml/v4 ...(*Node).Encode           node.go
  libopenapi ...(*NodeBuilder).AddYAMLNode       node_builder.go:648
  libopenapi ...(*Schema).MarshalYAMLInlineWithContext
Previous read by goroutine M:
  ...reads the same node's Tag
```

## Verification

| check | result |
|---|---|
| new test, `go test -race` | passes with fix; data race + FAIL without it |
| `go test ./datamodel/high/...` | pass |
| `go test ./renderer/... ./bundler/...` | pass |

## Notes

- `deepCopyYAMLNode` adds one allocation per encoded `*yaml.Node`; negligible next to the represent/desolve/serialize/recompose round-trip `Encode` already performs, and only on the `*yaml.Node` path.
- There is also an argument that `(*yaml.Node).Encode` in `go.yaml.in/yaml/v4` should not mutate caller-owned nodes at all — rc.4 did not. That would fix every caller and restore the previous contract. This PR keeps the change inside libopenapi so it doesn't depend on an upstream yaml release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
