### PR TITLE
tests: isolate temporary module commands from GO111MODULE

### DIFF
--- a/generator/golang/fullcircle_test.go
+++ b/generator/golang/fullcircle_test.go
@@ -26,6 +26,7 @@ func TestTrainTravelFullCircleCanonicalRoundTrip(t *testing.T) {
 	cmd := exec.Command("go", "run", "./cmd/roundtrip")
 	cmd.Dir = dir
 	cmd.Env = append(os.Environ(),
+		"GO111MODULE=on",
 		"GOWORK=off",
 		"GOFLAGS=-mod=mod",
 		"TRAIN_TRAVEL_SPEC="+filepath.Join(repoRoot, "generator", "golang", "testdata", "train-travel.yaml"),

--- a/generator/golang/roundtrip_components_test.go
+++ b/generator/golang/roundtrip_components_test.go
@@ -106,7 +106,7 @@ func reflectComponentsRoundTrip(t *testing.T, file *GeneratedFile) []byte {
 	out := filepath.Join(dir, "reconstructed.yaml")
 	cmd := exec.Command("go", "run", "./cmd/roundtrip")
 	cmd.Dir = dir
-	cmd.Env = append(os.Environ(), "GOWORK=off", "GOFLAGS=-mod=mod", "ROUNDTRIP_OUT="+out)
+	cmd.Env = append(os.Environ(), "GO111MODULE=on", "GOWORK=off", "GOFLAGS=-mod=mod", "ROUNDTRIP_OUT="+out)
 	if combined, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("reflect round-trip command failed: %v\n%s", err, combined)
 	}


### PR DESCRIPTION
The generator round-trip tests intentionally create temporary Go modules, but their `go run` subprocesses inherit `GO111MODULE=off` from the caller. Explicitly enable module mode for those subprocesses, alongside the existing `GOWORK=off` and `GOFLAGS=-mod=mod`, so the test behavior matches its temporary-module setup.

Testing:
- `go test ./generator/golang`
- Built the package test binary in module mode, then ran both round-trip tests with the binary environment set to `GO111MODULE=off`; both pass.