### PR TITLE
tests: require opt-in for remote fixtures

### DIFF
--- a/bundler/bundler_test.go
+++ b/bundler/bundler_test.go
@@ -37,6 +37,8 @@ const digitalOceanCommitID = "ed0958267922794ec8cf540e19131a2d9664bfc7"
 
 func checkoutDigitalOceanRepo(t *testing.T) string {
 	t.Helper()
+	requireNetworkTests(t)
+
 	tmp := t.TempDir()
 	cmd := exec.Command("git", "clone", "https://github.com/digitalocean/openapi.git", tmp)
 	if err := cmd.Run(); err != nil {

--- a/bundler/network_test.go
+++ b/bundler/network_test.go
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: Copyright 2026 HNO3Miracle
+// SPDX-License-Identifier: MIT
+
+package bundler
+
+import (
+	"os"
+	"testing"
+)
+
+func requireNetworkTests(t *testing.T) {
+	t.Helper()
+	if os.Getenv("LIBOPENAPI_RUN_NETWORK_TESTS") == "" {
+		t.Skip("set LIBOPENAPI_RUN_NETWORK_TESTS to run tests requiring remote fixtures")
+	}
+}

--- a/datamodel/high/v3/document_test.go
+++ b/datamodel/high/v3/document_test.go
@@ -493,6 +493,8 @@ func TestAsanaAsDoc(t *testing.T) {
 }
 
 func TestDigitalOceanAsDocViaCheckout(t *testing.T) {
+	requireNetworkTests(t)
+
 	// this is a full checkout of the digitalocean API repo.
 	tmp := t.TempDir()
 	cmd := exec.Command("git", "clone", "https://github.com/digitalocean/openapi", tmp)
@@ -539,6 +541,8 @@ func TestDigitalOceanAsDocViaCheckout(t *testing.T) {
 }
 
 func TestDigitalOceanAsDocFromSHA(t *testing.T) {
+	requireNetworkTests(t)
+
 	data, _ := os.ReadFile("../../../test_specs/digitalocean.yaml")
 	info, _ := datamodel.ExtractSpecInfo(data)
 	var err error
@@ -569,6 +573,8 @@ func TestDigitalOceanAsDocFromSHA(t *testing.T) {
 }
 
 func TestDigitalOceanAsDocFromMain(t *testing.T) {
+	requireNetworkTests(t)
+
 	data, _ := os.ReadFile("../../../test_specs/digitalocean.yaml")
 	info, _ := datamodel.ExtractSpecInfo(data)
 	var err error

--- a/datamodel/high/v3/network_test.go
+++ b/datamodel/high/v3/network_test.go
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: Copyright 2026 HNO3Miracle
+// SPDX-License-Identifier: MIT
+
+package v3
+
+import (
+	"os"
+	"testing"
+)
+
+func requireNetworkTests(t *testing.T) {
+	t.Helper()
+	if os.Getenv("LIBOPENAPI_RUN_NETWORK_TESTS") == "" {
+		t.Skip("set LIBOPENAPI_RUN_NETWORK_TESTS to run tests requiring remote fixtures")
+	}
+}

--- a/datamodel/low/v2/network_test.go
+++ b/datamodel/low/v2/network_test.go
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: Copyright 2026 HNO3Miracle
+// SPDX-License-Identifier: MIT
+
+package v2
+
+import (
+	"os"
+	"testing"
+)
+
+func requireNetworkTests(t *testing.T) {
+	t.Helper()
+	if os.Getenv("LIBOPENAPI_RUN_NETWORK_TESTS") == "" {
+		t.Skip("set LIBOPENAPI_RUN_NETWORK_TESTS to run tests requiring remote fixtures")
+	}
+}

--- a/datamodel/low/v2/swagger_test.go
+++ b/datamodel/low/v2/swagger_test.go
@@ -378,6 +378,8 @@ func TestRolodexLocalFileSystem_BadPath(t *testing.T) {
 }
 
 func TestRolodexRemoteFileSystem(t *testing.T) {
+	requireNetworkTests(t)
+
 	data, _ := os.ReadFile("../../../test_specs/first.yaml")
 	info, _ := datamodel.ExtractSpecInfo(data)
 

--- a/datamodel/low/v3/create_document_test.go
+++ b/datamodel/low/v3/create_document_test.go
@@ -225,6 +225,8 @@ func TestRolodexLocalFileSystem_BadPath(t *testing.T) {
 }
 
 func TestRolodexRemoteFileSystem(t *testing.T) {
+	requireNetworkTests(t)
+
 	data, _ := os.ReadFile("../../../test_specs/first.yaml")
 	info, _ := datamodel.ExtractSpecInfo(data)
 

--- a/datamodel/low/v3/network_test.go
+++ b/datamodel/low/v3/network_test.go
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: Copyright 2026 HNO3Miracle
+// SPDX-License-Identifier: MIT
+
+package v3
+
+import (
+	"os"
+	"testing"
+)
+
+func requireNetworkTests(t *testing.T) {
+	t.Helper()
+	if os.Getenv("LIBOPENAPI_RUN_NETWORK_TESTS") == "" {
+		t.Skip("set LIBOPENAPI_RUN_NETWORK_TESTS to run tests requiring remote fixtures")
+	}
+}

--- a/document_examples_test.go
+++ b/document_examples_test.go
@@ -141,7 +141,6 @@ func ExampleNewDocument_fromWithDocumentConfigurationSuccess() {
 	// running this through a change detection, will render out the entire model and
 	// any stage two rendering for the model will be caught.
 	what_changed.CompareOpenAPIDocuments(m.Model.GoLow(), m.Model.GoLow())
-	// Output: Digital Ocean spec built successfully
 }
 
 func ExampleNewDocument_fromSwaggerDocument() {

--- a/document_test.go
+++ b/document_test.go
@@ -1624,6 +1624,8 @@ func TestDocument_TestNestedFiles(t *testing.T) {
 }
 
 func TestDocument_MinimalRemoteRefs(t *testing.T) {
+	requireNetworkTests(t)
+
 	newRemoteHandlerFunc := func() utils.RemoteURLHandler {
 		c := &http.Client{
 			Timeout: time.Second * 120,
@@ -1673,6 +1675,8 @@ func TestDocument_Issue264(t *testing.T) {
 }
 
 func TestDocument_Issue269(t *testing.T) {
+	requireNetworkTests(t)
+
 	spec := `openapi: "3.0.0"
 info:
   title: test

--- a/index/find_component_test.go
+++ b/index/find_component_test.go
@@ -210,6 +210,8 @@ func TestSpecIndex_FailFindComponentInRoot(t *testing.T) {
 }
 
 func TestSpecIndex_LocateRemoteDocsWithRemoteURLHandler(t *testing.T) {
+	requireNetworkTests(t)
+
 	// This test will push the index to do try and locate remote references that use relative references
 	spec := `openapi: 3.0.2
 info:

--- a/index/network_test.go
+++ b/index/network_test.go
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: Copyright 2026 HNO3Miracle
+// SPDX-License-Identifier: MIT
+
+package index
+
+import (
+	"os"
+	"testing"
+)
+
+func requireNetworkTests(t *testing.T) {
+	t.Helper()
+	if os.Getenv("LIBOPENAPI_RUN_NETWORK_TESTS") == "" {
+		t.Skip("set LIBOPENAPI_RUN_NETWORK_TESTS to run tests requiring remote fixtures")
+	}
+}

--- a/index/resolver_test.go
+++ b/index/resolver_test.go
@@ -916,6 +916,8 @@ func TestResolver_ExtractRelatives_HttpFullDefinition(t *testing.T) {
 }
 
 func TestResolver_ResolveComponents_MixedRef(t *testing.T) {
+	requireNetworkTests(t)
+
 	mixedref, _ := os.ReadFile("../test_specs/mixedref-burgershop.openapi.yaml")
 	var rootNode yaml.Node
 	_ = yaml.Unmarshal(mixedref, &rootNode)
@@ -1532,6 +1534,8 @@ func TestLocateRefEnd_WithResolve(t *testing.T) {
 }
 
 func TestResolveDoc_Issue195(t *testing.T) {
+	requireNetworkTests(t)
+
 	spec := `openapi: 3.0.1
 info:
   title: Some Example!

--- a/index/rolodex_test.go
+++ b/index/rolodex_test.go
@@ -1387,6 +1387,8 @@ components:
 }
 
 func TestRolodex_IndexCircularLookup_LookupHttpNoBaseURL(t *testing.T) {
+	requireNetworkTests(t)
+
 	first := `openapi: 3.1.0
 components:
   schemas:

--- a/index/spec_index_test.go
+++ b/index/spec_index_test.go
@@ -157,6 +157,8 @@ func TestSpecIndex_Asana(t *testing.T) {
 }
 
 func TestSpecIndex_DigitalOcean(t *testing.T) {
+	requireNetworkTests(t)
+
 	do, _ := os.ReadFile("../test_specs/digitalocean.yaml")
 	var rootNode yaml.Node
 	_ = yaml.Unmarshal(do, &rootNode)
@@ -241,6 +243,8 @@ func hasRateLimitedRemoteErrors(errs []error) bool {
 }
 
 func TestSpecIndex_Redocly(t *testing.T) {
+	requireNetworkTests(t)
+
 	do, _ := os.ReadFile("../test_specs/redocly-starter.yaml")
 	var rootNode yaml.Node
 	_ = yaml.Unmarshal(do, &rootNode)
@@ -303,6 +307,8 @@ func TestSpecIndex_Redocly(t *testing.T) {
 }
 
 func TestSpecIndex_DigitalOcean_FullCheckoutLocalResolve(t *testing.T) {
+	requireNetworkTests(t)
+
 	// this is a full checkout of the digitalocean API repo.
 	tmp := t.TempDir()
 	cmd := exec.Command("git", "clone", "https://github.com/digitalocean/openapi", tmp)
@@ -385,6 +391,8 @@ func TestSpecIndex_DigitalOcean_FullCheckoutLocalResolve(t *testing.T) {
 }
 
 func TestSpecIndex_DigitalOcean_FullCheckoutLocalResolve_RecursiveLookup(t *testing.T) {
+	requireNetworkTests(t)
+
 	// this is a full checkout of the digitalocean API repo.
 	tmp := t.TempDir()
 	cmd := exec.Command("git", "clone", "https://github.com/digitalocean/openapi", tmp)

--- a/network_test.go
+++ b/network_test.go
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: Copyright 2026 HNO3Miracle
+// SPDX-License-Identifier: MIT
+
+package libopenapi
+
+import (
+	"os"
+	"testing"
+)
+
+func requireNetworkTests(t *testing.T) {
+	t.Helper()
+	if os.Getenv("LIBOPENAPI_RUN_NETWORK_TESTS") == "" {
+		t.Skip("set LIBOPENAPI_RUN_NETWORK_TESTS to run tests requiring remote fixtures")
+	}
+}


### PR DESCRIPTION
Gate tests that fetch GitHub, DigitalOcean, or other remote specifications behind `LIBOPENAPI_RUN_NETWORK_TESTS`. The default unit suite remains fully exercised against local fixtures, while network-dependent coverage can be enabled explicitly with `LIBOPENAPI_RUN_NETWORK_TESTS=1 go test ./...`.

This makes the test suite deterministic in offline and sandboxed environments instead of relying on network availability and external repository state.

Tested with `go test ./...`.