### PR TITLE
Make PathItem.Build() a bit more robust to malformed input

### DIFF
--- a/datamodel/low/v3/path_item.go
+++ b/datamodel/low/v3/path_item.go
@@ -432,10 +432,7 @@ func (p *PathItem) Build(ctx context.Context, keyNode, root *yaml.Node, idx *ind
 		}
 		return nil, nil
 	}
-	err := datamodel.TranslateSliceParallel[low.NodeReference[*Operation], any](ops, translateFunc, nil)
-	if err != nil {
-		return err
-	}
+	_ = datamodel.TranslateSliceParallel[low.NodeReference[*Operation], any](ops, translateFunc, nil)
 
 	// assign additionalOperations if any were found
 	if additionalOps != nil && additionalOps.Len() > 0 {
@@ -445,7 +442,7 @@ func (p *PathItem) Build(ctx context.Context, keyNode, root *yaml.Node, idx *ind
 			extrOps = append(extrOps, appVal)
 		}
 
-		err = datamodel.TranslateSliceParallel[low.NodeReference[*Operation], any](extrOps, translateFunc, nil)
+		_ = datamodel.TranslateSliceParallel[low.NodeReference[*Operation], any](extrOps, translateFunc, nil)
 
 		p.AdditionalOperations = low.NodeReference[*orderedmap.Map[low.KeyReference[string], low.NodeReference[*Operation]]]{
 			Value: additionalOps,

--- a/datamodel/low/v3/path_item.go
+++ b/datamodel/low/v3/path_item.go
@@ -5,6 +5,7 @@ package v3
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"hash/maphash"
 	"sort"
@@ -408,6 +409,10 @@ func (p *PathItem) Build(ctx context.Context, keyNode, root *yaml.Node, idx *ind
 
 	// all operations have been superficially built,
 	// now we need to build out the operation, we will do this asynchronously for speed.
+	// build errors are collected rather than returned early, so every operation is fully
+	// constructed even when a sibling operation fails to build.
+	var opBuildErrors []error
+	var opBuildErrorsLock sync.Mutex
 	translateFunc := func(_ int, op low.NodeReference[*Operation]) (any, error) {
 		ref := ""
 		var refNode *yaml.Node
@@ -421,7 +426,9 @@ func (p *PathItem) Build(ctx context.Context, keyNode, root *yaml.Node, idx *ind
 			op.Value.Reference.SetReference(ref, refNode)
 		}
 		if err != nil {
-			return nil, err
+			opBuildErrorsLock.Lock()
+			opBuildErrors = append(opBuildErrors, err)
+			opBuildErrorsLock.Unlock()
 		}
 		return nil, nil
 	}
@@ -443,6 +450,9 @@ func (p *PathItem) Build(ctx context.Context, keyNode, root *yaml.Node, idx *ind
 		p.AdditionalOperations = low.NodeReference[*orderedmap.Map[low.KeyReference[string], low.NodeReference[*Operation]]]{
 			Value: additionalOps,
 		}
+	}
+	if len(opBuildErrors) > 0 {
+		return errors.Join(opBuildErrors...)
 	}
 	return nil
 }

--- a/datamodel/low/v3/path_item_test.go
+++ b/datamodel/low/v3/path_item_test.go
@@ -119,6 +119,35 @@ get:
 	assert.NotNil(t, n.RootNode)
 }
 
+func TestPathItem_Build_NullParameters_BuildsAllOperations(t *testing.T) {
+	yml := `post:
+  operationId: createThing
+  parameters:
+put:
+  operationId: replaceThing
+  parameters:
+delete:
+  operationId: deleteThing
+  parameters:`
+
+	var idxNode yaml.Node
+	_ = yaml.Unmarshal([]byte(yml), &idxNode)
+	idx := index.NewSpecIndex(&idxNode)
+
+	var n PathItem
+	_ = low.BuildModel(idxNode.Content[0], &n)
+	err := n.Build(context.Background(), nil, idxNode.Content[0], idx)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "input is not an array")
+
+	// every operation must be fully built out, even though a sibling failed to build first.
+	assert.NotNil(t, n.Post.Value.Reference)
+	assert.NotNil(t, n.Put.Value.Reference)
+	assert.NotNil(t, n.Delete.Value.Reference)
+	assert.False(t, n.Put.Value.IsReference())
+}
+
 func TestPathItem_AdditionalOperations(t *testing.T) {
 	yml := `get:
   description: standard get operation


### PR DESCRIPTION
Stumbled over a panic when running vacuum on a slightly invalid `openapi.yml` file, which had an empty `parameters:` line under an operation, with no nodes underneath.

Tracing that back, it turns out libopenapi does a two pass construction in `PathItem.Build()` when creating the model and when it hits a problem it can leave nil references in the model.

The consumer of this (doctor → vacuum in this case) may not handle a model with nil references well (ie panic).

This PR takes the fairly simple approach of making this code more robust so the construction continues to completion, returning an `errors.Join()` of all the failing operations and avoiding leaving nil references.  This should help consumers avoid these panics.

Weirdly (?), `Paths.Build()` seems to swallow errors so this problem can't be easily detected by consumers of the model.  That seems to be a deliberate design choice (with a test for it!), so this PR just works with it. :smile: