### PR TITLE
fix(what-changed): don't flag object→composition wrap as breaking

### DIFF
--- a/what-changed/model/schema.go
+++ b/what-changed/model/schema.go
@@ -498,6 +498,17 @@ func CompareSchemas(l, r *base.SchemaProxy) *SchemaChanges {
 		comparisonLSchema := schemaComparisonViewForSimpleAllOfObject(l, lSchema)
 		comparisonRSchema := schemaComparisonViewForSimpleAllOfObject(r, rSchema)
 
+		// A plain object refactored into a oneOf/anyOf that still contains that object as a branch
+		// (often behind a local $ref, or an "object OR <alternative>" widening) is not a breaking
+		// change — everything valid before is still valid. Compare the old object against the
+		// preserved branch directly so genuine changes are still detected, and suppress the spurious
+		// top-level properties/required/type removal that the wrapper would otherwise produce.
+		skipPreservedCompositionDiff := false
+		if preservedBranch, ok := preservedCompositionBranchView(l, r); ok {
+			comparisonRSchema = preservedBranch
+			skipPreservedCompositionDiff = true
+		}
+
 		if low.AreEqual(lSchema, rSchema) {
 			// there is no point going on, we know nothing changed!
 			return nil
@@ -512,7 +523,8 @@ func CompareSchemas(l, r *base.SchemaProxy) *SchemaChanges {
 		skipSimpleScalarUnionDiff := schemasUseEquivalentSimpleScalarUnion(l, r)
 
 		// check schema core properties for changes.
-		checkSchemaPropertyChanges(comparisonLSchema, comparisonRSchema, l, r, &changes, sc, skipSimpleScalarUnionDiff)
+		checkSchemaPropertyChanges(comparisonLSchema, comparisonRSchema, l, r, &changes, sc,
+			skipSimpleScalarUnionDiff || skipPreservedCompositionDiff)
 
 		// now for the confusing part, there is also a schema's 'properties' property to parse.
 		// inception, eat your heart out.
@@ -542,6 +554,12 @@ func CompareSchemas(l, r *base.SchemaProxy) *SchemaChanges {
 		}
 		if skipSimpleScalarUnionDiff {
 			lanyOf = nil
+			ranyOf = nil
+		}
+		if skipPreservedCompositionDiff {
+			// The preserved branch is now folded into comparisonRSchema; don't also diff the wrapper
+			// composition itself (it would resurface as an added oneOf/anyOf).
+			roneOf = nil
 			ranyOf = nil
 		}
 
@@ -2106,6 +2124,164 @@ func extractScalarTypeName(node *yaml.Node) (string, bool) {
 		return "", false
 	}
 	return node.Value, true
+}
+
+// preservedCompositionBranchView detects the "wrapping" refactor where an OLD plain object schema is
+// reshaped into a NEW oneOf/anyOf composition that still contains that object as one of its branches
+// (commonly behind a local $ref when a schema is hoisted into a reusable component, or an
+// "object OR <alternative>" widening). Because the original object is still one of the accepted
+// shapes, every previously-valid value remains valid, so nothing was removed — but a naive
+// node-level diff sees the top-level `properties`/`required`/`type` vanish and reports them as
+// breaking removals.
+//
+// When the wrap is detected, the resolved "preserved" branch schema is returned so the caller can
+// compare the OLD object against that branch directly. That keeps genuine, e.g. property-level,
+// changes visible while dropping the spurious top-level removal signals. Only the wrapping direction
+// (l = old, r = new) is handled: the reverse (a composition collapsing to a single schema) can drop
+// alternatives and must remain breaking, so it is intentionally not matched here.
+func preservedCompositionBranchView(l, r *base.SchemaProxy) (*base.Schema, bool) {
+	if l == nil || r == nil || l.IsReference() || r.IsReference() {
+		return nil, false
+	}
+	// OLD must be a plain object carrying properties and no composition of its own.
+	// (nil schemas are handled by the predicate helpers, which treat nil as "no".)
+	lSchema := l.Schema()
+	rSchema := r.Schema()
+	if !schemaIsPlainObjectWithProperties(lSchema) {
+		return nil, false
+	}
+
+	// NEW must be a pure oneOf/anyOf wrapper (exactly one of the two, no competing top-level keys).
+	branches, ok := schemaWrappingCompositionBranches(rSchema)
+	if !ok {
+		return nil, false
+	}
+
+	// Find exactly one branch that preserves all of OLD's property names (the object, possibly
+	// evolved), resolving local $refs. Any additional branches are treated as added alternatives.
+	var primary *base.Schema
+	primaryCount := 0
+	compositionAcceptsNull := false
+	for _, branch := range branches {
+		if branch.Value == nil || base.CheckSchemaProxyForCircularRefs(branch.Value) {
+			return nil, false
+		}
+		// A nil resolved branch schema is handled by the predicate helpers below (treated as "no").
+		branchSchema := branch.Value.Schema()
+		if schemaTypeAcceptsNull(branchSchema) {
+			compositionAcceptsNull = true
+		}
+		if schemaPreservesObjectProperties(lSchema, branchSchema) {
+			primary = branchSchema
+			primaryCount++
+		}
+	}
+	if primaryCount != 1 || primary == nil {
+		return nil, false
+	}
+
+	// Nullability must be preserved: if OLD accepted null, NEW must still accept it (via a null
+	// branch or the preserved branch itself), otherwise dropping null is a real narrowing.
+	if schemaTypeAcceptsNull(lSchema) && !compositionAcceptsNull && !schemaTypeAcceptsNull(primary) {
+		return nil, false
+	}
+
+	return primary, true
+}
+
+// schemaWrappingCompositionBranches returns the branches of a schema that is a pure oneOf/anyOf
+// wrapper (exactly one of oneOf/anyOf, and no top-level properties/allOf/prefixItems/not that would
+// make it more than a wrapper). allOf is intentionally excluded — it is handled by
+// schemaComparisonViewForSimpleAllOfObject.
+func schemaWrappingCompositionBranches(schema *base.Schema) ([]low.ValueReference[*base.SchemaProxy], bool) {
+	if schema == nil {
+		return nil, false
+	}
+	if schemaHasProperties(schema) || len(schema.AllOf.Value) > 0 ||
+		len(schema.PrefixItems.Value) > 0 || schema.Not.Value != nil {
+		return nil, false
+	}
+	oneOf := schema.OneOf.Value
+	anyOf := schema.AnyOf.Value
+	switch {
+	case len(oneOf) > 0 && len(anyOf) == 0:
+		return oneOf, true
+	case len(anyOf) > 0 && len(oneOf) == 0:
+		return anyOf, true
+	default:
+		return nil, false
+	}
+}
+
+// schemaPreservesObjectProperties reports whether branch is an object that keeps every property name
+// declared on l (branch may add or widen properties — those are surfaced by the normal recursive
+// diff — but it must not drop any, which is what distinguishes the preserved object from an
+// unrelated alternative branch).
+func schemaPreservesObjectProperties(l, branch *base.Schema) bool {
+	if !schemaHasProperties(branch) || !schemaTypeIncludesObject(branch) {
+		return false
+	}
+	branchNames := make(map[string]struct{}, branch.Properties.Value.Len())
+	for k := range branch.Properties.Value.FromOldest() {
+		branchNames[k.Value] = struct{}{}
+	}
+	for k := range l.Properties.Value.FromOldest() {
+		if _, ok := branchNames[k.Value]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func schemaIsPlainObjectWithProperties(schema *base.Schema) bool {
+	return schemaHasProperties(schema) && schemaTypeIncludesObject(schema) && !schemaHasComposition(schema)
+}
+
+func schemaHasProperties(schema *base.Schema) bool {
+	return schema != nil && schema.Properties.Value != nil && schema.Properties.Value.Len() > 0
+}
+
+func schemaHasComposition(schema *base.Schema) bool {
+	if schema == nil {
+		return false
+	}
+	return len(schema.OneOf.Value) > 0 || len(schema.AnyOf.Value) > 0 || len(schema.AllOf.Value) > 0 ||
+		len(schema.PrefixItems.Value) > 0 || schema.Not.Value != nil
+}
+
+// schemaTypeIncludesObject reports whether the schema's declared type admits objects. A schema with
+// no explicit type but with properties is treated as an object.
+func schemaTypeIncludesObject(schema *base.Schema) bool {
+	if schema == nil {
+		return false
+	}
+	if schema.Type.IsEmpty() {
+		return schemaHasProperties(schema)
+	}
+	if schema.Type.Value.IsB() {
+		for _, t := range schema.Type.Value.B {
+			if t.Value == "object" {
+				return true
+			}
+		}
+		return false
+	}
+	return schema.Type.Value.A == "object"
+}
+
+func schemaTypeAcceptsNull(schema *base.Schema) bool {
+	if schema == nil || schema.Type.IsEmpty() {
+		return false
+	}
+	if schema.Type.Value.IsB() {
+		for _, t := range schema.Type.Value.B {
+			if t.Value == "null" {
+				return true
+			}
+		}
+		return false
+	}
+	return schema.Type.Value.A == "null"
 }
 
 func checkExamples(lSchema *base.Schema, rSchema *base.Schema, changes *[]*Change) {

--- a/what-changed/model/schema_test.go
+++ b/what-changed/model/schema_test.go
@@ -7422,3 +7422,398 @@ components:
 	// TotalBreakingChanges should count the vocabulary change
 	assert.Equal(t, 1, changes.TotalBreakingChanges())
 }
+
+// An inline object hoisted into a reusable component and referenced via `oneOf: [$ref, null]` is an
+// identical, non-breaking restructure: the referenced schema is byte-identical to the old inline
+// object and the null branch preserves nullability. The naive diff used to report the object's
+// properties/required as removed (breaking) because it never resolved the $ref.
+func TestCompareSchemas_InlineObjectWrappedInOneOfRefIsNotBreaking(t *testing.T) {
+	low.ClearHashCache()
+	left := `openapi: 3.1.0
+components:
+  schemas:
+    Widget:
+      type: object
+      properties:
+        config:
+          type:
+          - object
+          - 'null'
+          required:
+          - mode
+          - items
+          properties:
+            mode:
+              type: integer
+              enum: [1, 2]
+            items:
+              type: array
+              items:
+                type: object
+                required: [kind]
+                properties:
+                  kind:
+                    type: string`
+
+	right := `openapi: 3.1.0
+components:
+  schemas:
+    Widget:
+      type: object
+      properties:
+        config:
+          oneOf:
+          - $ref: '#/components/schemas/Config'
+          - type: 'null'
+    Config:
+      type: object
+      required:
+      - mode
+      - items
+      properties:
+        mode:
+          type: integer
+          enum: [1, 2]
+        items:
+          type: array
+          items:
+            type: object
+            required: [kind]
+            properties:
+              kind:
+                type: string`
+
+	leftDoc, rightDoc := test_BuildDoc(left, right)
+	lSchemaProxy := leftDoc.Components.Value.FindSchema("Widget").Value
+	rSchemaProxy := rightDoc.Components.Value.FindSchema("Widget").Value
+
+	changes := CompareSchemas(lSchemaProxy, rSchemaProxy)
+	// The restructure is equivalent, so there are no changes at all — and definitely no breaking ones.
+	assert.Nil(t, changes)
+	assert.Equal(t, 0, changes.TotalChanges())
+	assert.Equal(t, 0, changes.TotalBreakingChanges())
+}
+
+// Widening an object into `anyOf: [<same object>, <new alternative>]` still accepts every value the
+// object accepted before, so it is not breaking. The naive diff used to report the object's
+// properties/required as removed because the top-level node changed from an object to an anyOf.
+func TestCompareSchemas_ObjectWidenedIntoAnyOfIsNotBreaking(t *testing.T) {
+	low.ClearHashCache()
+	left := `openapi: 3.1.0
+components:
+  schemas:
+    Entry:
+      type: object
+      required: [kind]
+      properties:
+        kind:
+          type: string
+          enum: [alpha, beta]`
+
+	right := `openapi: 3.1.0
+components:
+  schemas:
+    Entry:
+      anyOf:
+      - type: object
+        required: [kind]
+        properties:
+          kind:
+            type: string
+            enum: [alpha, beta]
+      - type: array
+        items:
+          type: object
+          required: [kind]
+          properties:
+            kind:
+              type: string
+              enum: [alpha, beta]`
+
+	leftDoc, rightDoc := test_BuildDoc(left, right)
+	lSchemaProxy := leftDoc.Components.Value.FindSchema("Entry").Value
+	rSchemaProxy := rightDoc.Components.Value.FindSchema("Entry").Value
+
+	changes := CompareSchemas(lSchemaProxy, rSchemaProxy)
+	assert.Equal(t, 0, changes.TotalBreakingChanges())
+}
+
+// The combined case: hoisted into a $ref AND the referenced schema was widened (an enum gained a
+// member). The wrapper itself is non-breaking, and the genuine inner change must still be surfaced
+// (as a non-breaking enum addition) rather than hidden.
+func TestCompareSchemas_WrappedRefWithInnerWideningSurfacesNonBreakingChange(t *testing.T) {
+	low.ClearHashCache()
+	left := `openapi: 3.1.0
+components:
+  schemas:
+    Widget:
+      type: object
+      properties:
+        config:
+          type:
+          - object
+          - 'null'
+          required:
+          - mode
+          properties:
+            mode:
+              type: integer
+              enum: [1, 2]`
+
+	right := `openapi: 3.1.0
+components:
+  schemas:
+    Widget:
+      type: object
+      properties:
+        config:
+          oneOf:
+          - $ref: '#/components/schemas/Config'
+          - type: 'null'
+    Config:
+      type: object
+      required:
+      - mode
+      properties:
+        mode:
+          type: integer
+          enum: [1, 2, 3]`
+
+	leftDoc, rightDoc := test_BuildDoc(left, right)
+	lSchemaProxy := leftDoc.Components.Value.FindSchema("Widget").Value
+	rSchemaProxy := rightDoc.Components.Value.FindSchema("Widget").Value
+
+	changes := CompareSchemas(lSchemaProxy, rSchemaProxy)
+	assert.NotNil(t, changes)
+	// The enum gaining a member is surfaced as a change, but it is not breaking.
+	assert.Greater(t, changes.TotalChanges(), 0)
+	assert.Equal(t, 0, changes.TotalBreakingChanges())
+}
+
+// Guard: the reverse direction (a composition collapsing to a single object, dropping an
+// alternative) is a real narrowing and must stay breaking — the fix must not fire here.
+func TestCompareSchemas_AnyOfUnwrappedToObjectStaysBreaking(t *testing.T) {
+	low.ClearHashCache()
+	left := `openapi: 3.1.0
+components:
+  schemas:
+    Entry:
+      anyOf:
+      - type: object
+        required: [kind]
+        properties:
+          kind:
+            type: string
+      - type: array
+        items:
+          type: object`
+
+	right := `openapi: 3.1.0
+components:
+  schemas:
+    Entry:
+      type: object
+      required: [kind]
+      properties:
+        kind:
+          type: string`
+
+	leftDoc, rightDoc := test_BuildDoc(left, right)
+	lSchemaProxy := leftDoc.Components.Value.FindSchema("Entry").Value
+	rSchemaProxy := rightDoc.Components.Value.FindSchema("Entry").Value
+
+	changes := CompareSchemas(lSchemaProxy, rSchemaProxy)
+	assert.NotNil(t, changes)
+	assert.Greater(t, changes.TotalBreakingChanges(), 0)
+}
+
+// Guard: an object replaced by an anyOf whose branches do NOT preserve the original object's
+// properties is a genuine change (the original property is gone) and must stay breaking.
+func TestCompareSchemas_ObjectReplacedByNonPreservingAnyOfStaysBreaking(t *testing.T) {
+	low.ClearHashCache()
+	left := `openapi: 3.1.0
+components:
+  schemas:
+    Entry:
+      type: object
+      required: [kind]
+      properties:
+        kind:
+          type: string`
+
+	right := `openapi: 3.1.0
+components:
+  schemas:
+    Entry:
+      anyOf:
+      - type: object
+        required: [label]
+        properties:
+          label:
+            type: string
+      - type: array
+        items:
+          type: object`
+
+	leftDoc, rightDoc := test_BuildDoc(left, right)
+	lSchemaProxy := leftDoc.Components.Value.FindSchema("Entry").Value
+	rSchemaProxy := rightDoc.Components.Value.FindSchema("Entry").Value
+
+	changes := CompareSchemas(lSchemaProxy, rSchemaProxy)
+	assert.NotNil(t, changes)
+	assert.Greater(t, changes.TotalBreakingChanges(), 0)
+}
+
+// Guard: dropping nullability while hoisting into a ref is a real narrowing (null was accepted, now
+// it isn't). The fix must not fire because the composition has no null-accepting branch.
+func TestCompareSchemas_WrapDroppingNullabilityStaysBreaking(t *testing.T) {
+	low.ClearHashCache()
+	left := `openapi: 3.1.0
+components:
+  schemas:
+    Widget:
+      type: object
+      properties:
+        config:
+          type:
+          - object
+          - 'null'
+          required:
+          - mode
+          properties:
+            mode:
+              type: integer`
+
+	right := `openapi: 3.1.0
+components:
+  schemas:
+    Widget:
+      type: object
+      properties:
+        config:
+          oneOf:
+          - $ref: '#/components/schemas/Config'
+    Config:
+      type: object
+      required:
+      - mode
+      properties:
+        mode:
+          type: integer`
+
+	leftDoc, rightDoc := test_BuildDoc(left, right)
+	lSchemaProxy := leftDoc.Components.Value.FindSchema("Widget").Value
+	rSchemaProxy := rightDoc.Components.Value.FindSchema("Widget").Value
+
+	changes := CompareSchemas(lSchemaProxy, rSchemaProxy)
+	assert.NotNil(t, changes)
+	assert.Greater(t, changes.TotalBreakingChanges(), 0)
+}
+
+// Guard: a composition branch that is a circular $ref must not be followed (it would recurse). The
+// preservation shortcut bails out, so the comparison falls back to the normal diff without panicking.
+func TestCompareSchemas_WrapWithCircularRefBranchIsHandled(t *testing.T) {
+	low.ClearHashCache()
+	left := `openapi: 3.1.0
+components:
+  schemas:
+    Widget:
+      type: object
+      properties:
+        config:
+          type: object
+          required: [mode]
+          properties:
+            mode:
+              type: integer`
+
+	right := `openapi: 3.1.0
+components:
+  schemas:
+    Widget:
+      type: object
+      properties:
+        config:
+          oneOf:
+          - $ref: '#/components/schemas/Node'
+          - type: 'null'
+    Node:
+      type: object
+      required: [mode]
+      properties:
+        mode:
+          type: integer
+        child:
+          $ref: '#/components/schemas/Node'`
+
+	leftDoc, rightDoc := test_BuildDoc(left, right)
+	lSchemaProxy := leftDoc.Components.Value.FindSchema("Widget").Value
+	rSchemaProxy := rightDoc.Components.Value.FindSchema("Widget").Value
+
+	assert.NotPanics(t, func() {
+		CompareSchemas(lSchemaProxy, rSchemaProxy)
+	})
+}
+
+// Directly exercises the small predicate helpers behind preservedCompositionBranchView, including
+// nil and edge-typed inputs that the normal comparison path never produces.
+func TestPreservedCompositionWrapHelpers(t *testing.T) {
+	low.ClearHashCache()
+	spec := `openapi: 3.1.0
+components:
+  schemas:
+    BothComposition:
+      oneOf:
+      - type: string
+      anyOf:
+      - type: integer
+    EmptyWrapper:
+      description: no type, no properties, no composition
+    ScalarUnionNoNull:
+      type:
+      - string
+      - number
+    ScalarUnionWithNull:
+      type:
+      - string
+      - 'null'
+    UntypedWithProps:
+      properties:
+        a:
+          type: string
+    OneOfWrapper:
+      oneOf:
+      - type: string
+      - type: 'null'`
+
+	doc, _ := test_BuildDoc(spec, spec)
+	get := func(name string) *base.Schema {
+		return doc.Components.Value.FindSchema(name).Value.Schema()
+	}
+
+	// schemaWrappingCompositionBranches
+	_, ok := schemaWrappingCompositionBranches(nil)
+	assert.False(t, ok)
+	_, ok = schemaWrappingCompositionBranches(get("BothComposition"))
+	assert.False(t, ok) // both oneOf and anyOf -> not a pure wrapper
+	_, ok = schemaWrappingCompositionBranches(get("EmptyWrapper"))
+	assert.False(t, ok) // neither oneOf nor anyOf
+	branches, ok := schemaWrappingCompositionBranches(get("OneOfWrapper"))
+	assert.True(t, ok)
+	assert.Len(t, branches, 2)
+
+	// schemaHasComposition
+	assert.False(t, schemaHasComposition(nil))
+	assert.True(t, schemaHasComposition(get("BothComposition")))
+
+	// schemaTypeIncludesObject
+	assert.False(t, schemaTypeIncludesObject(nil))
+	assert.False(t, schemaTypeIncludesObject(get("ScalarUnionNoNull"))) // type array without object
+	assert.True(t, schemaTypeIncludesObject(get("UntypedWithProps")))   // no type but has properties
+
+	// schemaTypeAcceptsNull
+	assert.False(t, schemaTypeAcceptsNull(nil))
+	assert.False(t, schemaTypeAcceptsNull(get("EmptyWrapper")))      // no type
+	assert.False(t, schemaTypeAcceptsNull(get("ScalarUnionNoNull"))) // type array without null
+	assert.True(t, schemaTypeAcceptsNull(get("ScalarUnionWithNull")))
+}


### PR DESCRIPTION
## Summary

`what-changed` reports **false-positive breaking changes** when an object schema is refactored into
a `oneOf`/`anyOf` composition that still contains that object as one of its branches. No previously
valid value becomes invalid, so the change is not breaking, but the comparator reports the object's
`properties`/`required` as removed.

This PR teaches `CompareSchemas` to recognize that "wrapping" refactor and stop flagging it, while
keeping every genuine change (and the reverse, narrowing direction) fully reported.

## The two shapes that trigger it

**1. An inline object hoisted into a reusable component, referenced via `oneOf: [$ref, {type: null}]`.**
The referenced component is identical to the old inline object, but the `$ref` is never resolved, so
the properties look removed.

```yaml
# before
Widget:
  type: object
  properties:
    config:
      type: [object, 'null']
      required: [mode]
      properties:
        mode: { type: integer, enum: [1, 2] }

# after — identical schema, just hoisted + referenced
Widget:
  type: object
  properties:
    config:
      oneOf:
      - $ref: '#/components/schemas/Config'
      - type: 'null'
Config:
  type: object
  required: [mode]
  properties:
    mode: { type: integer, enum: [1, 2] }
```

```
$ openapi-changes summary before.yaml after.yaml --no-logo
  - Removed ... config properties: [mode]
  - Removed ... config required: [mode]
  ❌  2 Breaking changes
```

**2. An object widened into `anyOf: [<same object>, <new alternative>]`.**
The old object is preserved as the first branch, but the top-level node changed from an object to an
`anyOf`, so its properties look removed.

```yaml
# before
Entry:
  type: object
  required: [kind]
  properties:
    kind: { type: string }

# after — the object is still branch 0; an array alternative was added
Entry:
  anyOf:
  - type: object
    required: [kind]
    properties:
      kind: { type: string }
  - type: array
    items: { type: object }
```

```
$ openapi-changes summary before.yaml after.yaml --no-logo
  - Removed ... Entry properties/kind
  - Removed ... Entry required/kind
  ❌  2 Breaking changes
```

Both reproduce on the current `main` (and were originally hit with `openapi-changes` v0.2.8 /
libopenapi v0.37.3, and still on v0.2.10).

## Why it's a false positive

Everything valid before is still valid:

- Case 1: `oneOf: [Config, null]` is exactly the old nullable object — the properties moved *behind*
  the `$ref`, they were not removed.
- Case 2: the old object is still accepted as the first `anyOf` branch; an alternative was *added*.

The default rules already treat *adding* a `oneOf`/`anyOf` as non-breaking. The problem is that the
same restructure is *also* counted as a removal of the object's `properties`/`required`, so it gets
reported twice — once (correctly) as a non-breaking composition addition, and once (incorrectly) as a
breaking removal.

## Root cause

Comparison runs on the low-level node model. When the old side is a plain object (`properties` /
`required` / `type`) and the new side is a `oneOf`/`anyOf`, the field-by-field diff sees the
top-level `properties`/`required` disappear (they now live inside a branch, possibly behind a
`$ref`) and reports them removed. Nothing correlates the old object with the preserved branch, and a
`$ref` branch is keyed by its ref string rather than by resolved content.

## The fix

`CompareSchemas` now detects the **wrapping direction** and, when found, compares the old object
against the preserved branch directly:

- **Trigger:** old side is a plain object with properties; new side is a *pure* `oneOf`/`anyOf`
  wrapper whose branches — resolving local `$ref`s — contain **exactly one** branch that preserves
  all of the old object's property names. That branch becomes the comparison view for the new side;
  the wrapper composition is not separately re-reported.
- **Genuine changes still surface:** because the old object is compared against the preserved branch
  recursively, a real change inside the branch (e.g. a widened `enum`, an added property) is still
  reported — as breaking or non-breaking per the normal rules. Only the spurious top-level
  `properties`/`required`/`type` removal is suppressed.

It stays conservative via three guards:

- **Directional.** Only old-plain → new-composition is matched. The reverse (a composition
  collapsing to a single schema, which can drop alternatives) is left breaking.
- **Nullability preserved.** If the old object accepted `null`, the new composition must still accept
  it (a `null` branch, or a nullable preserved branch); otherwise the fix does not fire.
- **Unambiguous preservation.** Exactly one branch may preserve all of the old object's property
  names. A branch that drops a property is not treated as the preserved object, so real removals stay
  breaking.

The approach mirrors the existing `schemaComparisonViewForSimpleAllOfObject` and
`schemasUseEquivalentSimpleScalarUnion` helpers, extending the same "an equivalent restructure is not
breaking" idea to `oneOf`/`anyOf` and `$ref` branches. All new logic is self-contained
(`preservedCompositionBranchView` plus small predicates); the only changes to existing code are two
call-site tweaks in `CompareSchemas`.

## Tests

Added to `what-changed/model/schema_test.go`:

- `TestCompareSchemas_InlineObjectWrappedInOneOfRefIsNotBreaking` — identical hoist into `oneOf: [$ref, null]` ⇒ no changes.
- `TestCompareSchemas_ObjectWidenedIntoAnyOfIsNotBreaking` — `anyOf` widening ⇒ 0 breaking.
- `TestCompareSchemas_WrappedRefWithInnerWideningSurfacesNonBreakingChange` — hoist + inner enum widening ⇒ change surfaced, 0 breaking.
- `TestCompareSchemas_AnyOfUnwrappedToObjectStaysBreaking` — reverse direction stays breaking.
- `TestCompareSchemas_ObjectReplacedByNonPreservingAnyOfStaysBreaking` — non-preserving replacement stays breaking.
- `TestCompareSchemas_WrapDroppingNullabilityStaysBreaking` — dropped nullability stays breaking.

The full `what-changed/...` suite passes.

## Note / possible follow-up

When the preserved branch is used as the comparison view, an annotation placed on the *wrapper* node
rather than the branch (e.g. `writeOnly` or `description` on the composition itself) is compared
against the branch and can show as non-breaking add/remove noise. This does not affect
breaking-change detection. Happy to refine the handling if you'd prefer the wrapper-level keywords be
carried onto the comparison view.
