### PR TITLE
test: cover empty security requirements

### DIFF
--- a/datamodel/high/base/security_requirement_test.go
+++ b/datamodel/high/base/security_requirement_test.go
@@ -45,3 +45,24 @@ cake:
 	highBytes, _ := highExt.Render()
 	assert.Equal(t, yml, strings.TrimSpace(string(highBytes)))
 }
+
+func TestNewSecurityRequirement_EmptyRequirement(t *testing.T) {
+	var cNode yaml.Node
+
+	yml := `{}`
+
+	_ = yaml.Unmarshal([]byte(yml), &cNode)
+
+	var lowExt lowbase.SecurityRequirement
+	_ = lowmodel.BuildModel(cNode.Content[0], &lowExt)
+
+	_ = lowExt.Build(context.Background(), nil, cNode.Content[0], nil)
+
+	highExt := NewSecurityRequirement(&lowExt)
+
+	assert.True(t, highExt.ContainsEmptyRequirement)
+	assert.Equal(t, 0, orderedmap.Len(highExt.Requirements))
+
+	highBytes, _ := highExt.Render()
+	assert.Equal(t, yml, strings.TrimSpace(string(highBytes)))
+}


### PR DESCRIPTION
Summary
- Add high-level SecurityRequirement coverage for empty requirement objects.
- Assert the anonymous requirement marker survives promotion and rendering.

Validation
- go test ./datamodel/high/base ./datamodel/low/base ./what-changed/model
